### PR TITLE
Show state translation before props in the text area

### DIFF
--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -443,12 +443,19 @@ let TextUnit = React.createClass({
             // This issue is minor, placeholder is "New translation..." only the dots gets pushed on the left side.
             let dir = Locales.getLanguageDirection(this.props.textUnit.getTargetLocale());
 
+            let defaultTextAreaValue = "";
+            if (this.state.translation) {
+                defaultTextAreaValue = this.state.translation;
+            } else if (this.props.translation) {
+                defaultTextAreaValue = this.props.translation;
+            }
+
             return (
                 <div className="targetstring-container">
                     <FormControl ref="textUnitTextArea" componentClass="textarea" spellCheck="true" className="mrxs"
                                  onKeyUp={this.onKeyUpTextArea} onKeyDown={this.onKeyDownTextArea}
                                  placeholder={this.props.intl.formatMessage({ id: 'textUnit.target.placeholder' })}
-                                 defaultValue={this.props.translation ? this.props.translation : ""}
+                                 defaultValue={defaultTextAreaValue}
                                  onChange={this.transUnitEditTextAreaOnChange}
                                  dir={dir}
                                  onClick={this.onClickTextArea}/>


### PR DESCRIPTION
Uses the state's translation value as the defaultvalue
Otherwise, use the props' translation value. This
allows the edit area to maintain its current value
if / when react reenders during edit.

This happens on save error and the user wants to continue
editing with the translation that is already in the edit field