### PR TITLE
Preserve space when displaying the source and target string. Also add…

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -28,6 +28,7 @@ import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.xliff.XliffUtils;
 import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 import javax.persistence.EntityManager;
@@ -425,6 +426,8 @@ public class TMService {
 
         logger.debug("Add TMTextUnitVariant for tmId: {} locale id: {}, content: {}", tmTextUnitId, localeId, content);
 
+        Preconditions.checkNotNull(content, "content must not be null when adding a TMTextUnitVariant");
+        
         TMTextUnit tmTextUnit = entityManager.getReference(TMTextUnit.class, tmTextUnitId);
         Locale locale = entityManager.getReference(Locale.class, localeId);
 

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -511,6 +511,29 @@ let TextUnit = React.createClass({
             );
         }
     },
+    
+    /**
+     * render the source. If the source ends with a retrun line remove and 
+     * render a return line symbol so that the user as a clue about the trailing
+     * return line.
+     */
+    renderSource() {
+        
+        let source = this.props.textUnit.getSource();
+        let optionalReturnLineSymbol = "";
+        
+        if (source.endsWith("\n")) {
+            source = source.substring(0, source.length - 1); 
+            optionalReturnLineSymbol = (
+                    <span className="textunit-returnline"> ↵</span> 
+            );
+        }
+        
+        return (
+            <div className="plx pts textunit-string">{source}{optionalReturnLineSymbol}
+            </div>
+        );
+    },
 
     render() {
         // TODO: Must show which repository a string belongs to when multiple repositories are selected
@@ -546,7 +569,7 @@ let TextUnit = React.createClass({
                         <Row className='show-grid'>
                             <Col md={6}>
                                 <Row>
-                                    <div className="plx pts textunit-string">{this.props.textUnit.getSource()}</div>
+                                   {this.renderSource()}                                                               
                                     <div className="plx em color-gray-light2">{this.props.textUnit.getComment()}</div>
                                 </Row>
                             </Col>

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -357,6 +357,12 @@ div.textunit label {
 
 .textunit-string {
   width: 90%;
+  white-space: pre-wrap; 
+}
+
+.textunit-returnline {
+    color: $brand-primary;
+    font-size: 10px;
 }
 
 .textunit-string.textunit-target {


### PR DESCRIPTION
… a visual clue that a source ends with a return line.
