### PR TITLE
File scanner now processes properties with "en" target language like:…

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/LocaleAsFileNameType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/LocaleAsFileNameType.java
@@ -4,7 +4,7 @@ import static com.box.l10n.mojito.cli.filefinder.FilePattern.DOT;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
-import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleType;
+import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleTargetNotSourceType;
 
 /**
  *
@@ -16,7 +16,7 @@ public abstract class LocaleAsFileNameType extends FileType {
         this.baseNamePattern = "";
         this.sourceFilePatternTemplate = "{" + PARENT_PATH + "}{" + LOCALE + "}" + DOT + "{" + FILE_EXTENSION + "}";
         this.targetFilePatternTemplate = sourceFilePatternTemplate;
-        this.localeType = new AnyLocaleType();
+        this.localeType = new AnyLocaleTargetNotSourceType();
     }
 
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/LocaleInNameFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/LocaleInNameFileType.java
@@ -15,7 +15,6 @@ import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleType;
 public abstract class LocaleInNameFileType extends FileType {
 
     public LocaleInNameFileType() {
-        this.baseNamePattern = ".+?";
         this.sourceFilePatternTemplate = "{" + PARENT_PATH + "}{" + BASE_NAME + "}" + DOT + "{" + FILE_EXTENSION + "}";
         this.targetFilePatternTemplate = "{" + PARENT_PATH + "}{" + BASE_NAME + "}" + UNDERSCORE + "{" + LOCALE + "}" + DOT + "{" + FILE_EXTENSION + "}";
         this.localeType = new AnyLocaleType();

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/MacStringsFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/MacStringsFileType.java
@@ -7,7 +7,7 @@ import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.PATH_SEPERATOR;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.SUB_PATH;
-import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleType;
+import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleTargetNotSourceType;
 
 /**
  *
@@ -21,7 +21,7 @@ public class MacStringsFileType extends FileType {
         this.subPath = "lproj";
         this.sourceFilePatternTemplate = "{" + PARENT_PATH + "}{" + LOCALE + "}" + DOT + "{" + SUB_PATH + "}" + PATH_SEPERATOR + "{" + BASE_NAME + "}" + DOT + "{" + FILE_EXTENSION + "}";
         this.targetFilePatternTemplate = sourceFilePatternTemplate;
-        this.localeType = new AnyLocaleType();
+        this.localeType = new AnyLocaleTargetNotSourceType();
     }
 
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/ReswFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/ReswFileType.java
@@ -6,7 +6,7 @@ import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.PATH_SEPERATOR;
-import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleType;
+import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleTargetNotSourceType;
 
 /**
  *
@@ -18,7 +18,7 @@ public class ReswFileType extends FileType {
         this.sourceFileExtension = "resw";
         this.sourceFilePatternTemplate = "{" + PARENT_PATH + "}{" + LOCALE + "}" + PATH_SEPERATOR + "{" + BASE_NAME + "}" + DOT + "{" + FILE_EXTENSION + "}";
         this.targetFilePatternTemplate = sourceFilePatternTemplate;
-        this.localeType = new AnyLocaleType();
+        this.localeType = new AnyLocaleTargetNotSourceType();
     }
     
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/XtbFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/XtbFileType.java
@@ -6,16 +6,18 @@ import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.HYPHEN;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
 import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
+import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleTargetNotSourceType;
 
 /**
  *
  * @author jyi
  */
-public class XtbFileType extends LocaleInNameFileType {
+public class XtbFileType extends FileType {
 
     public XtbFileType() {
         this.sourceFileExtension = "xtb";
         this.sourceFilePatternTemplate = "{" + PARENT_PATH + "}{" + BASE_NAME + "}" + HYPHEN + "{" + LOCALE + "}" + DOT + "{" + FILE_EXTENSION + "}";
         this.targetFilePatternTemplate = sourceFilePatternTemplate;
+        this.localeType = new AnyLocaleTargetNotSourceType();
     }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/locale/AnyLocaleTargetNotSourceType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/locale/AnyLocaleTargetNotSourceType.java
@@ -2,14 +2,15 @@ package com.box.l10n.mojito.cli.filefinder.locale;
 
 /**
  * Generic {@link LocaleType} implementation, accepts any string as locale.
+ * The target locale can be anything but the source locale.
  *
  * @author jaurambault
  */
-public class AnyLocaleType extends LocaleType {
+public class AnyLocaleTargetNotSourceType extends LocaleType {
 
     @Override
     public String getTargetLocaleRegex() {
-        return ".+?";
+        return "(?!" + getSourceLocale() + ")[^/]+?|" + getSourceLocale() + "-[^/]+?";
     }
 
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/filefinder/FileFinderTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/filefinder/FileFinderTest.java
@@ -161,6 +161,7 @@ public class FileFinderTest extends IOTestBase {
         assertFalse(itSources.hasNext());
 
         Iterator<FileMatch> itTargets = fileFinder.getTargets().iterator();
+        assertEquals(getInputResourcesTestDir().toString() + "/filefinder_en.properties", itTargets.next().getPath().toString());
         assertEquals(getInputResourcesTestDir().toString() + "/filefinder_fr.properties", itTargets.next().getPath().toString());
         assertEquals(getInputResourcesTestDir().toString() + "/filefinder_fr_FR.properties", itTargets.next().getPath().toString());
         assertEquals(getInputResourcesTestDir().toString() + "/sub/filefinder2_fr.properties", itTargets.next().getPath().toString());

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/filefinder/FileFinderTest/findInSameDirectory/input/filefinder_en.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/filefinder/FileFinderTest/findInSameDirectory/input/filefinder_en.properties
@@ -1,0 +1,1 @@
+HELLO=Hello {0}!


### PR DESCRIPTION
… "file_en.properties" as a target file

Fix #178