### PR TITLE
drop name format changed to HH.mm.ss

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -25,6 +25,10 @@ import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.UpdateTMWithXLIFFResult;
 import com.box.l10n.mojito.service.translationkit.TranslationKitService;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
 import net.sf.okapi.common.exceptions.OkapiBadFilterInputException;
 import net.sf.okapi.common.exceptions.OkapiIOException;
 import org.joda.time.DateTime;
@@ -32,10 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
 
 /**
  * Service to generate {@link Drop}s.
@@ -345,7 +345,7 @@ public class DropService {
         currentWeek.setTime(uploadTime);
         currentWeek.set(Calendar.WEEK_OF_YEAR, currentWeek.get(Calendar.WEEK_OF_YEAR) - dropServiceConfig.getDropNameWeekOffset());
 
-        return "Week " + currentWeek.get(Calendar.WEEK_OF_YEAR) + new SimpleDateFormat(" (EEEE) - dd MMMM YYYY - HH:mm:ss").format(uploadTime);
+        return "Week " + currentWeek.get(Calendar.WEEK_OF_YEAR) + new SimpleDateFormat(" (EEEE) - dd MMMM YYYY - HH.mm.ss").format(uploadTime);
     }
 
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -33,10 +33,10 @@ import com.box.l10n.mojito.service.tm.search.UsedFilter;
 import com.box.l10n.mojito.service.translationkit.TranslationKitRepository;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.box.l10n.mojito.test.XliffUtils;
-import java.nio.charset.StandardCharsets;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -635,10 +635,10 @@ public class DropServiceTest extends ServiceTestBase {
         Calendar cal = Calendar.getInstance();
         cal.set(2013, 0, 1, 0, 0, 0);
 
-        assertEquals("Week 48 (Tuesday) - 01 January 2013 - 00:00:00", dropService.getDropName(cal.getTime()));
+        assertEquals("Week 48 (Tuesday) - 01 January 2013 - 00.00.00", dropService.getDropName(cal.getTime()));
 
         cal.set(Calendar.WEEK_OF_YEAR, 6);
-        assertEquals("Week 1 (Tuesday) - 05 February 2013 - 00:00:00", dropService.getDropName(cal.getTime()));
+        assertEquals("Week 1 (Tuesday) - 05 February 2013 - 00.00.00", dropService.getDropName(cal.getTime()));
     }
 
     @Test

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/exporter/BoxDropExporterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/exporter/BoxDropExporterTest.java
@@ -55,7 +55,7 @@ public class BoxDropExporterTest extends ServiceTestBase {
         logger.debug("Test initial creation");
         BoxDropExporter boxDropExporter = new BoxDropExporter();
         String groupName = testIdWatcher.getEntityName("groupName");
-        String dropName = groupName + new SimpleDateFormat(" (EEEE) - dd MMMM YYYY - HH:mm:ss").format(new Date());
+        String dropName = groupName + new SimpleDateFormat(" (EEEE) - dd MMMM YYYY - HH.mm.ss").format(new Date());
         boxDropExporter.init(groupName, dropName);
 
         logger.debug("Test re-creation from config");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/exporter/FileSystemDropExporterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/exporter/FileSystemDropExporterTest.java
@@ -12,9 +12,9 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
-import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +39,7 @@ public class FileSystemDropExporterTest extends ServiceTestBase {
         logger.debug("Test initial creation");
         FileSystemDropExporter fileSystemDropExporter = new FileSystemDropExporter();
         String groupName = testIdWatcher.getEntityName("groupName");
-        String dropName = groupName + new SimpleDateFormat(" (EEEE) - dd MMMM YYYY - HH:mm:ss").format(new Date());
+        String dropName = groupName + new SimpleDateFormat(" (EEEE) - dd MMMM YYYY - HH.mm.ss").format(new Date());
         fileSystemDropExporter.init(groupName, dropName);
 
         logger.debug("Test re-creation from config");


### PR DESCRIPTION
This is to fix reported [issue](https://github.com/box/mojito/issues/115).

When Mojito creates folder that contains translation files, it is created in the format of `Week # (day of week) - day month yyyy - hh:mm:ss`, for example, `Week 50 (Tuesday) - 10 January 2017 - 15:24:05`.

This works great if Mojito is configured to use Box or local file system on Mac.  However, if Mojito is configured to use file system on Windows for translation files, the folder creation fails with `java.nio.file.InvalidPathException: Illegal char <:> at index 110` because colon is one of the illegal characters for folder name on Windows.  I am updating the format to have `.` instead of `:`.
