### PR TITLE
Make sure comments are not copied when the TmTextUnitCurrentVariant i…

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/AddTMTextUnitCurrentVariantResult.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/AddTMTextUnitCurrentVariantResult.java
@@ -1,0 +1,41 @@
+package com.box.l10n.mojito.service.tm;
+
+import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant;
+
+/**
+ * Result of {@link TMService#addTMTextUnitCurrentVariantWithResult(java.lang.Long, java.lang.Long, java.lang.String, java.lang.String, com.box.l10n.mojito.entity.TMTextUnitVariant.Status, boolean, org.joda.time.DateTime) }
+ * 
+ * @author jeanaurambault
+ */
+public class AddTMTextUnitCurrentVariantResult {
+
+    /**
+     * Indicates if {@link TMTextUnitCurrentVariant} has been updated/created
+     * or not
+     */
+    boolean tmTextUnitCurrentVariantUpdated;
+
+    TMTextUnitCurrentVariant tmTextUnitCurrentVariant;
+
+    public AddTMTextUnitCurrentVariantResult(boolean tmTextUnitCurrentVariantUpdated, TMTextUnitCurrentVariant tmTextUnitCurrentVariant) {
+        this.tmTextUnitCurrentVariantUpdated = tmTextUnitCurrentVariantUpdated;
+        this.tmTextUnitCurrentVariant = tmTextUnitCurrentVariant;
+    }
+    
+    public boolean isTmTextUnitCurrentVariantUpdated() {
+        return tmTextUnitCurrentVariantUpdated;
+    }
+
+    public void setTmTextUnitCurrentVariantUpdated(boolean tmTextUnitCurrentVariantUpdated) {
+        this.tmTextUnitCurrentVariantUpdated = tmTextUnitCurrentVariantUpdated;
+    }
+
+    public TMTextUnitCurrentVariant getTmTextUnitCurrentVariant() {
+        return tmTextUnitCurrentVariant;
+    }
+
+    public void setTmTextUnitCurrentVariant(TMTextUnitCurrentVariant tmTextUnitCurrentVariant) {
+        this.tmTextUnitCurrentVariant = tmTextUnitCurrentVariant;
+    }
+
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/leveraging/LeveragingServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/leveraging/LeveragingServiceTest.java
@@ -124,5 +124,31 @@ public class LeveragingServiceTest extends ServiceTestBase {
         Assert.assertFalse(itSource.hasNext());
 
     }
+    
+    @Test
+    public void checkCommentsAreNotCopiedIfTmTextUnitCurrentVariantNotChanged() throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException {
+
+        TMTestData tmTestDataSource = new TMTestData(testIdWatcher);
+
+        Repository sourceRepository = tmTestDataSource.repository;
+
+        logger.debug("Create the target repository");
+        Repository targetRepository = repositoryService.createRepository(testIdWatcher.getEntityName("targetRepository"));
+
+        TM tm = targetRepository.getTm();
+
+        Asset asset = assetService.createAsset(targetRepository.getId(), "fake for test", "fake_for_test");
+        Long assetId = asset.getId();
+
+        tmService.addTMTextUnit(tm.getId(), assetId, "zuora_error_message_verify_state_province_update", "Please enter a valid state, region or province", "Comment1");
+        tmService.addTMTextUnit(tm.getId(), assetId, "TEST2", "Content2", "Comment2");
+        tmService.addTMTextUnit(tm.getId(), assetId, "TEST3", "Content3", "Comment3");
+
+        leveragingService.copyAllTranslationsWithExactMatchBetweenRepositories(sourceRepository, targetRepository).get();
+        leveragingService.copyAllTranslationsWithExactMatchBetweenRepositories(sourceRepository, targetRepository).get();
+
+        List<TMTextUnitVariant> targetTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesOrderByContent(targetRepository); 
+        Assert.assertEquals(1, targetTranslations.get(2).getTmTextUnitVariantComments().size());
+    }
 
 }


### PR DESCRIPTION
…s not changed.

Fixes bug were the comments would keep growing when performing multiple leveraging even though no real change were happening.

Fixes #186