### PR TITLE
Fix issue with node-fetch and compression for application/json.

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,7 @@
     "keycode": "^2.1.0",
     "keymirror": "~0.1.0",
     "lodash": "^3.10.1",
-    "node-fetch": "^1.3.2",
+    "node-fetch": "^1.6.3",
     "node-sass": "^3.3.3",
     "object-assign": "^1.0.0",
     "react": "^15.1.0",

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -39,7 +39,7 @@ org.springframework.http.converter.json.indent_output=false
 
 # Compression
 server.compression.enabled=true
-server.compression.mime-types=application/javascript,application/xml,text/html,text/xml,text/plain,text/css
+server.compression.mime-types=application/json,application/javascript,application/xml,text/html,text/xml,text/plain,text/css
 
 # ----------------------------------------
 # L10N PROPERTIES

--- a/webapp/src/main/resources/public/js/sdk/BaseClient.js
+++ b/webapp/src/main/resources/public/js/sdk/BaseClient.js
@@ -1,5 +1,14 @@
-import fetch from "node-fetch";
 import $ from "jquery";
+// TODO remove node-fetch which is only useful for older browser like Safari 9.
+// Chrome, Firefox support fetch correctly.
+//
+// node-fetch causes some issue with compression ("invalid response body at:
+// http://localhost:8080/ap…mit=10 reason: data error: incorrect header check",
+// type: "system", errno: "Z_DATA_ERROR", code: "Z_DATA_ERROR"}).
+//
+// A counter intuitive workaround is to use compress: false
+// we can remove it later when Safari 9 doesn't need to be supported
+import fetch from "node-fetch";
 
 class BaseClient {
     constructor() {
@@ -86,7 +95,9 @@ class BaseClient {
 
     get(url, data) {
         return fetch(url + '?' + $.param(data), {
-            follow: 0
+            follow: 0,
+            compress: false, // workaround for node-fetch, see this file header
+            credentials: 'include' // this is required if using fetch from the browser, not needed with node-fetch
         }).then(response => {
             this.handleUnauthenticatedResponse(response);
             return response.json();
@@ -96,6 +107,8 @@ class BaseClient {
     put(url, data) {
         return fetch(url, {
             method: 'put',
+            compress: false, // workaround for node-fetch, see this file header
+            credentials: 'include',
             body: JSON.stringify(data),
             headers: this.getHeaders(),
             follow: 0
@@ -107,6 +120,8 @@ class BaseClient {
     post(url, data) {
         return fetch(url, {
             method: 'post',
+            compress: false, // workaround for node-fetch, see this file header
+            credentials: 'include',
             body: JSON.stringify(data),
             headers: this.getHeaders(),
             follow: 0
@@ -119,6 +134,8 @@ class BaseClient {
     delete(url) {
         return fetch(url, {
             method: 'delete',
+            compress: false, // workaround for node-fetch, see this file header
+            credentials: 'include',
             headers: this.getHeaders(),
             follow: 0
         }).then(response => {


### PR DESCRIPTION
Before compression was not activated for json. First, it is bad for performance. Then if proxying requests (say a default Nginx setup that as compression on for json) it would break the app.

This is related to a strange behavior with node-fetch, which gives the following error: "invalid response body at:  http://localhost:8080/ap…mit=10 reason: data error: incorrect header check", type: "system", errno: "Z_DATA_ERROR", code: "Z_DATA_ERROR"})."

Considered removing 'node-fetch' but the native fetch API is only supported by Safari 10 and we'd like to keep support for now. Chrome, Firefox are fine.

 - enable compression for application/json
 - change node-fetch configuration to workaround the issue. Kind of counter intuitive but using "compress: false" prevents the issue and compression is still performed.
 - added "crendentials: 'include'" which is a setting needed if using native fetch (can be useful later if/when we remove node-fetch)