### PR TITLE
Allow to deploy then app with a context path.

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -130,22 +131,26 @@ public class AuthenticatedRestTemplate {
      * @return full URI of the REST WS
      */
     public String getURIForResource(String resourcePath) {
-
-        String uri;
+        
+        StringBuilder uri = new StringBuilder();
 
         if (resourcePath.startsWith(resttemplateConfig.getScheme())) {
-            uri = resourcePath;
+            uri.append(resourcePath);
         } else {
-            uri = resttemplateConfig.getScheme() + "://" + resttemplateConfig.getHost();
+            uri.append(resttemplateConfig.getScheme()).append("://").append(resttemplateConfig.getHost());
 
             if (resttemplateConfig.getPort() != 80) {
-                uri += ":" + resttemplateConfig.getPort();
+                uri.append(":").append(resttemplateConfig.getPort());
+            }
+            
+            if (!Strings.isNullOrEmpty(resttemplateConfig.getContextPath())) {
+                uri.append(resttemplateConfig.getContextPath());
             }
 
-            uri += "/" + resourcePath;
+            uri.append("/").append(resourcePath);
         }
 
-        return uri;
+        return uri.toString();
     }
 
     /**

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/FormLoginAuthenticationCsrfTokenInterceptor.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/FormLoginAuthenticationCsrfTokenInterceptor.java
@@ -56,6 +56,9 @@ public class FormLoginAuthenticationCsrfTokenInterceptor implements ClientHttpRe
      */
     @Autowired
     AuthenticatedRestTemplate authRestTemplate;
+    
+    @Autowired
+    ResttemplateConfig resttemplateConfig;
 
     /**
      * This is used for the authentication flow to keep things separate from the
@@ -274,7 +277,7 @@ public class FormLoginAuthenticationCsrfTokenInterceptor implements ClientHttpRe
         // hacky. Bascailly it says that authentication is successful if a 302 is returned
         // and the redirect (from location header) maps to the login redirect path from the config. 
         URI locationURI = URI.create(postLoginResponseEntity.getHeaders().get("Location").get(0));
-        String expectedLocation = "/" + formLoginConfig.getLoginRedirectPath();
+        String expectedLocation = resttemplateConfig.getContextPath() + "/" + formLoginConfig.getLoginRedirectPath();
         
         if (postLoginResponseEntity.getStatusCode().equals(HttpStatus.FOUND)
                 && expectedLocation.equals(locationURI.getPath())) {
@@ -286,7 +289,7 @@ public class FormLoginAuthenticationCsrfTokenInterceptor implements ClientHttpRe
 
         } else {
             throw new SessionAuthenticationException("Authentication failed.  Post login status code = " + postLoginResponseEntity.getStatusCode()
-                    + ", location = [" + locationURI.getPath() + "], expected location = [" + formLoginConfig.getLoginRedirectPath()+ "]");
+                    + ", location = [" + locationURI.getPath() + "], expected location = [" + expectedLocation + "]");
         }
     }
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/ResttemplateConfig.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/ResttemplateConfig.java
@@ -15,6 +15,7 @@ public class ResttemplateConfig {
     String host = "localhost";
     Integer port = 8080;
     String scheme = "http";
+    String contextPath = "";
 
     Authentication authentication = new Authentication();
 
@@ -88,4 +89,11 @@ public class ResttemplateConfig {
         this.authentication = authentication;
     }
 
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+    }
 }

--- a/restclient/src/test/java/com/box/l10n/mojito/rest/resttemplate/ResttemplateConfigTest.java
+++ b/restclient/src/test/java/com/box/l10n/mojito/rest/resttemplate/ResttemplateConfigTest.java
@@ -32,6 +32,7 @@ public class ResttemplateConfigTest {
         assertEquals("http", resttemplateConfig.getScheme());
         assertEquals("admin", resttemplateConfig.getAuthentication().getUsername());
         assertEquals("ChangeMe", resttemplateConfig.getAuthentication().getPassword());
+        assertEquals("", resttemplateConfig.getContextPath());
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/react/ReactAppController.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/ReactAppController.java
@@ -4,18 +4,19 @@ import com.box.l10n.mojito.rest.security.CsrfTokenController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.IllformedLocaleException;
 import java.util.Locale;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.ModelAndView;
 
 /**
  * The controller used to serve the React application.
@@ -48,7 +49,10 @@ public class ReactAppController {
 
     @Autowired
     CsrfTokenController csrfTokenController;
-
+    
+    @Value("${server.contextPath:}")
+    String contextPath = "";
+   
     //TODO(P1) For now, client routes must be copied in this controller
     @RequestMapping({
         "/",
@@ -66,6 +70,7 @@ public class ReactAppController {
         index.addObject("locale", getValidLocaleFromCookie(localeCookieValue));
         index.addObject("csrfToken", csrfTokenController.getCsrfToken(httpServletRequest));
         index.addObject("username", getUsername());
+        index.addObject("contextPath", contextPath);
 
         return index;
     }

--- a/webapp/src/main/resources/public/js/app.js
+++ b/webapp/src/main/resources/public/js/app.js
@@ -1,7 +1,8 @@
 import $ from "jquery";
 import React from "react";
 import ReactDOM from "react-dom";
-import {Router, Route, IndexRoute, browserHistory} from "react-router";
+import {Router, Route, IndexRoute, useRouterHistory} from "react-router";
+import { createHistory } from 'history'
 import {Modal, Button} from "react-bootstrap";
 import {FormattedMessage, IntlProvider, addLocaleData} from "react-intl";
 import App from "./components/App";
@@ -14,6 +15,7 @@ import Drops from "./components/drops/Drops";
 import Settings from "./components/settings/Settings";
 import WorkbenchActions from "./actions/workbench/WorkbenchActions";
 import SearchConstants from "./utils/SearchConstants";
+import UrlHelper from "./utils/UrlHelper";
 import SearchParamsStore from "./stores/workbench/SearchParamsStore";
 
 // NOTE this way of adding locale data is only recommeneded if there are a few locales.
@@ -32,13 +34,15 @@ import pt from 'react-intl/locale-data/pt';
 import zh from 'react-intl/locale-data/zh';
 addLocaleData([...en, ...fr, ...be, ...ko, ...ru, ...de, ...es, ...it, ...ja, ...pt, ...zh]);
 
+const browserHistory = useRouterHistory(createHistory)({basename: CONTEXT_PATH});
+
 if (!global.Intl) {
     // NOTE: require.ensure would have been nice to use to do module loading
     // but webpack doesn't support ES6 so after Babel transcompile,
     // require.ensure is no longer available.
     // https://webpack.github.io/docs/code-splitting.html#es6-modules
-    $.getScript('/webjars/Intl.js/dist/Intl.min.js', () => {
-        $.getScript('/webjars/Intl.js/locale-data/jsonp/' + LOCALE + '.js', () => {
+    $.getScript(getUrlWithContextPath('/webjars/Intl.js/dist/Intl.min.js'), () => {
+        $.getScript(getUrlWithContextPath('/webjars/Intl.js/locale-data/jsonp/') + LOCALE + '.js', () => {
             startApp();
         });
     });
@@ -108,7 +112,7 @@ BaseClient.authenticateHandler = function () {
         let pathNameStrippedLeadingSlash = location.pathname.substr(1, location.pathname.length);
         let currentLocation = pathNameStrippedLeadingSlash + window.location.search;
 
-        window.location.href = "/login?" + $.param({"showPage": currentLocation});
+        window.location.href = UrlHelper.getUrlWithContextPath("/login?") + $.param({"showPage": currentLocation});
     }
 
     ReactDOM.render(

--- a/webapp/src/main/resources/public/js/components/Login.js
+++ b/webapp/src/main/resources/public/js/components/Login.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import React from "react";
 import {FormattedMessage, FormattedNumber, injectIntl} from "react-intl";
 import {FormControl, Button} from "react-bootstrap";
+import UrlHelper from "../utils/UrlHelper";
 
 let Login = React.createClass({
 
@@ -42,7 +43,7 @@ let Login = React.createClass({
      * @return {string}
      */
     getLoginFormPostUrl: function (showPage) {
-        let result = '/login';
+        let result = UrlHelper.getUrlWithContextPath('/login');
 
         if (showPage) {
             result += '?' + $.param({"showPage": showPage});
@@ -62,7 +63,7 @@ let Login = React.createClass({
             <div className="container login-container">
                 <div className="row">
                     <div className="center-block login-logo-container">
-                        <img src="/img/logo-login.png" className="logo mbm" alt="Mojito"/>
+                        <img src={UrlHelper.getUrlWithContextPath("/img/logo-login.png")} className="logo mbm" alt="Mojito"/>
                     </div>
                     <div className="center-block login-form-container">
                         <form action={loginFormPostUrl} method="post">

--- a/webapp/src/main/resources/public/js/components/header/Header.js
+++ b/webapp/src/main/resources/public/js/components/header/Header.js
@@ -5,6 +5,7 @@ import { withRouter } from "react-router";
 
 import LocaleSelectorModal from "./LocaleSelectorModal";
 import Locales from "../../utils/Locales";
+import UrlHelper from "../../utils/UrlHelper";
 
 import RepositoryActions from "../../actions/RepositoryActions";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
@@ -58,7 +59,7 @@ let Header = React.createClass({
         return (
             <Navbar fluid={true}>
                 <a className="navbar-brand">
-                    <img src="/img/logo.png" className="logo" alt="Box Mojito" />
+                    <img src={UrlHelper.getUrlWithContextPath('/img/logo.png')} className="logo" alt="Box Mojito" />
                 </a>
                 <Nav>
                     <li className={(this.props.router.isActive("/repositories")) ? "active" : ""}>
@@ -84,7 +85,7 @@ let Header = React.createClass({
 
                         <MenuItem divider />
                         <MenuItem onSelect={this.logoutSelected}>
-                            <form action="/logout" method="post" ref="logoutForm">
+                            <form action={UrlHelper.getUrlWithContextPath("/logout")} method="post" ref="logoutForm">
                                 <FormControl type="hidden" name="_csrf" value={CSRF_TOKEN}/>
                                 <FormattedMessage id="header.loggedInUser.logout" />
                             </form>

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.js
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.js
@@ -15,6 +15,7 @@ import TextUnitsReviewModal from "./TextUnitsReviewModal";
 import TextUnitSelectorCheckBox from "./TextUnitSelectorCheckBox";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 import ReviewTextUnitsDTO from "../../stores/workbench/ReviewTextUnitsDTO";
+import UrlHelper from "../../utils/UrlHelper";
 
 let SearchResults = React.createClass({
 
@@ -574,23 +575,27 @@ let SearchResults = React.createClass({
 
         if (!this.state.isSearching) {
             if (!this.state.isReadyForSearching) {
-                result = (
-                    <div className="empty-search-container text-center center-block">
-                        <FormattedMessage id="search.result.selectRepoAndLocale"/>
-                    </div>
-                );
+                result = this.getEmptyStateContainerContent("search.result.selectRepoAndLocale");
             }
             else if (this.state.searchHadNoResults) {
-                result = (
-                    <div className="empty-search-container text-center center-block">
-                        <FormattedMessage id="search.result.empty"/>
-                    </div>);
+                result = this.getEmptyStateContainerContent("search.result.empty");
             }
         }
 
         return result;
     },
       
+    /**
+     * @param {string} messageId message id of the message to be displayed 
+     * @returns {JSX}
+     */
+    getEmptyStateContainerContent(messageId) {
+        return <div className="empty-search-container text-center center-block">
+                    <div><FormattedMessage id={messageId}/></div>
+                    <img className="empty-search-container-img" src={UrlHelper.getUrlWithContextPath('/img/magnifying-glass.svg')} />
+            </div>;
+    },
+
     render() {
         return (
             <div onKeyUp={this.onKeyUpSearchResults} onClick={this.onChangeSearchResults}>

--- a/webapp/src/main/resources/public/js/sdk/BaseClient.js
+++ b/webapp/src/main/resources/public/js/sdk/BaseClient.js
@@ -2,8 +2,7 @@ import $ from "jquery";
 
 class BaseClient {
     constructor() {
-        //TODO configure this!!
-        this.baseUrl = location.origin + '/api/';
+        this.baseUrl = location.origin + CONTEXT_PATH +  '/api/';
     }
 
     /**

--- a/webapp/src/main/resources/public/js/utils/LocationHistory.js
+++ b/webapp/src/main/resources/public/js/utils/LocationHistory.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import UrlHelper from "./UrlHelper";
 
 class LocationHistory {
 
@@ -13,7 +14,7 @@ class LocationHistory {
      * @param {object} params params to build the query string
      */
     updateLocation(router, pathname, params) {
-        if (window.location.pathname === pathname) {
+        if (window.location.pathname === UrlHelper.getUrlWithContextPath(pathname)) {
             let newQuery = this.buildQuery(params);
 
             if (window.location.search === "") {

--- a/webapp/src/main/resources/public/js/utils/UrlHelper.js
+++ b/webapp/src/main/resources/public/js/utils/UrlHelper.js
@@ -1,0 +1,12 @@
+class UrlHelper {
+
+    constructor() {
+        this.contextPath = CONTEXT_PATH;
+    }
+
+    getUrlWithContextPath(url) {
+        return this.contextPath + url;
+    }
+};
+
+export default new UrlHelper();

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -634,14 +634,15 @@ label.current-pageNumber {
 }
 
 .empty-search-container {
-  background-image: url("/img/magnifying-glass.svg");
-  background-repeat: no-repeat;
-  background-size: 125px;
-  background-position: center;
   width: 600px;
   height: 300px;
   opacity: 0.5;
   margin-top: 80px;
+}
+
+.empty-search-container-img {
+    margin-top: 20px;
+    width: 125px;
 }
 
 .search-text .glyphicon-refresh.spinning {

--- a/webapp/src/main/resources/templates/index.html
+++ b/webapp/src/main/resources/templates/index.html
@@ -4,23 +4,24 @@
         <title>Mojito</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-        <link rel="stylesheet" type="text/css" href="/css/mojito.css" />
-        <link rel="stylesheet" type="text/css" href="/css/bootstrap-multiselect.css" />
-        <link rel="stylesheet" type="text/css" href="/css/animate.min.css">
+        <link rel="stylesheet" type="text/css" href="{{contextPath}}/css/mojito.css" />
+        <link rel="stylesheet" type="text/css" href="{{contextPath}}/css/bootstrap-multiselect.css" />
+        <link rel="stylesheet" type="text/css" href="{{contextPath}}/css/animate.min.css">
 
         <script type="text/javascript">
             LOCALE = '{{locale}}';
             CSRF_TOKEN = '{{csrfToken}}';
             USERNAME = '{{username}}';
+            CONTEXT_PATH = '{{contextPath}}';
         </script>
 
-        <script src="/intl/{{locale}}.js"></script>
+        <script src="{{contextPath}}/intl/{{locale}}.js"></script>
 
     </head>
 
     <body>
         <div id="app"></div>
-        <script type="text/javascript" src="/js/bundle.min.js"></script>
+        <script type="text/javascript" src="{{contextPath}}/js/bundle.min.js"></script>
     </body>
 
 </html>


### PR DESCRIPTION
Before the app was running on http://{hostname}:{port}/. Now it is possible to have the app run
on http://{hostname}:{port}/{contextPath}/

In the server config, use 'server.contextPath={contextPath}' to define the context path (eg '/mojito').
The CLI must use the matching setting: 'l10n.resttemplate.contextPath={contextPath}'

The frontend has been refactored to support the context path.

Fix #181