### PR TITLE
Support MacString keys not enclosed in double quotes

### DIFF
--- a/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/macStrings_mojito.fprm
+++ b/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/macStrings_mojito.fprm
@@ -12,7 +12,7 @@ mimeType=text/plain
 ruleCount.i=4
 rule0.ruleName=Comments+String
 rule0.ruleType.i=0
-rule0.expr=/\*(.*?)\*/\n\"(.*?)\"\s*=(.*?);$
+rule0.expr=^\s*/\*(.*?)\*/\n\"?(.*?)\"?\s*=(.*?);$
 rule0.groupSource.i=3
 rule0.groupTarget.i=-1
 rule0.groupName.i=2
@@ -54,7 +54,7 @@ rule2.codeFinderRules.sample=
 rule2.codeFinderRules.useAllRulesWhenTesting.b=false
 rule3.ruleName=String
 rule3.ruleType.i=0
-rule3.expr=\"(.*?)\"\s*=(.*?);$
+rule3.expr=^\s*\"?(.*?)\"?\s*=(.*?);$
 rule3.groupSource.i=2
 rule3.groupTarget.i=-1
 rule3.groupName.i=1

--- a/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/macStrings_mojito.fprm
+++ b/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/macStrings_mojito.fprm
@@ -9,62 +9,78 @@ useDoubleCharEscape.b=false
 oneLevelGroups.b=false
 regexOptions.i=40
 mimeType=text/plain
-ruleCount.i=4
-rule0.ruleName=Comments+String
+ruleCount.i=5
+rule0.ruleName=BracketingComments+String
 rule0.ruleType.i=0
-rule0.expr=^\s*/\*(.*?)\*/\n\"?(.*?)\"?\s*=(.*?);$
+rule0.expr=^\s*/\*(.*?)\*/\n\"?((?!\s|//).*?)\"?\s*=(.*?);$
 rule0.groupSource.i=3
 rule0.groupTarget.i=-1
 rule0.groupName.i=2
 rule0.groupNote.i=1
 rule0.preserveWS.b=true
 rule0.useCodeFinder.b=true
-rule0.sample=/* Menu item to make the current document plain text */$0a$"Make Plain Text" = "Make Plain \"Text";$0a$/* Menu item to make the current document rich text */$0a$"Make Rich Text" = "Make Rich Text";$0a$
+rule0.sample=/* Menu item to make the current document plain text */$0a$"Make Plain Text" = "Make Plain \"Text";$0a$/* Menu item to make the current document rich text */$0a$Make Rich Text = "Make Rich Text";$0a$
 rule0.codeFinderRules.count.i=3
 rule0.codeFinderRules.rule0=%(([-0+#]?)[-0+#]?)((\d\$)?)(([\d\*]*)(\.[\d\*]*)?)[dioxXucsfeEgGpn]
 rule0.codeFinderRules.rule1=(\\r\\n)|\\a|\\b|\\f|\\n|\\r|\\t|\\v
 rule0.codeFinderRules.rule2=\<(/?)\w+[^>]*?>
 rule0.codeFinderRules.sample=
 rule0.codeFinderRules.useAllRulesWhenTesting.b=false
-rule1.ruleName=Bracketing Comments
-rule1.ruleType.i=3
-rule1.expr=/\*(.*?)\*/
-rule1.groupSource.i=1
+rule1.ruleName=LineComments+String
+rule1.ruleType.i=0
+rule1.expr=^\s*(//[^\n]*?\n)*//([^\n]*?)\n\"?((?!\s|//).*?)\"?\s*=(.*?);$
+rule1.groupSource.i=4
 rule1.groupTarget.i=-1
-rule1.groupName.i=-1
-rule1.groupNote.i=-1
+rule1.groupName.i=3
+rule1.groupNote.i=2
 rule1.preserveWS.b=true
-rule1.useCodeFinder.b=false
-rule1.sample=test /* test */
-rule1.codeFinderRules.count.i=0
+rule1.useCodeFinder.b=true
+rule1.sample=// Menu item to make the current document plain text$0a$"Make Plain Text" = "Make Plain \"Text";$0a$// Menu item to make the current document rich text$0a$Make Rich Text = "Make Rich Text";$0a$
+rule1.codeFinderRules.count.i=3
+rule1.codeFinderRules.rule0=%(([-0+#]?)[-0+#]?)((\d\$)?)(([\d\*]*)(\.[\d\*]*)?)[dioxXucsfeEgGpn]
+rule1.codeFinderRules.rule1=(\\r\\n)|\\a|\\b|\\f|\\n|\\r|\\t|\\v
+rule1.codeFinderRules.rule2=\<(/?)\w+[^>]*?>
 rule1.codeFinderRules.sample=
 rule1.codeFinderRules.useAllRulesWhenTesting.b=false
-rule2.ruleName=Line Comments
+rule2.ruleName=Bracketing Comments
 rule2.ruleType.i=3
-rule2.expr=//(.*?)\n
+rule2.expr=/\*(.*?)\*/
 rule2.groupSource.i=-1
 rule2.groupTarget.i=-1
 rule2.groupName.i=-1
 rule2.groupNote.i=-1
 rule2.preserveWS.b=true
 rule2.useCodeFinder.b=false
-rule2.sample=// test$0a$test // bbb$0a$
+rule2.sample=test /* test */
 rule2.codeFinderRules.count.i=0
 rule2.codeFinderRules.sample=
 rule2.codeFinderRules.useAllRulesWhenTesting.b=false
-rule3.ruleName=String
-rule3.ruleType.i=0
-rule3.expr=^\s*\"?(.*?)\"?\s*=(.*?);$
-rule3.groupSource.i=2
+rule3.ruleName=Line Comments
+rule3.ruleType.i=3
+rule3.expr=//(.*?)\n
+rule3.groupSource.i=-1
 rule3.groupTarget.i=-1
-rule3.groupName.i=1
+rule3.groupName.i=-1
 rule3.groupNote.i=-1
 rule3.preserveWS.b=true
-rule3.useCodeFinder.b=true
-rule3.sample=/* Menu item to make the current document plain text */$0a$"Make Plain Text" = "Make Plain \"Text";$0a$/* Menu item to make the current document rich text */$0a$"Make Rich Text" = "Make Rich Text";$0a$
-rule3.codeFinderRules.count.i=3
-rule3.codeFinderRules.rule0=%(([-0+#]?)[-0+#]?)((\d\$)?)(([\d\*]*)(\.[\d\*]*)?)[dioxXucsfeEgGpn]
-rule3.codeFinderRules.rule1=(\\r\\n)|\\a|\\b|\\f|\\n|\\r|\\t|\\v
-rule3.codeFinderRules.rule2=\<(/?)\w+[^>]*?>
+rule3.useCodeFinder.b=false
+rule3.sample=// test$0a$test // bbb$0a$
+rule3.codeFinderRules.count.i=0
 rule3.codeFinderRules.sample=
 rule3.codeFinderRules.useAllRulesWhenTesting.b=false
+rule4.ruleName=String
+rule4.ruleType.i=0
+rule4.expr=^\s*\"?(.*?)\"?\s*=(.*?);$
+rule4.groupSource.i=2
+rule4.groupTarget.i=-1
+rule4.groupName.i=1
+rule4.groupNote.i=-1
+rule4.preserveWS.b=true
+rule4.useCodeFinder.b=true
+rule4.sample="Make Plain Text" = "Make Plain \"Text";$0a$Make Rich Text = "Make Rich Text";$0a$
+rule4.codeFinderRules.count.i=3
+rule4.codeFinderRules.rule0=%(([-0+#]?)[-0+#]?)((\d\$)?)(([\d\*]*)(\.[\d\*]*)?)[dioxXucsfeEgGpn]
+rule4.codeFinderRules.rule1=(\\r\\n)|\\a|\\b|\\f|\\n|\\r|\\t|\\v
+rule4.codeFinderRules.rule2=\<(/?)\w+[^>]*?>
+rule4.codeFinderRules.sample=
+rule4.codeFinderRules.useAllRulesWhenTesting.b=false

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionServiceTest.java
@@ -373,7 +373,37 @@ public class AssetExtractionServiceTest extends ServiceTestBase {
         assertEquals(" Title: Title for the add content to folder menu header ", assetTextUnits.get(0).getComment());
 
     }
-    
+
+    @Test
+    public void testMacStringsKeysWithoutDoubleQuotes() throws Exception {
+
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+
+        String content = "/* Comment 1 */\n"
+                + "NSUsageDescription 1 = \"Add to Folder 1\";\n"
+                + "NSUsageDescription 2 = \"Add to Folder 2\";\n\n"
+                + "/* Comment 3 */\n"
+                + "NSUsageDescription 3 = \"Add to Folder 3\";";
+        Asset asset = assetService.createAsset(repository.getId(), content, "path/to/fake/en.lproj/Localizable.strings");
+
+        PollableFuture<Asset> processResult = assetExtractionService.processAsset(asset.getId(), null, PollableTask.INJECT_CURRENT_TASK);
+        Asset processedAsset = processResult.get();
+
+        List<AssetTextUnit> assetTextUnits = assetTextUnitRepository.findByAssetExtraction(processedAsset.getLastSuccessfulAssetExtraction());
+
+        assertEquals("Processing should have extracted 3 text units", 3, assetTextUnits.size());
+        assertEquals("NSUsageDescription 1", assetTextUnits.get(0).getName());
+        assertEquals("Add to Folder 1", assetTextUnits.get(0).getContent());
+        assertEquals(" Comment 1 ", assetTextUnits.get(0).getComment());
+        assertEquals("NSUsageDescription 2", assetTextUnits.get(1).getName());
+        assertEquals("Add to Folder 2", assetTextUnits.get(1).getContent());
+        assertNull(assetTextUnits.get(1).getComment());
+        assertEquals("NSUsageDescription 3", assetTextUnits.get(2).getName());
+        assertEquals("Add to Folder 3", assetTextUnits.get(2).getContent());
+        assertEquals(" Comment 3 ", assetTextUnits.get(2).getComment());
+
+    }
+
     @Test
     public void testMacStringsNoComment() throws Exception {
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -874,7 +874,7 @@ public class TMServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void testLocalizeMacStringsKeysNotEnclosedInDoubleQuotes() throws Exception {
+    public void testLocalizeMacStringsNamessNotEnclosedInDoubleQuotes() throws Exception {
 
         Repository repo = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
         RepositoryLocale repoLocale;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -872,4 +872,43 @@ public class TMServiceTest extends ServiceTestBase {
         logger.debug("localized=\n{}", localizedAsset);
         assertEquals(assetContent, localizedAsset);
     }
+
+    @Test
+    public void testLocalizeMacStringsKeysNotEnclosedInDoubleQuotes() throws Exception {
+
+        Repository repo = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        RepositoryLocale repoLocale;
+        try {
+            repoLocale = repositoryService.addRepositoryLocale(repo, "en-GB");
+        } catch (RepositoryLocaleCreationException e) {
+            throw new RuntimeException(e);
+        }
+
+        String assetContent = "NSUsageDescription = \"Usage description:\";\n";
+        asset = assetService.createAsset(repo.getId(), assetContent, "en.lproj/Localizable.strings");
+        asset = assetRepository.findOne(asset.getId());
+        assetId = asset.getId();
+        tmId = repo.getTm().getId();
+
+        PollableFuture<Asset> assetResult = assetService.addOrUpdateAssetAndProcessIfNeeded(repo.getId(), assetContent, asset.getPath());
+        try {
+            pollableTaskService.waitForPollableTask(assetResult.getPollableTask().getId());
+        } catch (PollableTaskException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        assetResult.get();
+
+        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+        textUnitSearcherParameters.setRepositoryIds(repo.getId());
+        textUnitSearcherParameters.setStatusFilter(StatusFilter.FOR_TRANSLATION);
+        List<TextUnitDTO> textUnitDTOs = textUnitSearcher.search(textUnitSearcherParameters);
+        assertEquals(1, textUnitDTOs.size());
+        for (TextUnitDTO textUnitDTO : textUnitDTOs) {
+            logger.debug("source=[{}]", textUnitDTO.getSource());
+        }
+
+        String localizedAsset = tmService.generateLocalized(asset, assetContent, repoLocale, "en-GB");
+        logger.debug("localized=\n{}", localizedAsset);
+        assertEquals(assetContent, localizedAsset);
+    }
 }


### PR DESCRIPTION
@aurambaj  This change is to support keys that are not enclosed in double quotes.  InfoPlist.strings can have it.  For example,
```
/* Keys without double quotes */
Example 1 = "first example";

/* Keys with double quotes */
"Example 2" = "second example";
```