### PR TITLE
MOJI-208 drop-import --import-status not working and incorrect descri…

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
@@ -42,7 +42,7 @@ public class Param {
     public static final String TARGET_DIRECTORY_DESCRIPTION = "Target directory that will contain localized assets";
 
     public static final String DROP_IMPORT_STATUS = "--import-status";
-    public static final String DROP_IMPORT_STATUS_DESCRIPTION = "Target directory that will contain localized assets";
+    public static final String DROP_IMPORT_STATUS_DESCRIPTION = "Override the status of translations being imported";
 
     public static final String SOURCE_LOCALE_LONG = "--source-locale";
     public static final String SOURCE_LOCALE_SHORT = "-sl";

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
@@ -128,7 +128,7 @@ public class DropWS {
     public ImportDropConfig importDrop(@RequestBody ImportDropConfig importDropConfig) throws Exception {
 
         // TODO(P1) Check here that the repo exists (and the user has access to it)?
-        PollableFuture importDropFuture = dropService.importDrop(importDropConfig.getDropId(), importDropConfig.getImportStatus(), PollableTask.INJECT_CURRENT_TASK);
+        PollableFuture importDropFuture = dropService.importDrop(importDropConfig.getDropId(), importDropConfig.getStatus(), PollableTask.INJECT_CURRENT_TASK);
 
         importDropConfig.setPollableTask(importDropFuture.getPollableTask());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/ImportDropConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/ImportDropConfig.java
@@ -22,7 +22,7 @@ public class ImportDropConfig {
     @JsonProperty(required = true)
     Long dropId;
 
-    TMTextUnitVariant.Status importStatus;
+    TMTextUnitVariant.Status status;
 
     PollableTask pollableTask;
 
@@ -42,12 +42,12 @@ public class ImportDropConfig {
         this.dropId = dropId;
     }
 
-    public TMTextUnitVariant.Status getImportStatus() {
-        return importStatus;
+    public TMTextUnitVariant.Status getStatus() {
+        return status;
     }
 
-    public void setImportStatus(TMTextUnitVariant.Status importStatus) {
-        this.importStatus = importStatus;
+    public void setStatus(TMTextUnitVariant.Status status) {
+        this.status = status;
     }
 
     @JsonProperty


### PR DESCRIPTION
…ption

Using --import-status option from CLI never gets set on the server-side because ImportDropConfig on client side had `status` and server side had `importStatus`, therefore, causing serialization of this attribute to be always null.  
