### PR TITLE
MOJI-228 integrity checker for leading and trailing whitespaces

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoCommand.java
@@ -21,7 +21,7 @@ public abstract class RepoCommand extends Command {
     protected static final String INTEGRITY_CHECK_SHORT_PARAM = "-it";
     protected static final String INTEGRITY_CHECK_DESCRIPTION
             = "Integrity Checker by File Extension, comma seperated format: \"FILE_EXTENSION_1:CHECKER_TYPE_1,FILE_EXTENSION_2:CHECKER_TYPE_2\"\n       "
-            + "Available Checker types: MESSAGE_FORMAT, PRINTF_LIKE, SIMPLE_PRINTF_LIKE, COMPOSITE_FORMAT, TRAILING_WHITESPACE, HTML_TAG\n       "
+            + "Available Checker types: MESSAGE_FORMAT, PRINTF_LIKE, SIMPLE_PRINTF_LIKE, COMPOSITE_FORMAT, WHITESPACE, TRAILING_WHITESPACE, HTML_TAG\n       "
             + "For examples: \"properties:MESSAGE_FORMAT,xliff:PRINTF_LIKE\"";
 
     @Autowired

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
@@ -11,6 +11,7 @@ public enum IntegrityCheckerType {
     PRINTF_LIKE,
     SIMPLE_PRINTF_LIKE,
     COMPOSITE_FORMAT,
+    WHITESPACE,
     TRAILING_WHITESPACE,
     HTML_TAG;
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerType.java
@@ -11,6 +11,7 @@ public enum IntegrityCheckerType {
     PRINTF_LIKE(PrintfLikeIntegrityChecker.class.getName()),
     SIMPLE_PRINTF_LIKE(SimplePrintfLikeIntegrityChecker.class.getName()),
     COMPOSITE_FORMAT(CompositeFormatIntegrityChecker.class.getName()),
+    WHITESPACE(WhitespaceIntegrityChecker.class.getName()),
     TRAILING_WHITESPACE(TrailingWhitespaceIntegrityChecker.class.getName()),
     HTML_TAG(HtmlTagIntegrityChecker.class.getName());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/WhitespaceIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/WhitespaceIntegrityChecker.java
@@ -1,0 +1,87 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import org.apache.commons.codec.binary.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks that there are the same leading and trailing whitespaces in the source and target content.
+ * 
+ * @author jyi
+ */
+public class WhitespaceIntegrityChecker implements TextUnitIntegrityChecker {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(WhitespaceIntegrityChecker.class);
+
+    private static final String STRING_WITH_LEADING_REGEX = "^(\\s+).+";
+    private static final String STRING_WITH_TRAILING_REGEX = ".+?(\\s+)$";
+    private static final String GROUP_WITH_WHITESPACES = "$1";
+
+    @Override
+    public void check(String sourceContent, String targetContent) throws WhitespaceIntegrityCheckerException {
+        checkLeadingWhitespaces(sourceContent, targetContent);
+        checkTrailingWhitespaces(sourceContent, targetContent);
+    }
+    
+    public void checkLeadingWhitespaces(String sourceContent, String targetContent) throws WhitespaceIntegrityCheckerException {
+        logger.debug("Get leading whitespaces around the source");
+        String sourceWhiteSpaces = getLeadingWhitespaces(sourceContent);
+        logger.debug("Source leading whitespaces: {}", sourceWhiteSpaces);
+
+        logger.debug("Get leading whitespaces around the target");
+        String targetWhiteSpaces = getLeadingWhitespaces(targetContent);
+        logger.debug("Target leading whitespaces: {}", targetWhiteSpaces);
+
+        logger.debug("Make sure the target has the same leading whitespaces as the source");
+        if (!StringUtils.equals(sourceWhiteSpaces, targetWhiteSpaces)) {
+            throw new WhitespaceIntegrityCheckerException("Leading whitespaces around source and target are different");
+        }
+    }
+    
+    public void checkTrailingWhitespaces(String sourceContent, String targetContent) throws WhitespaceIntegrityCheckerException {
+        logger.debug("Get trailing whitespaces around the source");
+        String sourceWhiteSpaces = getTrailingWhitespaces(sourceContent);
+        logger.debug("Source trailing whitespaces: {}", sourceWhiteSpaces);
+
+        logger.debug("Get trailing whitespaces around the target");
+        String targetWhiteSpaces = getTrailingWhitespaces(targetContent);
+        logger.debug("Target trailing whitespaces: {}", targetWhiteSpaces);
+
+        logger.debug("Make sure the target has the same trailing whitespaces as the source");
+        if (!StringUtils.equals(sourceWhiteSpaces, targetWhiteSpaces)) {
+            throw new WhitespaceIntegrityCheckerException("Trailing shitespaces around source and target are different");
+        }
+    }
+
+    /**
+     * Gets the leading whitespace in a string.
+     *
+     * @param string
+     * @return the leading whitespace or null if no trailing whitespace
+     */
+    String getLeadingWhitespaces(String string) {
+        String leadingWhitepsaces = null;
+        if (string.matches(STRING_WITH_LEADING_REGEX)) {
+            leadingWhitepsaces = string.replaceAll(STRING_WITH_LEADING_REGEX, GROUP_WITH_WHITESPACES);
+        }
+        return leadingWhitepsaces;
+    }
+    
+    /**
+     * Gets the trailing whitespace in a string.
+     *
+     * @param string
+     * @return the trailing whitespace or null if no trailing whitespace
+     */
+    String getTrailingWhitespaces(String string) {
+        String trailingWhitespaces = null;
+        if (string.matches(STRING_WITH_TRAILING_REGEX)) {
+            trailingWhitespaces = string.replaceAll(STRING_WITH_TRAILING_REGEX, GROUP_WITH_WHITESPACES);
+        }
+        return trailingWhitespaces;
+    }
+    
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/WhitespaceIntegrityCheckerException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/WhitespaceIntegrityCheckerException.java
@@ -1,0 +1,13 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+/**
+ *
+ * @author jyi
+ */
+public class WhitespaceIntegrityCheckerException extends IntegrityCheckException {
+    
+    public WhitespaceIntegrityCheckerException(String message) {
+        super(message);
+    }
+    
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/WhitespaceIntegrityCheckerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/WhitespaceIntegrityCheckerTest.java
@@ -1,0 +1,135 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author jyi
+ */
+public class WhitespaceIntegrityCheckerTest {
+    
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(WhitespaceIntegrityCheckerTest.class);
+
+    WhitespaceIntegrityChecker checker = new WhitespaceIntegrityChecker();
+
+    @Test
+    public void testWhitespaceIntegrityCheckerWorksWithNoLeadingTrailingWhitespaces() {
+        String source = "There are %1 files and %2 folders";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+        checker.check(source, target);
+    }
+    
+    @Test
+    public void testWhitespaceIntegrityCheckerWorksWithLeadingTrailingWhitespaces() {
+        String source = " There are %1 files and %2 folders\n";
+        String target = " Il y a %1 fichiers et %2 dossiers\n";
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testWhitespaceIntegrityCheckerWorksWithMultipleLeadingTrailingWhitespaces() {
+        String source = "\t  There are %1 files and %2 folders  \n";
+        String target = "\t  Il y a %1 fichiers et %2 dossiers  \n";
+        checker.check(source, target);
+    }
+    
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testWhitespaceIntegrityCheckerWorksWithDifferentLeadingTrailingWhitespaces1() {
+        String source = " There are %1 files and %2 folders \n";
+        String target = "  Il y a %1 fichiers et %2 dossiers\n";
+        checker.check(source, target);
+    }
+    
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testWhitespaceIntegrityCheckerWorksWithDifferentLeadingTrailingWhitespaces2() {
+        String source = "\nThere are %1 files and %2 folders ";
+        String target = " Il y a %1 fichiers et %2 dossiers\n";
+        checker.check(source, target);
+    }
+    
+    @Test
+    public void testLeadingWhitespaceCheckWorks() {
+        String source = "\n There are %1 files and %2 folders";
+        String target = "\n Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testLeadingWhitespaceCheckWorksWithoutLeadingWhitespaces() {
+        String source = "There are %1 files and %2 folders";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testLeadingWhitespaceCheckCatchesRemovedNewline() {
+        String source = "\nThere are %1 files and %2 folders";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testLeadingWhitespaceCheckCatchesRemovedSpace() {
+        String source = " There are %1 files and %2 folders";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testLeadingWhitespaceCheckCatchesDifferentLeadingWhitespaces() {
+        String source = " \nThere are %1 files and %2 folders";
+        String target = "\n Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+    
+    @Test
+    public void testTrailingWhitespaceCheckWorks() {
+        String source = "There are %1 files and %2 folders \n";
+        String target = "Il y a %1 fichiers et %2 dossiers \n";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testTrailingWhitespaceCheckWorksWithoutTrailingWhitespaces() {
+        String source = "There are %1 files and %2 folders";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testTrailingWhitespaceCheckCatchesRemovedNewline() {
+        String source = "There are %1 files and %2 folders\n";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testTrailingWhitespaceCheckCatchesRemovedSpace() {
+        String source = "There are %1 files and %2 folders ";
+        String target = "Il y a %1 fichiers et %2 dossiers";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = WhitespaceIntegrityCheckerException.class)
+    public void testTrailingWhitespaceCheckCatchesDifferentTrailingWhitespaces() {
+        String source = "There are %1 files and %2 folders \n";
+        String target = "Il y a %1 fichiers et %2 dossiers\n ";
+
+        checker.check(source, target);
+    }
+    
+}


### PR DESCRIPTION
I have created a new integrity checker that checks both leading and trailing whitespaces.  We'll remove TRAILING_WHITESPACE integrity checker after updating existing repositories to use the WHITESPACE integrity checker.