### PR TITLE
Refactor Repository actions, store and components

### DIFF
--- a/webapp/src/main/resources/public/js/actions/RepositoryActions.js
+++ b/webapp/src/main/resources/public/js/actions/RepositoryActions.js
@@ -1,16 +1,12 @@
 import alt from "../alt";
-import RepositoryClient from "../sdk/RepositoryClient";
 
 class RepositoryActions {
-
-    init() {
-        this.getAllRepositories();
-    }
-
-    getAllRepositories() {
-        return (dispatch) => RepositoryClient.getRepositories().then(response => {
-           dispatch(response);
-        });
+    constructor() {
+        this.generateActions(
+            "getAllRepositories",
+            "getAllRepositoriesSuccess",
+            "getAllRepositoriesError"
+        );
     }
 }
 

--- a/webapp/src/main/resources/public/js/actions/RepositoryDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/RepositoryDataSource.js
@@ -1,0 +1,15 @@
+import RepositoryClient from "../sdk/RepositoryClient";
+import RepositoryActions from "./RepositoryActions";
+
+const RepositoryDataSource = {
+    getAllRepositories: {
+        remote() {
+            return RepositoryClient.getRepositories();
+        },
+
+        success: RepositoryActions.getAllRepositoriesSuccess,
+        error: RepositoryActions.getAllRepositoriesError
+    }
+};
+
+export default RepositoryDataSource;

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -69,7 +69,6 @@ let Drops = React.createClass({
 
     componentDidMount() {
         RepositoryActions.getAllRepositories();
-
         this.fetchDrops();
     },
 

--- a/webapp/src/main/resources/public/js/components/header/Header.js
+++ b/webapp/src/main/resources/public/js/components/header/Header.js
@@ -63,7 +63,11 @@ let Header = React.createClass({
                 </a>
                 <Nav>
                     <li className={(this.props.router.isActive("/repositories")) ? "active" : ""}>
-                        <Link onClick={RepositoryActions.getAllRepositories} to="/repositories"><FormattedMessage id="header.repositories" /></Link>
+                        <Link onClick={() => {
+                            if (this.props.router.isActive("/repositories")) {
+                                  RepositoryActions.getAllRepositories();
+                            }}}
+                         to="/repositories"><FormattedMessage id="header.repositories" /></Link>
                     </li>
                     <li className={(this.props.router.isActive("/workbench")) ? "active" : ""}>
                         <Link onClick={this.updateSearchParamsForDefaultView} to="/workbench"><FormattedMessage id="header.workbench" /></Link>

--- a/webapp/src/main/resources/public/js/components/repositories/Repositories.js
+++ b/webapp/src/main/resources/public/js/components/repositories/Repositories.js
@@ -7,26 +7,31 @@ import RepositoryHeaderColumn from "./RepositoryHeaderColumn";
 import RepositoryRow from "./RepositoryRow";
 import RepositoryActions from "../../actions/RepositoryActions";
 import RepositoryStatistic from "../../components/repositories/RepositoryStatistic";
+import FluxyMixin from "alt-mixins/FluxyMixin";
 
 let Repositories = React.createClass({
 
+    mixins: [FluxyMixin],
+
+    statics: {
+        storeListeners: {
+            "onRepositoryStoreChanged": RepositoryStore
+        }
+    },
+
     getInitialState: function () {
         let state = RepositoryStore.getState();
-
         state.isLocaleStatsShown = false;
         state.activeRepoId = null;
-
         return state;
     },
 
     componentDidMount: function () {
-        RepositoryActions.init();
-
-        RepositoryStore.listen(this.dataChanged);
+        RepositoryActions.getAllRepositories();
     },
-
-    componentWillUnmount: function () {
-        RepositoryStore.unlisten(this.dataChanged);
+    
+    onRepositoryStoreChanged: function () {
+        this.setState(RepositoryStore.getState());
     },
 
     getTableRow: function (rowData) {
@@ -105,12 +110,7 @@ let Repositories = React.createClass({
                 </ReactSidebarResponsive>
             </div>
         );
-    },
-
-    dataChanged: function (state) {
-        this.setState(state);
     }
-
 });
 
 export default Repositories;

--- a/webapp/src/main/resources/public/js/components/repositories/RepositoryRow.js
+++ b/webapp/src/main/resources/public/js/components/repositories/RepositoryRow.js
@@ -347,7 +347,7 @@ let RepositoryRow = React.createClass({
 
         return (
             <tr className={rowClass}>
-                <td className="repo-name" overlay={descriptionTooltip}>
+                <td className="repo-name">
                     <OverlayTrigger placement="right" overlay={descriptionTooltip}>
                         <Link onClick={this.updateSearchParamsForRepoDefault.bind(this, repoId)}
                               to='/workbench'>{this.props.rowData.name}</Link>

--- a/webapp/src/main/resources/public/js/components/workbench/RepositoryDropdown.js
+++ b/webapp/src/main/resources/public/js/components/workbench/RepositoryDropdown.js
@@ -32,7 +32,6 @@ let RepositoryDropDown = React.createClass({
      * Handler for when RepositoryStore is updated
      */
     onRepositoriesFetched() {
-
         let searchParams = SearchParamsStore.getState();
 
         if (searchParams.changedParam === SearchConstants.REPOSITORIES_CHANGED ||

--- a/webapp/src/main/resources/public/js/components/workbench/Workbench.js
+++ b/webapp/src/main/resources/public/js/components/workbench/Workbench.js
@@ -11,7 +11,7 @@ import LocalesDropdown from "./LocalesDropdown";
 
 import RepositoryActions from "../../actions/RepositoryActions";
 import RepositoryDropDown from "./RepositoryDropdown";
-import RepositoriesStore from "../../stores/RepositoryStore";
+import RepositoryStore from "../../stores/RepositoryStore";
 
 import SearchResults from "./SearchResults";
 import StatusDropdown from "./StatusDropdown";
@@ -45,7 +45,7 @@ let Workbench = React.createClass({
     onSearchParamsStoreChanged: function (searchParams) {
         this.updateLocationForSearchParam(searchParams);
     },
-
+    
     /**
      * Updates the browser location based to reflect search
      *
@@ -79,7 +79,6 @@ let Workbench = React.createClass({
     },
 
     render: function () {
-        
         return (
             <div>
                 <div className="pull-left">

--- a/webapp/src/main/resources/public/js/sdk/BaseClient.js
+++ b/webapp/src/main/resources/public/js/sdk/BaseClient.js
@@ -45,7 +45,6 @@ class BaseClient {
      * @param {Response} response
      */
     handleUnauthenticatedResponse(response) {
-        console.log(response.status);
         if (response.status === 401) {
             BaseClient.authenticateHandler();
         }

--- a/webapp/src/main/resources/public/js/stores/RepositoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/RepositoryStore.js
@@ -1,19 +1,21 @@
 import alt from "../alt";
 import RepositoryActions from "../actions/RepositoryActions";
+import RepositoryDataSource from "../actions/RepositoryDataSource";
 import RepositoryLocale from "../sdk/entity/RepositoryLocale";
 
 class RepositoryStore {
 
     constructor() {
-
-        this.repositories = [];
-
-        this.bindListeners({
-            handleUpdateRepositories: RepositoryActions.GET_ALL_REPOSITORIES
-        });
+        this.repositories = [];        
+        this.bindActions(RepositoryActions);
+        this.registerAsync(RepositoryDataSource);
     }
 
-    handleUpdateRepositories(repositories) {
+    getAllRepositories() {
+        this.getInstance().getAllRepositories();
+    }
+
+    getAllRepositoriesSuccess(repositories) {
         this.repositories = repositories;
     }
 


### PR DESCRIPTION
- Introduce RepositoryDataSource
- Change to Header navigation to prevent calling twice the getAllRepositories when navigating from another page