### PR TITLE
Fix flickering of translation strings before save is complete

### DIFF
--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -495,7 +495,7 @@ let TextUnit = React.createClass({
         if (this.state.isEditMode) {
             ui = this.getUIForEditMode();
         } else {
-            let targetString = this.props.translation;
+            let targetString = this.hasTargetChanged() ? this.state.translation : this.props.translation;
             let dir;
 
             let noTranslation = false;


### PR DESCRIPTION
This will show the translation in the state while
save is occuring.  When save is done, the prop
is updated, and the component will be rerendered.