### PR TITLE
fix null encoding in XML prolog for android resource files

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XMLFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XMLFilter.java
@@ -138,7 +138,7 @@ public class XMLFilter extends net.sf.okapi.filters.xml.XMLFilter {
     protected void createStartDocumentSkeleton(StartDocument startDoc) {
         // Add the XML declaration
         skel = new GenericSkeleton();
-        if (!params.omitXMLDeclaration) {
+        if (!params.omitXMLDeclaration && doc.getXmlEncoding() != null) {
             skel.add("<?xml version=\"" + doc.getXmlVersion() + "\"");
             skel.add(" encoding=\"" + doc.getXmlEncoding() + "\"");
             if (doc.getXmlStandalone()) {


### PR DESCRIPTION
Some android resource files do not have XML prolog.  For example, 

```
<resources>
    <string name="test" description="simple">resource</string>
</resources>
```

For this input, output is incorrectly generated with null encoding:

```
<?xml version="1.0" encoding="null"?>
<resources>
    <string name="test" description="simple">resource</string>
</resources>
```
