### PR TITLE
Added max width to repo dropdown

### DIFF
--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -628,6 +628,12 @@ label.current-pageNumber {
   overflow: scroll;
 }
 
+.repository-dropdown li > a {
+  max-width: 500px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 .repository-dropdown ul {
   max-height: 400px;
   overflow: scroll;


### PR DESCRIPTION
<img width="727" alt="screen shot 2016-08-01 at 5 08 32 pm" src="https://cloud.githubusercontent.com/assets/1339380/17312858/098d055a-580b-11e6-836a-f154b44f84a1.png">
<img width="487" alt="screen shot 2016-08-01 at 5 11 02 pm" src="https://cloud.githubusercontent.com/assets/1339380/17312860/0d5c134c-580b-11e6-9abf-218bce209381.png">
