### PR TITLE
Travis is moving to new default distribution: trusty but it doesn't s…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - oraclejdk7
+dist: precise
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
…upport 'oraclejdk7' which we use to build right now. Force the old version: precise to be used... later we should probably move to jdk8