### PR TITLE
Introduce virtual asset with APIs to manage text units

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -117,9 +117,9 @@ public class PushCommand extends Command {
         } catch (PollableTaskException e) {
             throw new CommandException(e.getMessage(), e.getCause());
         }
-
+ 
         logger.debug("process deleted assets here");
-        Set<Long> assetIds = Sets.newHashSet(assetClient.getAssetIds(repository.getId(), false));
+        Set<Long> assetIds = Sets.newHashSet(assetClient.getAssetIds(repository.getId(), false, false));
         assetIds.removeAll(usedAssetIds);
         if (!assetIds.isEmpty()) {
             assetClient.deleteAssetsByIds(assetIds);

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/VirtualAssetCreateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/VirtualAssetCreateCommand.java
@@ -1,0 +1,80 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.ConsoleWriter;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.rest.client.HttpClientErrorExceptionHelper;
+import com.box.l10n.mojito.rest.client.HttpClientErrorJson;
+import com.box.l10n.mojito.rest.client.RepositoryClient;
+import com.box.l10n.mojito.rest.client.VirtualAsset;
+import com.box.l10n.mojito.rest.client.VirtualAssetClient;
+import com.box.l10n.mojito.rest.entity.Repository;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * @author jaurambault
+ */
+@Component
+@Scope("prototype")
+@Parameters(commandNames = {"virtual-asset-create"}, commandDescription = "Create an asset (with virtual content)")
+public class VirtualAssetCreateCommand extends Command {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(VirtualAssetCreateCommand.class);
+
+    @Autowired
+    ConsoleWriter consoleWriter;
+
+    @Parameter(names = {Param.REPOSITORY_LONG, Param.REPOSITORY_SHORT}, arity = 1, required = true, description = Param.REPOSITORY_DESCRIPTION)
+    String repositoryParam;
+
+    @Parameter(names = {"--path", "-p"}, arity = 1, required = true, description = Param.REPOSITORY_DESCRIPTION)
+    String pathParam;
+
+    @Autowired
+    VirtualAssetClient virtualAssetClient;
+
+    @Autowired
+    RepositoryClient repositoryClient;
+
+    @Autowired
+    CommandHelper commandHelper;
+    
+    @Autowired
+    HttpClientErrorExceptionHelper httpClientErrorExceptionHelper;
+
+    CommandDirectories commandDirectories;
+
+    @Override
+    public void execute() throws CommandException {
+
+        consoleWriter.newLine().a("Create a virtual asset: ").fg(Ansi.Color.CYAN).a(pathParam).
+                reset().a(" in repository: ").fg(Ansi.Color.CYAN).a(repositoryParam).println(2);
+
+        Repository repository = commandHelper.findRepositoryByName(repositoryParam);
+
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setPath(pathParam);
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setDeleted(Boolean.FALSE);
+
+        try {
+            consoleWriter.a(" - Create virtual asset: ").fg(Ansi.Color.CYAN).a(pathParam).println();
+            virtualAsset = virtualAssetClient.createOrUpdate(virtualAsset);
+            consoleWriter.a(" --> asset id: ").fg(Ansi.Color.MAGENTA).a(virtualAsset.getId()).println();
+            consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
+        } catch (HttpClientErrorException hcee) {
+            HttpClientErrorJson toHttpClientErrorJson = httpClientErrorExceptionHelper.toHttpClientErrorJson(hcee);
+            consoleWriter.println().fg(Ansi.Color.RED).a(toHttpClientErrorJson.getMessage()).println(2);
+        }
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/VirtualAssetCreateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/VirtualAssetCreateCommandTest.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.rest.client.RepositoryClient;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class VirtualAssetCreateCommandTest extends CLITestBase {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(VirtualAssetCreateCommandTest.class);
+
+    @Autowired
+    RepositoryClient repositoryClient; 
+
+    @Test
+    public void execute() throws Exception {
+        Repository repository = createTestRepoUsingRepoService();        
+        getL10nJCommander().run("virtual-asset-create", "-r", repository.getName(), "-p", "asset1");
+        getL10nJCommander().run("virtual-asset-create", "-r", repository.getName(), "-p", "asset2");
+    }
+        
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
@@ -69,14 +69,14 @@ public class AssetClient extends BaseClient {
      * still used to fetch the translations). This can be used to generate a
      * file with tag "fr" even if the translations are stored with fr-FR
      * repository locale.
-     * @param filterConfigIdOverride Optional, can be null. Allows to specify
-     * a specific Okapi filter to use to process the asset
+     * @param filterConfigIdOverride Optional, can be null. Allows to specify a
+     * specific Okapi filter to use to process the asset
      * @return the localized asset content
      */
     public LocalizedAssetBody getLocalizedAssetForContent(
-            Long assetId, 
+            Long assetId,
             Long localeId,
-            String content, 
+            String content,
             String outputBcp47tag,
             FilterConfigIdOverride filterConfigIdOverride) {
         logger.debug("Getting localized asset with asset id = {}, locale id = {}, outputBcp47tag: {}", assetId, localeId, outputBcp47tag);
@@ -94,25 +94,24 @@ public class AssetClient extends BaseClient {
                 LocalizedAssetBody.class);
     }
 
-
     /**
-     * Gets a pseudo localized version of provided content, the content is related to a
-     * given Asset.
+     * Gets a pseudo localized version of provided content, the content is
+     * related to a given Asset.
      *
      * The content can be a new version of the asset stored in the TMS. This is
-     * used to pseudo localize files during development with usually minor changes done
-     * to the persisted asset.
+     * used to pseudo localize files during development with usually minor
+     * changes done to the persisted asset.
      *
      * @param assetId {@link Asset#id}
      * @param content the asset content to be pseudolocalized
-     * @param filterConfigIdOverride Optional, can be null. Allows to specify
-     * a specific Okapi filter to use to process the asset
+     * @param filterConfigIdOverride Optional, can be null. Allows to specify a
+     * specific Okapi filter to use to process the asset
      * @return the pseudoloocalized asset content
      */
     public LocalizedAssetBody getPseudoLocalizedAssetForContent(Long assetId, String content, FilterConfigIdOverride filterConfigIdOverride) {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder
-                       .fromPath(getBasePathForResource(assetId, "pseudo"));
+                .fromPath(getBasePathForResource(assetId, "pseudo"));
 
         LocalizedAssetBody localizedAssetBody = new LocalizedAssetBody();
         localizedAssetBody.setContent(content);
@@ -125,21 +124,21 @@ public class AssetClient extends BaseClient {
     }
 
     /**
-     * Imports a localized version of an asset. 
-     * 
-     * The target strings are checked against the source strings and if they 
-     * are equals the status of the imported translation is defined by 
+     * Imports a localized version of an asset.
+     *
+     * The target strings are checked against the source strings and if they are
+     * equals the status of the imported translation is defined by
      * statusForSourceEqTarget. When SKIIPED is specified the import is actually
      * skipped.
-     * 
+     *
      * For not fully translated locales, targets are imported only if they are
      * different from target of the parent locale.
      *
      * @param assetId {@link Asset#id}
      * @param localeId {@link Locale#id}
      * @param content the asset content to be localized
-     * @param statusForSourceEqTarget the status of the text unit variant 
-     * when the source equals the target
+     * @param statusForSourceEqTarget the status of the text unit variant when
+     * the source equals the target
      */
     public void importLocalizedAssetForContent(
             Long assetId,
@@ -284,9 +283,10 @@ public class AssetClient extends BaseClient {
      *
      * @param repositoryId
      * @param deleted optional
+     * @param virtual optional
      * @return
      */
-    public List<Long> getAssetIds(Long repositoryId, Boolean deleted) {
+    public List<Long> getAssetIds(Long repositoryId, Boolean deleted, Boolean virtual) {
         Assert.notNull(repositoryId);
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder
@@ -297,6 +297,10 @@ public class AssetClient extends BaseClient {
 
         if (deleted != null) {
             params.put("deleted", deleted.toString());
+        }
+
+        if (virtual != null) {
+            params.put("virtual", virtual.toString());
         }
 
         return authenticatedRestTemplate.getForObjectAsListWithQueryStringParams(uriBuilder.toUriString(), Long[].class, params);

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/HttpClientErrorExceptionHelper.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/HttpClientErrorExceptionHelper.java
@@ -1,0 +1,22 @@
+package com.box.l10n.mojito.rest.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+@Component
+public class HttpClientErrorExceptionHelper {
+
+    public HttpClientErrorJson toHttpClientErrorJson(HttpClientErrorException hcee) {
+        try {
+            return new ObjectMapper().readValue(hcee.getResponseBodyAsString(), HttpClientErrorJson.class);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Can't convert HttpClientErrorException to Json", ioe);
+        }
+    }
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/HttpClientErrorJson.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/HttpClientErrorJson.java
@@ -1,0 +1,40 @@
+package com.box.l10n.mojito.rest.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HttpClientErrorJson {
+
+    String status;
+    String message;
+    String exception;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getException() {
+        return exception;
+    }
+
+    public void setException(String exception) {
+        this.exception = exception;
+    }
+
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/VirtualAsset.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/VirtualAsset.java
@@ -1,0 +1,46 @@
+package com.box.l10n.mojito.rest.client;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+public class VirtualAsset {
+
+    Long id;
+    Long repositoryId;
+    String path;
+    Boolean deleted;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(Long repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(Boolean deleted) {
+        this.deleted = deleted;
+    }
+
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/VirtualAssetClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/VirtualAssetClient.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.rest.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author wyau
+ */
+@Component
+public class VirtualAssetClient extends BaseClient {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(VirtualAssetClient.class);
+
+    @Override
+    public String getEntityName() {
+        return "virtualAssets";
+    }
+
+    public VirtualAsset createOrUpdate(VirtualAsset virtualAsset) {
+        return authenticatedRestTemplate.postForObject(
+                getBasePathForEntity(),
+                virtualAsset,
+                VirtualAsset.class
+        );
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Asset.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Asset.java
@@ -47,6 +47,9 @@ public class Asset extends AuditableEntity {
     @Column(name = "content_md5", length = 32)
     private String contentMd5;
 
+    @Column(name = "`virtual`", nullable=false)
+    private Boolean virtual = false;
+    
     @OneToOne
     @JoinColumn(name = "last_successful_asset_extraction_id", foreignKey = @ForeignKey(name = "FK__ASSET__ASSET_EXTRACTION__ID"))
     private AssetExtraction lastSuccessfulAssetExtraction;
@@ -117,5 +120,12 @@ public class Asset extends AuditableEntity {
     public void setDeleted(Boolean deleted) {
         this.deleted = deleted;
     }
-    
+
+    public Boolean getVirtual() {
+        return virtual;
+    }
+
+    public void setVirtual(Boolean virtual) {
+        this.virtual = virtual;
+    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractImportTranslationsStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractImportTranslationsStep.java
@@ -350,7 +350,7 @@ public abstract class AbstractImportTranslationsStep extends AbstractMd5Computat
         //TODO(P1) check text unit in translation kit translakit and complain? or not ...
         String targetString = target.toString();
 
-        logger.debug("Looking at TMTextUnitVariantCommentAnnotations to decide if translation should be included or needs review (by default included and no review");
+        logger.debug("Looking at TMTextUnitVariantCommentAnnotations to decide if translation should be included or needs review (by default included and no review)");
         TMTextUnitVariantCommentAnnotations tmTextUnitVariantCommentAnnotations = new TMTextUnitVariantCommentAnnotations(target);
 
         boolean includedInLocalizedFile = true;

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractMd5ComputationStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractMd5ComputationStep.java
@@ -55,6 +55,10 @@ public abstract class AbstractMd5ComputationStep extends BasePipelineStep {
             }
             md5 = tmService.computeTMTextUnitMD5(name, source, comments);
         }
+        
+        if (logger.isDebugEnabled()) {
+            logger.debug("Handle text unit with name: {}\nsource: {}\ncomments: {}\nmd5: {}", name, source, comments, md5);
+        }
 
         return event;
     }    

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/TranslateStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/TranslateStep.java
@@ -1,19 +1,15 @@
 package com.box.l10n.mojito.okapi;
 
+import com.box.l10n.mojito.service.tm.TranslatorWithInheritance;
 import com.box.l10n.mojito.entity.Asset;
-import com.box.l10n.mojito.entity.Locale;
 import com.box.l10n.mojito.entity.RepositoryLocale;
 import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
-import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantRepository;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
-import com.box.l10n.mojito.service.tm.search.StatusFilter;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
-import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import net.sf.okapi.common.Event;
 import net.sf.okapi.common.LocaleId;
@@ -56,6 +52,8 @@ public class TranslateStep extends AbstractMd5ComputationStep {
 
     RepositoryLocale repositoryLocale;
 
+    TranslatorWithInheritance translatorWithInheritance;
+
     /**
      * Cache that contains the translations required to translate the asset.
      */
@@ -67,16 +65,17 @@ public class TranslateStep extends AbstractMd5ComputationStep {
      * @param asset {@link Asset} that will be used to lookup translations
      * @param repositoryLocale used to fetch translations. It can be different
      * from the locale used in the Okapi pipeline ({@link #targetLocale}) in
-     * case the file needs to be generated for a tag that is different from 
-     * the locale used for translation.
+     * case the file needs to be generated for a tag that is different from the
+     * locale used for translation.
      * @param inheritanceMode
      */
     public TranslateStep(Asset asset, RepositoryLocale repositoryLocale, InheritanceMode inheritanceMode) {
         this.asset = asset;
         this.inheritanceMode = inheritanceMode;
         this.repositoryLocale = repositoryLocale;
+        this.translatorWithInheritance = new TranslatorWithInheritance(asset, repositoryLocale, inheritanceMode);
     }
-        
+
     @SuppressWarnings("deprecation")
     @StepParameterMapping(parameterType = StepParameterType.TARGET_LOCALE)
     public void setTargetLocale(LocaleId targetLocale) {
@@ -100,141 +99,17 @@ public class TranslateStep extends AbstractMd5ComputationStep {
 
         if (textUnit.isTranslatable()) {
 
-            String translation = null;
-
-            logger.debug("Look for a translation in target locale: {} for text unit with name: {}", targetLocale.toBCP47(), name);
-            logger.trace("comments: {}\nsource: {}", comments, source);
-            
-            TextUnitDTO textUnitDTO = getTextUnitDTO(md5, repositoryLocale.getLocale().getId());
-
-            if (textUnitDTO != null) {
-                logger.debug("Found translation for target locale");
-                translation = textUnitDTO.getTarget();
-            } else if (InheritanceMode.USE_PARENT.equals(inheritanceMode)) {
-                logger.debug("No translation found for target locale, look for translations in parent locales");
-                translation = getTranslationWithInheritance(md5, source);
-            }
+            String translation = translatorWithInheritance.getTranslation(name, source, md5, repositoryLocale, inheritanceMode);
 
             if (translation == null && InheritanceMode.REMOVE_UNTRANSLATED.equals(inheritanceMode)) {
                 logger.debug("Remove untranslated text unit");
                 event = Event.NOOP_EVENT;
             } else {
-                logger.debug("Set translation for text unit with name: {}: {}", name, translation);
+                logger.debug("Set translation for text unit with name: {}, translation: {}", name, translation);
                 textUnit.setTarget(targetLocale, new TextContainer(translation));
             }
         }
 
         return event;
     }
-
-    /**
-     * Look for a translation in parent locale excluding the root locale for a
-     * given MD5, if none is found it returns the source.
-     *
-     * <p>
-     * The root locale (repository locale with parent locale null) is excluded
-     * for optimization purpose, the translations fetched would be the same as
-     * the source, hence returning the source directly is more efficient.
-     *
-     * @param md5 MD5 to lookup the translation
-     * @param source the source to fallback to if there is no translation
-     * @return the translation from a parent locale or the source if no
-     * translation is found.
-     */
-    protected String getTranslationWithInheritance(String md5, String source) {
-
-        String translation = null;
-
-        logger.debug("Get Translation with inheritance");
-        RepositoryLocale repositoryLocaleForFind = repositoryLocale.getParentLocale();
-
-        while (translation == null && repositoryLocaleForFind != null && repositoryLocaleForFind.getParentLocale() != null) {
-
-            logger.debug("Looking for a translation in locale: {}", repositoryLocaleForFind.getLocale().getBcp47Tag());
-            TextUnitDTO textUnitDTO = getTextUnitDTO(md5, repositoryLocaleForFind.getLocale().getId());
-
-            if (textUnitDTO != null) {
-                logger.debug("Found a translation using inheritance in locale: {}", repositoryLocaleForFind.getLocale().getBcp47Tag());
-                translation = textUnitDTO.getTarget();
-            } else {
-                logger.debug("No inherited translation in locale: {}", repositoryLocaleForFind.getLocale().getBcp47Tag());
-            }
-
-            repositoryLocaleForFind = repositoryLocaleForFind.getParentLocale();
-        }
-
-        if (translation == null) {
-            logger.debug("No translation using inheritance, fallback to source");
-            translation = source;
-        }
-
-        return translation;
-    }
-
-    /**
-     * Gets a {@link TextUnitDTO} from the cache for a given locale and text
-     * unit MD5.
-     *
-     * @param md5 the MD5 of the text unit (see
-     * {@link TMService#computeTMTextUnitMD5(java.lang.String, java.lang.String, java.lang.String)})
-     * @param localeId the {@link Locale#id}
-     * @return a {@link TextUnitDTO} or {@code null} if no translation is
-     * available
-     */
-    private TextUnitDTO getTextUnitDTO(String md5, Long localeId) {
-        Map<String, TextUnitDTO> translationsForLocaleMap = getTextUnitDTOsForLocaleMapFromCache(localeId);
-        return translationsForLocaleMap.get(md5);
-    }
-
-    /**
-     * Gets the cached map of {@link TextUnitDTO}s keyed by MD5 that contains
-     * all current translations for a given locale.
-     *
-     * @param localeId the {@link Locale#id}
-     * @return the cached map
-     */
-    private Map<String, TextUnitDTO> getTextUnitDTOsForLocaleMapFromCache(Long localeId) {
-
-        logger.debug("Get TextUnitDTOs for a locale as a map from the cache");
-        Map<String, TextUnitDTO> translationsForLocaleMap = localeToTextUnitDTOsForLocaleMap.get(localeId);
-
-        if (translationsForLocaleMap == null) {
-            logger.debug("No map in cache, get the map and cache it");
-            translationsForLocaleMap = getTextUnitDTOsForLocaleByContentMD5(localeId);
-            localeToTextUnitDTOsForLocaleMap.put(localeId, translationsForLocaleMap);
-        }
-
-        return translationsForLocaleMap;
-    }
-
-    /**
-     * Gets the map of {@link TextUnitDTO}s keyed by MD5 that contains all
-     * current translations for a given locale.
-     *
-     * @param localeId the {@link Locale#id}
-     * @return the map of {@link TextUnitDTO}s keyed by MD5 that contains all
-     * current translations for a given locale
-     */
-    private Map<String, TextUnitDTO> getTextUnitDTOsForLocaleByContentMD5(Long localeId) {
-
-        Map<String, TextUnitDTO> res = new HashMap<>();
-
-        logger.debug("Prepare TextUnitSearcherParameters to fetch translation for locale: {}", localeId);
-        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
-        textUnitSearcherParameters.setLocaleId(localeId);
-        textUnitSearcherParameters.setAssetId(asset.getId());
-        textUnitSearcherParameters.setStatusFilter(StatusFilter.TRANSLATED_AND_NOT_REJECTED);
-
-        logger.debug("Getting TextUnitDTOs");
-        List<TextUnitDTO> textUnitDTOs = textUnitSearcher.search(textUnitSearcherParameters);
-
-        logger.debug("Transform TextUnitDTOs list into map keyed by MD5");
-        for (TextUnitDTO textUnitDTO : textUnitDTOs) {
-            String md5 = tmService.computeTMTextUnitMD5(textUnitDTO.getName(), textUnitDTO.getSource(), textUnitDTO.getComment());
-            res.put(md5, textUnitDTO);
-        }
-
-        return res;
-    }
-
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetSpecification.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetSpecification.java
@@ -61,4 +61,21 @@ public class AssetSpecification {
             }   
         };
     }
+    
+    /**
+     * A {@link Specification} that checks if {@link Asset} has virtualContent
+     * 
+     * @param virtual
+     * @return {@link Specification}
+     */
+    public static SingleParamSpecification<Asset> virtualEquals(final Boolean virtual) {
+        return new SingleParamSpecification<Asset>(virtual) {
+            @Override
+            public Predicate toPredicate(Root<Asset> root, 
+                                         CriteriaQuery<?> query, 
+                                         CriteriaBuilder builder) {
+                return builder.equal(root.get(Asset_.virtual), virtual);
+            }   
+        };
+    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/SourceAsset.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/SourceAsset.java
@@ -18,7 +18,6 @@ public class SourceAsset {
     private PollableTask pollableTask;
     private FilterConfigIdOverride filterConfigIdOverride;
 
-
     public Long getRepositoryId() {
         return repositoryId;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/VirtualAssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/VirtualAssetWS.java
@@ -1,0 +1,84 @@
+package com.box.l10n.mojito.rest.asset;
+
+import com.box.l10n.mojito.service.asset.VirtualAssetTextUnit;
+import com.box.l10n.mojito.okapi.InheritanceMode;
+import com.box.l10n.mojito.service.asset.VirtualAsset;
+import com.box.l10n.mojito.service.asset.VirtualAssetRequiredException;
+import com.box.l10n.mojito.service.asset.VirtualAssetService;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author jaurambault
+ */
+@RestController
+public class VirtualAssetWS {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(VirtualAssetWS.class);
+
+    @Autowired
+    VirtualAssetService virtualAssetService;
+
+    @RequestMapping(value = "/api/virtualAssets", method = RequestMethod.POST)
+    public VirtualAsset createOrUpdateVirtualAsset(@RequestBody VirtualAsset virtualAsset) throws VirtualAssetRequiredException {
+        return virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+    }
+
+    @RequestMapping(value = "/api/virtualAssets/{assetId}/textUnits", method = RequestMethod.POST)
+    public void addTextUnits(
+            @PathVariable("assetId") long assetId,
+            @RequestBody List<VirtualAssetTextUnit> virtualAssetTextUnits) throws VirtualAssetRequiredException {
+
+        virtualAssetService.addTextUnits(virtualAssetTextUnits, assetId);
+    }
+
+    @RequestMapping(value = "/api/virtualAssets/{assetId}/textUnits", method = RequestMethod.PUT)
+    public void replaceTextUnits(
+            @PathVariable("assetId") long assetId,
+            @RequestBody List<VirtualAssetTextUnit> virtualAssetTextUnits) throws VirtualAssetRequiredException {
+
+        virtualAssetService.replaceTextUnits(assetId, virtualAssetTextUnits);
+    }
+
+    @RequestMapping(value = "/api/virtualAssets/{assetId}/textUnits", method = RequestMethod.DELETE)
+    public void deleteTextUnit(
+            @PathVariable("assetId") long assetId,
+            @RequestBody VirtualAssetTextUnit virtualAssetTextUnit) {
+        virtualAssetService.deleteTextUnit(assetId, virtualAssetTextUnit.getName());
+    }
+
+    @RequestMapping(value = "/api/virtualAssets/{assetId}/locale/{localeId}/textUnits", method = RequestMethod.POST)
+    public void importLocalizedTextUnits(
+            @PathVariable("assetId") long assetId,
+            @PathVariable("localeId") long localeId,
+            @RequestBody List<VirtualAssetTextUnit> textUnitForVirtualAssets) throws VirtualAssetRequiredException {
+
+        virtualAssetService.importLocalizedTextUnits(assetId, localeId, textUnitForVirtualAssets);
+    }
+
+    @RequestMapping(value = "/api/virtualAssets/{assetId}/textUnits", method = RequestMethod.GET)
+    public List<VirtualAssetTextUnit> getTextUnits(@PathVariable("assetId") long assetId) throws VirtualAssetRequiredException {
+        return virtualAssetService.getTextUnits(assetId);
+    }
+    
+    @RequestMapping(value = "/api/virtualAssets/{assetId}/locale/{localeId}/textUnits", method = RequestMethod.GET)
+    public List<VirtualAssetTextUnit> getLocalizedTextUnits(
+            @PathVariable("assetId") long assetId,
+            @PathVariable(value = "localeId") long localeId,
+            @RequestParam(value = "inheritanceMode", defaultValue = "USE_PARENT") InheritanceMode inheritanceMode) throws VirtualAssetRequiredException {
+
+        return virtualAssetService.getLoalizedTextUnits(assetId, localeId, inheritanceMode);
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetService.java
@@ -5,7 +5,6 @@ import com.box.l10n.mojito.entity.AssetTextUnit;
 import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.rest.asset.FilterConfigIdOverride;
-import com.box.l10n.mojito.rest.asset.SourceAsset;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
 import com.box.l10n.mojito.service.pollableTask.InjectCurrentTask;
 import com.box.l10n.mojito.service.pollableTask.MsgArg;
@@ -61,16 +60,16 @@ public class AssetService {
      * contain the asset
      * @param assetContent Content of the asset
      * @param assetPath Remote path of the asset
-     * @param filterConfigIdOverride Optional, can be null. Allows to specify
-     * a specific Okapi filter to use to process the asset
+     * @param filterConfigIdOverride Optional, can be null. Allows to specify a
+     * specific Okapi filter to use to process the asset
      * @return The created asset
      * @throws ExecutionException
      * @throws InterruptedException
      */
     public PollableFuture<Asset> addOrUpdateAssetAndProcessIfNeeded(
-            Long repositoryId, 
-            String assetContent, 
-            String assetPath, 
+            Long repositoryId,
+            String assetContent,
+            String assetPath,
             FilterConfigIdOverride filterConfigIdOverride) throws ExecutionException, InterruptedException {
         return addOrUpdateAssetAndProcessIfNeeded(repositoryId, assetContent, assetPath, filterConfigIdOverride, PollableTask.INJECT_CURRENT_TASK);
     }
@@ -101,9 +100,13 @@ public class AssetService {
         // Check if the an asset with the same path already exists
         Asset asset = assetRepository.findByPathAndRepositoryId(assetPath, repositoryId);
 
+        if (asset != null && Boolean.TRUE.equals(asset.getVirtual())) {
+            throw new AssetUpdateException("Update on an Asset can't be performed on virtual asset");
+        }
+        
         // if an asset for the given path does not already exists or if its contents changed, start the extraction
         if (asset == null) {
-            asset = createAsset(repositoryId, assetContent, assetPath, currentTask);
+            asset = createAssetWithPollable(repositoryId, assetContent, assetPath, currentTask);
             assetExtractionService.processAsset(asset.getId(), filterConfigIdOverride, currentTask, PollableTask.INJECT_CURRENT_TASK);
         } else if (isAssetUpdateNeeded(asset, assetContent)) {
             updateAssetContent(asset, assetContent, currentTask);
@@ -134,7 +137,7 @@ public class AssetService {
     public Asset createAsset(Long repositoryId, String assetContent, String assetPath) throws AssetCreationException {
 
         try {
-            return createAsset(repositoryId, assetContent, assetPath, null);
+            return createAssetWithPollable(repositoryId, assetContent, assetPath, null);
         } catch (Exception e) {
             throw new AssetCreationException(e.getMessage(), e.getCause());
         }
@@ -152,12 +155,27 @@ public class AssetService {
      */
     @Pollable(message = "Creating asset: {assetPath}")
     @Transactional
-    private Asset createAsset(Long repositoryId, String assetContent, @MsgArg(name = "assetPath") String assetPath, @ParentTask PollableTask parentTask) {
+    private Asset createAssetWithPollable(
+            Long repositoryId,
+            String assetContent,
+            @MsgArg(name = "assetPath") String assetPath,
+            @ParentTask PollableTask parentTask) {
+
+        return createAsset(repositoryId, assetContent, Boolean.FALSE, assetPath);
+    }
+
+    public Asset createAsset(
+            Long repositoryId,
+            String assetContent,
+            boolean virtualContent,
+            String assetPath) {
+
         Asset asset = new Asset();
 
         asset.setRepository(repositoryRepository.getOne(repositoryId));
         asset.setContent(assetContent);
         asset.setContentMd5(DigestUtils.md5Hex(assetContent));
+        asset.setVirtual(virtualContent);
         asset.setPath(assetPath);
 
         assetRepository.save(asset);
@@ -214,10 +232,10 @@ public class AssetService {
         asset.setDeleted(false);
         assetRepository.save(asset);
     }
-    
+
     /**
-     * 
-     * @param asset 
+     *
+     * @param asset
      */
     @Transactional
     private void undeleteAssetIfDeleted(Asset asset) {
@@ -226,32 +244,33 @@ public class AssetService {
             assetRepository.save(asset);
         }
     }
-    
+
     /**
-     * Deletes an {@link Asset} by the {@link Asset#id}. It performs logical delete.
+     * Deletes an {@link Asset} by the {@link Asset#id}. It performs logical
+     * delete.
      *
      * @param asset
      */
     @Transactional
     public void deleteAsset(Asset asset) {
-        
+
         logger.debug("Delete an asset with path: {}", asset.getPath());
 
         asset.setDeleted(true);
         assetRepository.save(asset);
-        
+
         logger.debug("Deleted asset with path: {}", asset.getPath());
 
     }
 
     /**
      * Deletes multiple {@link Asset} by the list of {@link Asset#id}
-     * 
-     * @param assetIds 
+     *
+     * @param assetIds
      */
     @Transactional
     public void deleteAssets(Set<Long> assetIds) {
-        
+
         logger.debug("Delete assets {}", assetIds.toString());
 
         for (Long assetId : assetIds) {
@@ -260,9 +279,9 @@ public class AssetService {
                 deleteAsset(asset);
             }
         }
-        
+
         logger.debug("Deleted assets {}", assetIds.toString());
-        
+
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetUpdateException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetUpdateException.java
@@ -1,0 +1,17 @@
+package com.box.l10n.mojito.service.asset;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class AssetUpdateException extends RuntimeException {
+
+    public AssetUpdateException(String message) {
+        super(message);
+    }
+    
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAsset.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAsset.java
@@ -1,0 +1,46 @@
+package com.box.l10n.mojito.service.asset;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+public class VirtualAsset {
+
+    Long id;
+    Long repositoryId;
+    String path;
+    Boolean deleted;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(Long repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(Boolean deleted) {
+        this.deleted = deleted;
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetRequiredException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetRequiredException.java
@@ -1,0 +1,16 @@
+package com.box.l10n.mojito.service.asset;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class VirtualAssetRequiredException extends Exception {    
+
+    public VirtualAssetRequiredException(String message) {
+        super(message);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
@@ -1,0 +1,361 @@
+package com.box.l10n.mojito.service.asset;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.AssetExtraction;
+import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.AssetTextUnitToTMTextUnit;
+import com.box.l10n.mojito.entity.PluralForm;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.entity.TMTextUnit;
+import com.box.l10n.mojito.entity.TMTextUnitVariant;
+import com.box.l10n.mojito.okapi.InheritanceMode;
+import com.box.l10n.mojito.service.NormalizationUtils;
+import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
+import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
+import com.box.l10n.mojito.service.assetExtraction.AssetTextUnitToTMTextUnitRepository;
+import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
+import com.box.l10n.mojito.service.leveraging.LeveragerByContentForSourceLeveraging;
+import com.box.l10n.mojito.service.leveraging.LeveragerByTmTextUnit;
+import com.box.l10n.mojito.service.pluralform.PluralFormService;
+import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
+import com.box.l10n.mojito.service.repository.RepositoryRepository;
+import com.box.l10n.mojito.service.tm.TMService;
+import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
+import com.box.l10n.mojito.service.tm.TranslatorWithInheritance;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
+import com.google.common.base.Strings;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import static org.slf4j.LoggerFactory.getLogger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service to manage virtual assets.
+ *
+ * @author jaurambault
+ */
+@Service
+public class VirtualAssetService {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(VirtualAssetService.class);
+
+    @Autowired
+    AssetRepository assetRepository;
+
+    @Autowired
+    AssetExtractionService assetExtractionService;
+
+    @Autowired
+    AssetTextUnitToTMTextUnitRepository assetTextUnitToTMTextUnitRepository;
+
+    @Autowired
+    AssetExtractionRepository assetExtractionRepository;
+
+    @Autowired
+    LeveragerByContentForSourceLeveraging leveragerByContentForSourceLeveraging;
+
+    @Autowired
+    TMTextUnitRepository tmTextUnitRepository;
+
+    @Autowired
+    TMService tmService;
+
+    @Autowired
+    RepositoryRepository repositoryRepository;
+
+    @Autowired
+    AssetTextUnitRepository assetTextUnitRepository;
+
+    @Autowired
+    TextUnitSearcher textUnitSearcher;
+
+    @Autowired
+    RepositoryLocaleRepository repositoryLocaleRepository;
+
+    @Autowired
+    PluralFormService pluralFormService;
+
+    @Transactional
+    public VirtualAsset createOrUpdateVirtualAsset(VirtualAsset virtualAsset) throws VirtualAssetRequiredException {
+
+        logger.debug("Create or update virtual asset with path: {}", virtualAsset.getPath());
+        Asset asset = assetRepository.findByPathAndRepositoryId(virtualAsset.getPath(), virtualAsset.getRepositoryId());
+
+        if (asset != null && !asset.getVirtual()) {
+            throw new VirtualAssetRequiredException("Standard asset can't be modify");
+        } else if (asset != null) {
+            logger.debug("Virtual asset exists, update it");
+            asset.setDeleted(virtualAsset.getDeleted());
+            asset = assetRepository.save(asset);
+        } else {
+            logger.debug("No existing virtual asset, create one");
+            asset = new Asset();
+            asset.setRepository(repositoryRepository.getOne(virtualAsset.getRepositoryId()));
+            asset.setPath(virtualAsset.getPath());
+            asset.setContent("");
+            asset.setContentMd5(asset.getContent());
+            asset.setVirtual(Boolean.TRUE);
+
+            logger.debug("Create a default AssetExtraction for virtual asset");
+            AssetExtraction createAssetExtraction = assetExtractionService.createAssetExtraction(asset, null);
+            asset.setLastSuccessfulAssetExtraction(createAssetExtraction);
+
+            asset = assetRepository.save(asset);
+        }
+
+        virtualAsset.setId(asset.getId());
+        return virtualAsset;
+    }
+
+    @Transactional
+    public List<VirtualAssetTextUnit> getTextUnits(long assetId) throws VirtualAssetRequiredException {
+
+        logger.debug("Get textunit for virtual asset: {}", assetId);
+
+        List<VirtualAssetTextUnit> virtualAssetTextUnits = new ArrayList<>();
+
+        Asset asset =  getVirtualAsset(assetId);
+        Long lastSuccessfulAssetExtractionId = asset.getLastSuccessfulAssetExtraction().getId();
+        List<AssetTextUnit> findByAssetExtractionAssetId = assetTextUnitRepository.findByAssetExtractionIdOrderByNameAsc(lastSuccessfulAssetExtractionId);
+
+        for (AssetTextUnit assetTextUnit : findByAssetExtractionAssetId) {
+            VirtualAssetTextUnit textUnitForVirtualAsset = convertAssetTextUnitToVirtualAssetTextUnit(assetTextUnit);
+            virtualAssetTextUnits.add(textUnitForVirtualAsset);
+        }
+
+        return virtualAssetTextUnits;
+    }
+
+    @Transactional
+    public List<VirtualAssetTextUnit> getLoalizedTextUnits(
+            long assetId,
+            long localeId,
+            InheritanceMode inheritanceMode) throws VirtualAssetRequiredException {
+
+        logger.debug("Get localized virtual asset: {} for locale: {}", assetId, localeId);
+
+        List<VirtualAssetTextUnit> virtualAssetTextUnits = new ArrayList<>();
+
+        Asset asset = getVirtualAsset(assetId);
+        Long lastSuccessfulAssetExtractionId = asset.getLastSuccessfulAssetExtraction().getId();
+        List<AssetTextUnit> findByAssetExtractionAssetId = assetTextUnitRepository.findByAssetExtractionIdOrderByNameAsc(lastSuccessfulAssetExtractionId);
+
+        RepositoryLocale repositoryLocale = repositoryLocaleRepository.findByRepositoryIdAndLocaleId(asset.getRepository().getId(), localeId);
+
+        TranslatorWithInheritance translatorWithInheritance = new TranslatorWithInheritance(asset, repositoryLocale, InheritanceMode.USE_PARENT);
+
+        for (AssetTextUnit assetTextUnit : findByAssetExtractionAssetId) {
+
+            //fc765f49ba95dc2871caa83e7a8aab5a
+            String translation = translatorWithInheritance.getTranslation(
+                    assetTextUnit.getName(),
+                    assetTextUnit.getContent(),
+                    assetTextUnit.getMd5(),
+                    repositoryLocale,
+                    inheritanceMode
+            );
+
+            if (translation == null && InheritanceMode.REMOVE_UNTRANSLATED.equals(inheritanceMode)) {
+                logger.debug("Remove untranslated text unit");
+            } else {
+                logger.debug("Set translation for text unit with name: {}, translation: {}", assetTextUnit.getName(), translation);
+
+                VirtualAssetTextUnit virtualAssetTextUnit = convertAssetTextUnitToVirtualAssetTextUnit(assetTextUnit);
+                virtualAssetTextUnit.setContent(translation);
+                if (assetTextUnit.getPluralForm() != null) {
+                    virtualAssetTextUnit.setPluralForm(assetTextUnit.getPluralForm().getName());
+                }
+                virtualAssetTextUnit.setPluralFormOther(assetTextUnit.getPluralFormOther());
+                virtualAssetTextUnits.add(virtualAssetTextUnit);
+            }
+        }
+
+        return virtualAssetTextUnits;
+    }
+
+    @Transactional
+    public void addTextUnits(List<VirtualAssetTextUnit> virtualAssetTextUnits, long assetId) throws VirtualAssetRequiredException {
+
+        logger.debug("Add text units ({}) to virtual assetId: {}", virtualAssetTextUnits.size(), assetId);
+
+        for (VirtualAssetTextUnit virtualAssetTextUnit : virtualAssetTextUnits) {
+            normalizeVirtualAssetTextUnit(virtualAssetTextUnit);
+            PluralForm pluralForm = pluralFormService.findByPluralFormString(virtualAssetTextUnit.getPluralForm());
+
+            addTextUnit(
+                    assetId,
+                    virtualAssetTextUnit.getName(),
+                    virtualAssetTextUnit.getContent(),
+                    virtualAssetTextUnit.getComment(),
+                    pluralForm,
+                    virtualAssetTextUnit.getPluralFormOther());
+        }
+    }
+
+    @Transactional
+    public void replaceTextUnits(long assetId, List<VirtualAssetTextUnit> virtualAssetTextUnits) throws VirtualAssetRequiredException {
+
+        logger.debug("Replace text units (new: {}) in virtual assetId: {}", virtualAssetTextUnits.size(), assetId);
+        Asset asset = assetRepository.findOne(assetId);
+
+        logger.debug("Create a new AssetExtraction for virtual asset");
+        AssetExtraction createAssetExtraction = assetExtractionService.createAssetExtraction(asset, null);
+        asset.setLastSuccessfulAssetExtraction(createAssetExtraction);
+        assetRepository.save(asset);
+
+        addTextUnits(virtualAssetTextUnits, assetId);
+    }
+
+    @Transactional
+    public void importLocalizedTextUnits(
+            long assetId,
+            long localeId,
+            List<VirtualAssetTextUnit> textUnitForVirtualAssets) throws VirtualAssetRequiredException {
+
+        logger.debug("Add text unit variants ({}) to virtual assetId: {}", textUnitForVirtualAssets.size(), assetId);
+
+        for (VirtualAssetTextUnit textUnitForVirtualAsset : textUnitForVirtualAssets) {
+            normalizeVirtualAssetTextUnit(textUnitForVirtualAsset);
+            addTextUnitVariant(
+                    assetId,
+                    localeId,
+                    textUnitForVirtualAsset.getName(),
+                    textUnitForVirtualAsset.getContent(),
+                    textUnitForVirtualAsset.getComment());
+        }
+    }
+
+    @Transactional
+    public void deleteTextUnit(Long assetId, String name) {
+
+        logger.debug("Try deleting text unit with name: {} from asset id: {}", name, assetId);
+
+        Asset asset = assetRepository.findOne(assetId);
+        Long assetExtractionId = asset.getLastSuccessfulAssetExtraction().getId();
+        AssetTextUnit assetTextUnit = assetTextUnitRepository.findByAssetExtractionIdAndName(assetExtractionId, name);
+
+        if (assetTextUnit != null) {
+            logger.debug("Asset text unit found, perform delete");
+            assetTextUnitToTMTextUnitRepository.deleteByAssetTextUnitId(assetTextUnit.getId());
+            assetTextUnitRepository.delete(assetTextUnit);
+        } else {
+            logger.debug("No asset text unit found for name: {} and asset id: {}. Skip delete", name, assetId);
+        }
+    }
+
+    void addTextUnit(
+            long assetId,
+            String name,
+            String content,
+            String comment,
+            PluralForm pluralForm,
+            String pluralFormOther) throws VirtualAssetRequiredException {
+
+        logger.debug("Add text unit to virtual assetId: {}, with name: {}", assetId, name);
+        Asset asset = getVirtualAsset(assetId);
+
+        Long assetExtractionId = asset.getLastSuccessfulAssetExtraction().getId();
+        AssetTextUnit assetTextUnit = assetTextUnitRepository.findByAssetExtractionIdAndName(assetExtractionId, name);
+        String newTMTextUnitMD5 = tmService.computeTMTextUnitMD5(name, content, comment);
+
+        if (assetTextUnit != null && newTMTextUnitMD5.equals(assetTextUnit.getMd5())) {
+            logger.debug("Asset text unit unchanged, do nothing");
+        } else {
+
+            if (assetTextUnit != null) {
+                logger.debug("Asset text unit has changed, remove all previous entries");
+                assetTextUnitToTMTextUnitRepository.deleteByAssetTextUnitId(assetTextUnit.getId());
+                assetTextUnitRepository.delete(assetTextUnit);
+            }
+
+            AssetTextUnit previousAssetTextUnit = assetTextUnit;
+
+            logger.debug("Create asset text unit for name: {}, in asset id: {}", name, assetId);
+            assetTextUnit = assetExtractionService.createAssetTextUnit(
+                    asset.getLastSuccessfulAssetExtraction().getId(),
+                    name,
+                    content,
+                    comment,
+                    pluralForm,
+                    pluralFormOther);
+
+            logger.debug("Look for an existing TmTextunit");
+            TMTextUnit tmTextUnit = tmTextUnitRepository.findFirstByAssetAndMd5(asset, assetTextUnit.getMd5());
+
+            if (tmTextUnit == null) {
+                logger.debug("Create TmTextUnit");
+                tmTextUnit = tmService.addTMTextUnit(
+                        asset.getRepository().getTm().getId(),
+                        asset.getId(),
+                        name,
+                        content,
+                        comment,
+                        null,
+                        pluralForm,
+                        pluralFormOther);
+
+                logger.debug("Perform leveraging");
+                List<TMTextUnit> tmTextUnits = new ArrayList<>();
+                tmTextUnits.add(tmTextUnit);
+
+                if (previousAssetTextUnit != null) {
+                    new LeveragerByTmTextUnit(previousAssetTextUnit.getId()).performLeveragingFor(tmTextUnits, null);
+                }
+
+                leveragerByContentForSourceLeveraging.performLeveragingFor(tmTextUnits, null);
+            }
+
+            logger.debug("Map asset text unit to textunit");
+            AssetTextUnitToTMTextUnit assetTextUnitToTMTextUnit = new AssetTextUnitToTMTextUnit();
+            assetTextUnitToTMTextUnit.setAssetExtraction(assetExtractionRepository.getOne(assetExtractionId));
+            assetTextUnitToTMTextUnit.setAssetTextUnit(assetTextUnit);
+            assetTextUnitToTMTextUnit.setTmTextUnit(tmTextUnit);
+            assetTextUnitToTMTextUnitRepository.save(assetTextUnitToTMTextUnit);
+
+        }
+    }
+
+    TMTextUnitVariant addTextUnitVariant(long assetId, long localeId, String name, String content, String comment) throws VirtualAssetRequiredException {
+        logger.debug("Add text unit variant to virtual assetId: {}, with name: {}", assetId, name);
+        TMTextUnit findFirstByAssetAndName = tmTextUnitRepository.findFirstByAssetAndName(assetRepository.getOne(assetId), name);
+        return tmService.addCurrentTMTextUnitVariant(findFirstByAssetAndName.getId(), localeId, content);
+    }
+
+    VirtualAssetTextUnit convertAssetTextUnitToVirtualAssetTextUnit(AssetTextUnit assetTextUnit) {
+
+        VirtualAssetTextUnit virtualAssetTextUnit = new VirtualAssetTextUnit();
+
+        virtualAssetTextUnit.setName(assetTextUnit.getName());
+        virtualAssetTextUnit.setContent(assetTextUnit.getContent());
+        virtualAssetTextUnit.setComment(assetTextUnit.getComment());
+        if (assetTextUnit.getPluralForm() != null) {
+            virtualAssetTextUnit.setPluralForm(assetTextUnit.getPluralForm().getName());
+        }
+        virtualAssetTextUnit.setPluralFormOther(assetTextUnit.getPluralFormOther());
+
+        return virtualAssetTextUnit;
+    }
+
+    void normalizeVirtualAssetTextUnit(VirtualAssetTextUnit virtualAssetTextUnit) {
+        virtualAssetTextUnit.setName(NormalizationUtils.normalize(virtualAssetTextUnit.getName()));
+        virtualAssetTextUnit.setContent(NormalizationUtils.normalize(Strings.nullToEmpty(virtualAssetTextUnit.getContent())));
+        virtualAssetTextUnit.setComment(NormalizationUtils.normalize(virtualAssetTextUnit.getComment()));
+    }
+
+    Asset getVirtualAsset(long assetId) throws VirtualAssetRequiredException {
+        Asset asset = assetRepository.findOne(assetId);
+
+        if (asset == null || asset.getVirtual() == null || !asset.getVirtual()) {
+            throw new VirtualAssetRequiredException("Operation requires a Virtual asset");
+        }
+
+        return asset;
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetTextUnit.java
@@ -1,0 +1,55 @@
+package com.box.l10n.mojito.service.asset;
+
+/**
+ * @author jaurambault
+ */
+public class VirtualAssetTextUnit {
+
+    String name;
+    String content;
+    String comment;
+
+    String pluralForm;
+    String pluralFormOther;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public String getPluralForm() {
+        return pluralForm;
+    }
+
+    public void setPluralForm(String pluralForm) {
+        this.pluralForm = pluralForm;
+    }
+
+    public String getPluralFormOther() {
+        return pluralFormOther;
+    }
+
+    public void setPluralFormOther(String pluralFormOther) {
+        this.pluralFormOther = pluralFormOther;
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetTextUnitToTMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetTextUnitToTMTextUnitRepository.java
@@ -12,4 +12,6 @@ public interface AssetTextUnitToTMTextUnitRepository extends JpaRepository<Asset
 
     void deleteByAssetExtractionId(Long assetExtractionId);
 
+    public void deleteByAssetTextUnitId(Long assetTextUnitId);
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
@@ -37,4 +37,8 @@ public interface AssetTextUnitRepository extends JpaRepository<AssetTextUnit, Lo
     List<AssetTextUnit> getUnmappedAssetTextUnits(Long assetExtractionId);
 
     void deleteByAssetExtractionId(Long assetExtractionId);
+
+    public AssetTextUnit findByAssetExtractionIdAndName(Long assetExtractionId, String name);
+
+    public List<AssetTextUnit> findByAssetExtractionIdOrderByNameAsc(Long assetExtractionId);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/leveraging/LeveragerByTmTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/leveraging/LeveragerByTmTextUnit.java
@@ -7,27 +7,33 @@ import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Configurable;
 
 /**
- *
+ * Performs leveraging based using the provided TmTextUnit id
+ * 
  * @author jaurambault
  */
-@Component
-public class LeveragerByMd5 extends AbstractLeverager {
+@Configurable
+public class LeveragerByTmTextUnit extends AbstractLeverager {
 
     /**
      * logger
      */
-    static Logger logger = LoggerFactory.getLogger(LeveragerByMd5.class);
+    static Logger logger = LoggerFactory.getLogger(LeveragerByTmTextUnit.class);
+    
+    Long tmTextUnitId;
 
+    public LeveragerByTmTextUnit(Long tmTextUnitId) {
+        this.tmTextUnitId = tmTextUnitId;
+    }
+    
     @Override
     public List<TextUnitDTO> getLeveragingMatches(TMTextUnit tmTextUnit, Long sourceTmId) {
-        logger.debug("Get TextUnitDTOs for leveraging by MD5");
+        logger.debug("Get TextUnitDTOs for leveraging with TmTextUnit");
 
         TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
-        textUnitSearcherParameters.setMd5(tmTextUnit.getMd5());
-        textUnitSearcherParameters.setTmId(sourceTmId);
+        textUnitSearcherParameters.setTmTextUnitId(tmTextUnitId);
         textUnitSearcherParameters.setStatusFilter(StatusFilter.TRANSLATED);
 
         return textUnitSearcher.search(textUnitSearcherParameters);
@@ -35,12 +41,12 @@ public class LeveragerByMd5 extends AbstractLeverager {
 
     @Override
     public boolean isTranslationNeededIfUniqueMatch() {
-        return false;
+        return true;
     }
 
     @Override
     public String getType() {
-        return "Leverage by source Md5";
+        return "Leverage with TmTextUnit";
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pluralform/PluralFormForLocaleRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pluralform/PluralFormForLocaleRepository.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.service.pluralform;
  
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.PluralForm;
 import com.box.l10n.mojito.entity.PluralFormForLocale;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -10,4 +12,6 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
  */
 @RepositoryRestResource(exported = false)
 public interface PluralFormForLocaleRepository extends JpaRepository<PluralFormForLocale, Long>, JpaSpecificationExecutor<PluralFormForLocale> {
+    
+    PluralFormForLocale findByLocaleAndPluralForm(Locale locale, PluralForm pluralForm);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pluralform/PluralFormForLocaleService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pluralform/PluralFormForLocaleService.java
@@ -36,6 +36,7 @@ public class PluralFormForLocaleService {
         List<Locale> locales = localeRepository.findAll();
         
         for (Locale locale : locales) {
+            
             ULocale forLanguageTag = ULocale.forLanguageTag(locale.getBcp47Tag());
             
             PluralRules pluralRules = PluralRules.forLocale(forLanguageTag);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pluralform/PluralFormService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pluralform/PluralFormService.java
@@ -50,11 +50,18 @@ public class PluralFormService {
     /**
      * Returns the PluralForm for the given plural form string.
      *
-     * @param pluralForm the plural form string
+     * @param pluralFormString the plural form string
      * @return The corresponding plural form or {@code null} if none found
      */
-    public PluralForm findByPluralFormString(String pluralForm) {
-        return getPluralFormMap().get(pluralForm);
+    public PluralForm findByPluralFormString(String pluralFormString) {
+        
+        PluralForm pluralForm = null;
+        
+        if (pluralFormString != null) {
+            pluralForm = getPluralFormMap().get(pluralFormString.toLowerCase());
+        }
+        
+        return pluralForm;
     }
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TranslatorWithInheritance.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TranslatorWithInheritance.java
@@ -1,0 +1,209 @@
+package com.box.l10n.mojito.service.tm;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.okapi.InheritanceMode;
+import com.box.l10n.mojito.okapi.TranslateStep;
+import com.box.l10n.mojito.service.locale.LocaleService;
+import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
+import com.box.l10n.mojito.service.tm.search.StatusFilter;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+
+/**
+ * @author jeanaurambault
+ */
+@Configurable
+public class TranslatorWithInheritance {
+
+    static Logger logger = LoggerFactory.getLogger(TranslatorWithInheritance.class);
+
+    @Autowired
+    TMTextUnitRepository tmTextUnitRepository;
+
+    @Autowired
+    TMTextUnitCurrentVariantRepository tmTextUnitCurrentVariantRepository;
+
+    @Autowired
+    LocaleService localeService;
+
+    @Autowired
+    RepositoryLocaleRepository repositoryLocaleRepository;
+
+    @Autowired
+    TextUnitSearcher textUnitSearcher;
+
+    @Autowired
+    TMService tmService;
+
+    Asset asset;
+
+    InheritanceMode inheritanceMode;
+
+    RepositoryLocale repositoryLocale;
+
+    /**
+     * Cache that contains the translations required to translate the asset.
+     */
+    Map<Long, Map<String, TextUnitDTO>> localeToTextUnitDTOsForLocaleMap = new HashMap<>();
+
+    /**
+     * Creates the {@link TranslateStep} for a given asset.
+     *
+     * @param asset {@link Asset} that will be used to lookup translations
+     * @param repositoryLocale used to fetch translations. It can be different
+     * from the locale used in the Okapi pipeline ({@link #targetLocale}) in
+     * case the file needs to be generated for a tag that is different from the
+     * locale used for translation.
+     * @param inheritanceMode
+     */
+    public TranslatorWithInheritance(Asset asset, RepositoryLocale repositoryLocale, InheritanceMode inheritanceMode) {
+        this.asset = asset;
+        this.inheritanceMode = inheritanceMode;
+        this.repositoryLocale = repositoryLocale;
+    }
+
+    
+    public String getTranslation(
+            String name,
+            String source,
+            String md5,
+            RepositoryLocale repositoryLocale,
+            InheritanceMode inheritanceMode) {
+
+        String translation = null;
+
+        logger.debug("Look for a translation in target locale: {} for text unit with name: {}", repositoryLocale.getLocale().getBcp47Tag(), name);
+        TextUnitDTO textUnitDTO = getTextUnitDTO(md5, repositoryLocale.getLocale().getId());
+
+        if (textUnitDTO != null) {
+            logger.debug("Found translation for target locale");
+            translation = textUnitDTO.getTarget();
+        } else if (InheritanceMode.USE_PARENT.equals(inheritanceMode)) {
+            logger.debug("No translation found for target locale, look for translations in parent locales");
+            translation = getTranslationWithInheritance(md5, source);
+        }
+
+        return translation;
+    }
+
+    /**
+     * Look for a translation in parent locale excluding the root locale for a
+     * given MD5, if none is found it returns the source.
+     *
+     * <p>
+     * The root locale (repository locale with parent locale null) is excluded
+     * for optimization purpose, the translations fetched would be the same as
+     * the source, hence returning the source directly is more efficient.
+     *
+     * @param md5 MD5 to lookup the translation
+     * @param source the source to fallback to if there is no translation
+     * @return the translation from a parent locale or the source if no
+     * translation is found.
+     */
+    private String getTranslationWithInheritance(String md5, String source) {
+
+        String translation = null;
+
+        logger.debug("Get Translation with inheritance");
+        RepositoryLocale repositoryLocaleForFind = repositoryLocale.getParentLocale();
+
+        while (translation == null && repositoryLocaleForFind != null && repositoryLocaleForFind.getParentLocale() != null) {
+
+            logger.debug("Looking for a translation in locale: {}", repositoryLocaleForFind.getLocale().getBcp47Tag());
+            TextUnitDTO textUnitDTO = getTextUnitDTO(md5, repositoryLocaleForFind.getLocale().getId());
+
+            if (textUnitDTO != null) {
+                logger.debug("Found a translation using inheritance in locale: {}", repositoryLocaleForFind.getLocale().getBcp47Tag());
+                translation = textUnitDTO.getTarget();
+            } else {
+                logger.debug("No inherited translation in locale: {}", repositoryLocaleForFind.getLocale().getBcp47Tag());
+            }
+
+            repositoryLocaleForFind = repositoryLocaleForFind.getParentLocale();
+        }
+
+        if (translation == null) {
+            logger.debug("No translation using inheritance, fallback to source");
+            translation = source;
+        }
+
+        return translation;
+    }
+
+    /**
+     * Gets a {@link TextUnitDTO} from the cache for a given locale and text
+     * unit MD5.
+     *
+     * @param md5 the MD5 of the text unit (see
+     * {@link TMService#computeTMTextUnitMD5(java.lang.String, java.lang.String, java.lang.String)})
+     * @param localeId the {@link Locale#id}
+     * @return a {@link TextUnitDTO} or {@code null} if no translation is
+     * available
+     */
+    private TextUnitDTO getTextUnitDTO(String md5, Long localeId) {
+        Map<String, TextUnitDTO> translationsForLocaleMap = getTextUnitDTOsForLocaleMapFromCache(localeId);
+        return translationsForLocaleMap.get(md5);
+    }
+
+    /**
+     * Gets the cached map of {@link TextUnitDTO}s keyed by MD5 that contains
+     * all current translations for a given locale.
+     *
+     * @param localeId the {@link Locale#id}
+     * @return the cached map
+     */
+    private Map<String, TextUnitDTO> getTextUnitDTOsForLocaleMapFromCache(Long localeId) {
+
+        logger.debug("Get TextUnitDTOs for a locale as a map from the cache");
+        Map<String, TextUnitDTO> translationsForLocaleMap = localeToTextUnitDTOsForLocaleMap.get(localeId);
+
+        if (translationsForLocaleMap == null) {
+            logger.debug("No map in cache, get the map and cache it");
+            translationsForLocaleMap = getTextUnitDTOsForLocaleByContentMD5(localeId);
+            localeToTextUnitDTOsForLocaleMap.put(localeId, translationsForLocaleMap);
+        }
+
+        return translationsForLocaleMap;
+    }
+
+    /**
+     * Gets the map of {@link TextUnitDTO}s keyed by MD5 that contains all
+     * current translations for a given locale.
+     *
+     * @param localeId the {@link Locale#id}
+     * @return the map of {@link TextUnitDTO}s keyed by MD5 that contains all
+     * current translations for a given locale
+     */
+    private Map<String, TextUnitDTO> getTextUnitDTOsForLocaleByContentMD5(Long localeId) {
+
+        Map<String, TextUnitDTO> res = new HashMap<>();
+
+        logger.debug("Prepare TextUnitSearcherParameters to fetch translation for locale: {}", localeId);
+        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+        textUnitSearcherParameters.setLocaleId(localeId);
+        textUnitSearcherParameters.setAssetId(asset.getId());
+        textUnitSearcherParameters.setStatusFilter(StatusFilter.TRANSLATED_AND_NOT_REJECTED);
+
+        logger.debug("Getting TextUnitDTOs");
+        List<TextUnitDTO> textUnitDTOs = textUnitSearcher.search(textUnitSearcherParameters);
+
+        logger.debug("Transform TextUnitDTOs list (size={}) into map keyed by MD5", textUnitDTOs.size());
+        for (TextUnitDTO textUnitDTO : textUnitDTOs) {
+            String md5 = tmService.computeTMTextUnitMD5(textUnitDTO.getName(), textUnitDTO.getSource(), textUnitDTO.getComment());
+            res.put(md5, textUnitDTO);
+        }
+
+        return res;
+    }
+
+}

--- a/webapp/src/main/resources/db/migration/V18__Virtual_asset.sql
+++ b/webapp/src/main/resources/db/migration/V18__Virtual_asset.sql
@@ -1,0 +1,1 @@
+alter table asset add column `virtual` bit not null;

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/WSTestDataFactory.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/WSTestDataFactory.java
@@ -6,6 +6,7 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.factory.XliffDataFactory;
 import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.asset.AssetUpdateException;
 import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.pollableTask.PollableTaskException;
@@ -85,7 +86,7 @@ public class WSTestDataFactory {
      * @param testIdWatcher
      * @return The {@link Repository}
      */
-    public Repository createRepoAndAssetAndTextUnits(TestIdWatcher testIdWatcher) throws RepositoryNameAlreadyUsedException {
+    public Repository createRepoAndAssetAndTextUnits(TestIdWatcher testIdWatcher) throws RepositoryNameAlreadyUsedException, AssetUpdateException {
         Repository repository = createRepository(testIdWatcher);
 
         try {

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/asset/AssetWSTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/asset/AssetWSTest.java
@@ -158,12 +158,12 @@ public class AssetWSTest extends WSTestBase {
         assertTrue(assets.get(0).getPath().equals(path2) || assets.get(0).getPath().equals(path3));
         assertTrue(assets.get(1).getPath().equals(path2) || assets.get(1).getPath().equals(path3));
         
-        List<Long> assetIds = assetClient.getAssetIds(repository.getId(), null);
+        List<Long> assetIds = assetClient.getAssetIds(repository.getId(), null, null);
         assertEquals("There should be three asset ids for this repository", 3, assetIds.size());
-        assetIds = assetClient.getAssetIds(repository.getId(), false);
+        assetIds = assetClient.getAssetIds(repository.getId(), false, null);
         assertEquals("There should be one undeleted asset id for this repository", 1, assetIds.size());
         assertEquals(sourceAssetAfterPost1.getAddedAssetId(), assetIds.iterator().next());
-        assetIds = assetClient.getAssetIds(repository.getId(), true);
+        assetIds = assetClient.getAssetIds(repository.getId(), true, null);
         assertEquals("There should be two deleted asset ids for this repository", 2, assetIds.size());
         assertTrue(assetIds.iterator().next().equals(sourceAssetAfterPost2.getAddedAssetId()) || assetIds.iterator().next().equals(sourceAssetAfterPost3.getAddedAssetId()));  
         assertTrue(assetIds.iterator().next().equals(sourceAssetAfterPost2.getAddedAssetId()) || assetIds.iterator().next().equals(sourceAssetAfterPost3.getAddedAssetId()));  

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/asset/VirtualAssetWSTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/asset/VirtualAssetWSTest.java
@@ -1,0 +1,10 @@
+package com.box.l10n.mojito.rest.asset;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+public class VirtualAssetWSTest {
+    
+    
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/asset/AssetServiceConcurrentTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/asset/AssetServiceConcurrentTest.java
@@ -66,7 +66,7 @@ public class AssetServiceConcurrentTest extends ServiceTestBase {
      * @throws InterruptedException
      */
     @Test
-    public void testConcurrencyForAssetExtraction() throws ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException {
+    public void testConcurrencyForAssetExtraction() throws ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException, AssetUpdateException {
         logger.debug("Testing for concurrency when processing same asset with same/updated contents in parallel");
 
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
@@ -118,7 +118,7 @@ public class AssetServiceConcurrentTest extends ServiceTestBase {
      * @throws InterruptedException 
      */
     @Test
-    public void testConcurrentMultipleAssetExtractions() throws ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException {
+    public void testConcurrentMultipleAssetExtractions() throws ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException, AssetUpdateException {
         logger.debug("Testing for concurrency when processing 10 different assets in parallel");
 
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
@@ -168,7 +168,7 @@ public class AssetServiceConcurrentTest extends ServiceTestBase {
      * @throws InterruptedException 
      */
     @Test
-    public void testConcurrentAssetExtractions() throws ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException {
+    public void testConcurrentAssetExtractions() throws ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException, AssetUpdateException {
         logger.debug("Testing for concurrency when processing single new asset in parallel");
 
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));

--- a/webapp/src/test/java/com/box/l10n/mojito/service/asset/VirtualAssetServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/asset/VirtualAssetServiceTest.java
@@ -1,0 +1,386 @@
+package com.box.l10n.mojito.service.asset;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.entity.TMTextUnitVariant;
+import com.box.l10n.mojito.okapi.InheritanceMode;
+import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import com.box.l10n.mojito.service.pluralform.PluralFormService;
+import com.box.l10n.mojito.service.repository.RepositoryService;
+import com.box.l10n.mojito.test.TestIdWatcher;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import static org.slf4j.LoggerFactory.getLogger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ *
+ * @author jeanaurambault
+ */
+public class VirtualAssetServiceTest extends ServiceTestBase {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(VirtualAssetServiceTest.class);
+
+    @Autowired
+    VirtualAssetService virtualAssetService;
+
+    @Autowired
+    AssetRepository assetRepository;
+
+    @Autowired
+    RepositoryService repositoryService;
+
+    @Autowired
+    AssetService assetService;
+
+    @Autowired
+    PluralFormService pluralFormService;
+
+    @Rule
+    public TestIdWatcher testIdWatcher = new TestIdWatcher();
+
+    @Test
+    public void testCreateVirtualAsset() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testCreateVirtualAsset"));
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+        Asset asset = assetRepository.findByPathAndRepositoryId("default", repository.getId());
+        assertEquals("default", asset.getPath());
+        assertEquals(false, asset.getDeleted());
+    }
+
+    @Test
+    public void testUpdateVirtualAsset() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testUpdateVirtualAsset"));
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+        Asset asset = assetRepository.findByPathAndRepositoryId("default", repository.getId());
+        assertEquals("default", asset.getPath());
+        assertEquals(false, asset.getDeleted());
+
+        virtualAsset.setDeleted(Boolean.TRUE);
+        virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+        asset = assetRepository.findByPathAndRepositoryId("default", repository.getId());
+        assertEquals("default", asset.getPath());
+        assertEquals(true, asset.getDeleted());
+    }
+
+    @Test(expected = VirtualAssetRequiredException.class)
+    public void testCantUpdateAssetAsVirtual() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testCantUpdateAssetAsVirtual"));
+        assetService.createAsset(repository.getId(), "", "default");
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+    }
+
+    @Test
+    public void testAddTextUnit() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testAddTextUnit"));
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAsset = virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+
+        virtualAssetService.addTextUnit(
+                virtualAsset.getId(),
+                "name_plural_other",
+                "content plural",
+                "comment plural",
+                pluralFormService.findByPluralFormString("other"),
+                "name_plural_other");
+
+        virtualAssetService.addTextUnit(
+                virtualAsset.getId(),
+                "name",
+                "content",
+                "comment",
+                null,
+                null);
+
+        List<VirtualAssetTextUnit> textUnits = virtualAssetService.getTextUnits(virtualAsset.getId());
+        assertEquals(2, textUnits.size());
+
+        int i = 0;
+        assertEquals("name", textUnits.get(i).getName());
+        assertEquals("content", textUnits.get(i).getContent());
+        assertEquals("comment", textUnits.get(i).getComment());
+        assertNull(textUnits.get(i).getPluralForm());
+        assertNull(textUnits.get(i).getPluralFormOther());
+
+        i++;
+        assertEquals("name_plural_other", textUnits.get(i).getName());
+        assertEquals("content plural", textUnits.get(i).getContent());
+        assertEquals("comment plural", textUnits.get(i).getComment());
+        assertEquals("other", textUnits.get(i).getPluralForm());
+        assertEquals("name_plural_other", textUnits.get(i).getPluralFormOther());
+    }
+
+    @Test(expected = VirtualAssetRequiredException.class)
+    public void testCantAddTextUnitToNoVirtual() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testCantAddTextUnitToNoVirtual"));
+        Asset asset = assetService.createAsset(repository.getId(), "", "default");
+
+        virtualAssetService.addTextUnit(
+                asset.getId(),
+                "name_plural_other",
+                "content plural",
+                "comment plural",
+                pluralFormService.findByPluralFormString("other"),
+                "name_plural_other");
+    }
+
+    @Test
+    public void testAddTextUnitVariant() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testAddTextUnitVariant"));
+        RepositoryLocale repositoryLocaleFrFR = repositoryService.addRepositoryLocale(repository, "fr-FR");
+        long frFRLocaleId = repositoryLocaleFrFR.getLocale().getId();
+
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAsset = virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+
+        virtualAssetService.addTextUnit(
+                virtualAsset.getId(),
+                "name_plural_other",
+                "content plural",
+                "comment plural",
+                pluralFormService.findByPluralFormString("other"),
+                "name_plural_other");
+
+        TMTextUnitVariant addTextUnitVariant = virtualAssetService.addTextUnitVariant(virtualAsset.getId(), frFRLocaleId, "name_plural_other", "content-fr", "comment-fr");
+        Assert.assertNotNull(addTextUnitVariant.getId());
+
+        List<VirtualAssetTextUnit> loalizedTextUnits = virtualAssetService.getLoalizedTextUnits(virtualAsset.getId(), frFRLocaleId, InheritanceMode.REMOVE_UNTRANSLATED);
+        assertEquals(1, loalizedTextUnits.size());
+        int i = 0;
+        assertEquals("name_plural_other", loalizedTextUnits.get(i).getName());
+        assertEquals("content-fr", loalizedTextUnits.get(i).getContent());
+        assertEquals("comment plural", loalizedTextUnits.get(i).getComment());
+        assertEquals("other", loalizedTextUnits.get(i).getPluralForm());
+        assertEquals("name_plural_other", loalizedTextUnits.get(i).getPluralFormOther());
+    }
+
+    @Test
+    public void testAddGetReplaceTextUnits() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testAddTextUnitVariant"));
+
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAsset = virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+
+        List<VirtualAssetTextUnit> virtualAssetTextUnits = new ArrayList<>();
+
+        VirtualAssetTextUnit virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name1");
+        virtualAssetTextUnit.setContent("content1");
+        virtualAssetTextUnit.setComment("comment1");
+        virtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name2");
+        virtualAssetTextUnit.setContent("content2");
+        virtualAssetTextUnit.setComment("comment2");
+        virtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name3_other");
+        virtualAssetTextUnit.setContent("content3");
+        virtualAssetTextUnit.setComment("comment3");
+        virtualAssetTextUnit.setPluralForm("other");
+        virtualAssetTextUnit.setPluralFormOther("name3_other");
+        virtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetService.addTextUnits(virtualAssetTextUnits, virtualAsset.getId());
+
+        List<VirtualAssetTextUnit> textUnits = virtualAssetService.getTextUnits(virtualAsset.getId());
+
+        assertEquals(3, textUnits.size());
+        int i = 0;
+        assertEquals("name1", textUnits.get(i).getName());
+        assertEquals("content1", textUnits.get(i).getContent());
+        assertEquals("comment1", textUnits.get(i).getComment());
+        assertNull(textUnits.get(i).getPluralForm());
+        assertNull(textUnits.get(i).getPluralFormOther());
+
+        i++;
+        assertEquals("name2", textUnits.get(i).getName());
+        assertEquals("content2", textUnits.get(i).getContent());
+        assertEquals("comment2", textUnits.get(i).getComment());
+        assertNull(textUnits.get(i).getPluralForm());
+        assertNull(textUnits.get(i).getPluralFormOther());
+
+        i++;
+        assertEquals("name3_other", textUnits.get(i).getName());
+        assertEquals("content3", textUnits.get(i).getContent());
+        assertEquals("comment3", textUnits.get(i).getComment());
+        assertEquals("other", textUnits.get(i).getPluralForm());
+        assertEquals("name3_other", textUnits.get(i).getPluralFormOther());
+
+        List<VirtualAssetTextUnit> replaceVirtualAssetTextUnits = new ArrayList<>();
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name1");
+        virtualAssetTextUnit.setContent("content1");
+        virtualAssetTextUnit.setComment("comment1");
+        replaceVirtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name4");
+        virtualAssetTextUnit.setContent("content4");
+        virtualAssetTextUnit.setComment("comment4");
+        replaceVirtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetService.replaceTextUnits(virtualAsset.getId(), replaceVirtualAssetTextUnits);
+
+        List<VirtualAssetTextUnit> replacedTextUnits = virtualAssetService.getTextUnits(virtualAsset.getId());
+
+        assertEquals(2, replacedTextUnits.size());
+        i = 0;
+        assertEquals("name1", replacedTextUnits.get(i).getName());
+        assertEquals("content1", replacedTextUnits.get(i).getContent());
+        assertEquals("comment1", replacedTextUnits.get(i).getComment());
+        assertNull(replacedTextUnits.get(i).getPluralForm());
+        assertNull(replacedTextUnits.get(i).getPluralFormOther());
+
+        i++;
+        assertEquals("name4", replacedTextUnits.get(i).getName());
+        assertEquals("content4", replacedTextUnits.get(i).getContent());
+        assertEquals("comment4", replacedTextUnits.get(i).getComment());
+        assertNull(replacedTextUnits.get(i).getPluralForm());
+        assertNull(replacedTextUnits.get(i).getPluralFormOther());
+    }
+
+    @Test
+    public void testImportLocalizedTextUnits() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testAddTextUnitVariant"));
+        RepositoryLocale repositoryLocaleFrFR = repositoryService.addRepositoryLocale(repository, "fr-FR");
+        long frFRLocaleId = repositoryLocaleFrFR.getLocale().getId();
+
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAsset = virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+
+        List<VirtualAssetTextUnit> virtualAssetTextUnits = new ArrayList<>();
+
+        VirtualAssetTextUnit virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name1");
+        virtualAssetTextUnit.setContent("content1");
+        virtualAssetTextUnit.setComment("comment1");
+        virtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name2");
+        virtualAssetTextUnit.setContent("content2");
+        virtualAssetTextUnit.setComment("comment2");
+        virtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name3_other");
+        virtualAssetTextUnit.setContent("content3");
+        virtualAssetTextUnit.setComment("comment3");
+        virtualAssetTextUnit.setPluralForm("other");
+        virtualAssetTextUnit.setPluralFormOther("name3_other");
+        virtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetService.addTextUnits(virtualAssetTextUnits, virtualAsset.getId());
+
+        List<VirtualAssetTextUnit> localizedVirtualAssetTextUnits = new ArrayList<>();
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name1");
+        virtualAssetTextUnit.setContent("content1-fr");
+        virtualAssetTextUnit.setComment("comment1-fr");
+        localizedVirtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name2");
+        virtualAssetTextUnit.setContent("content2-fr");
+        virtualAssetTextUnit.setComment("comment2-fr");
+        localizedVirtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setName("name3_other");
+        virtualAssetTextUnit.setContent("content3-fr");
+        virtualAssetTextUnit.setComment("comment3-fr");
+        virtualAssetTextUnit.setPluralForm("other");
+        virtualAssetTextUnit.setPluralFormOther("name3_other");
+        localizedVirtualAssetTextUnits.add(virtualAssetTextUnit);
+
+        virtualAssetService.importLocalizedTextUnits(virtualAsset.getId(), frFRLocaleId, localizedVirtualAssetTextUnits);
+
+        List<VirtualAssetTextUnit> loalizedTextUnits = virtualAssetService.getLoalizedTextUnits(virtualAsset.getId(), frFRLocaleId, InheritanceMode.REMOVE_UNTRANSLATED);
+        assertEquals(3, loalizedTextUnits.size());
+        int i = 0;
+        assertEquals("name1", loalizedTextUnits.get(i).getName());
+        assertEquals("content1-fr", loalizedTextUnits.get(i).getContent());
+        assertEquals("comment1", loalizedTextUnits.get(i).getComment());
+        assertNull(loalizedTextUnits.get(i).getPluralForm());
+        assertNull(loalizedTextUnits.get(i).getPluralFormOther());
+
+        i++;
+        assertEquals("name2", loalizedTextUnits.get(i).getName());
+        assertEquals("content2-fr", loalizedTextUnits.get(i).getContent());
+        assertEquals("comment2", loalizedTextUnits.get(i).getComment());
+        assertNull(loalizedTextUnits.get(i).getPluralForm());
+        assertNull(loalizedTextUnits.get(i).getPluralFormOther());
+
+        i++;
+        assertEquals("name3_other", loalizedTextUnits.get(i).getName());
+        assertEquals("content3-fr", loalizedTextUnits.get(i).getContent());
+        assertEquals("comment3", loalizedTextUnits.get(i).getComment());
+        assertEquals("other", loalizedTextUnits.get(i).getPluralForm());
+        assertEquals("name3_other", loalizedTextUnits.get(i).getPluralFormOther());
+    }
+
+    @Test
+    public void testDeleteTextUnit() throws Exception {
+
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("testAddTextUnit"));
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath("default");
+        virtualAsset = virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+
+        virtualAssetService.addTextUnit(
+                virtualAsset.getId(),
+                "name_plural_other",
+                "content plural",
+                "comment plural",
+                pluralFormService.findByPluralFormString("other"),
+                "name_plural_other");
+
+        virtualAssetService.addTextUnit(
+                virtualAsset.getId(),
+                "name",
+                "content",
+                "comment",
+                null,
+                null);
+
+        List<VirtualAssetTextUnit> textUnits = virtualAssetService.getTextUnits(virtualAsset.getId());
+        assertEquals(2, textUnits.size());
+
+        virtualAssetService.deleteTextUnit(virtualAsset.getId(), "name_plural_other");
+
+        textUnits = virtualAssetService.getTextUnits(virtualAsset.getId());
+        assertEquals(1, textUnits.size());
+        assertEquals("name", textUnits.get(0).getName());
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionCleanupServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionCleanupServiceTest.java
@@ -7,6 +7,7 @@ import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.asset.AssetUpdateException;
 import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.pollableTask.PollableTaskRepository;
@@ -142,7 +143,7 @@ public class AssetExtractionCleanupServiceTest extends ServiceTestBase {
         return repository;
     }
 
-    private void createOrUpdateAssetAndWaitUntilProcessingEnds(Repository repository, String assetPath, int assetVersion) throws ExecutionException, InterruptedException {
+    private void createOrUpdateAssetAndWaitUntilProcessingEnds(Repository repository, String assetPath, int assetVersion) throws ExecutionException, InterruptedException, AssetUpdateException {
 
         String xliff = xliffDataFactory.generateSourceXliff(Arrays.asList(
             xliffDataFactory.createTextUnit(1L, "2_factor_challenge_buttom", "Submit" + assetVersion, null)

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/AssetIntegrityCheckerServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/AssetIntegrityCheckerServiceTest.java
@@ -6,6 +6,7 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.asset.AssetUpdateException;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.IntegrityCheckerType;
 import com.box.l10n.mojito.service.locale.LocaleService;
@@ -61,7 +62,7 @@ public class AssetIntegrityCheckerServiceTest extends ServiceTestBase {
     protected static final String ASSET_PATH = "source-asset-path.xliff";
 
     @Test
-    public void testIntegrityCheckerIsUsedInTmServiceUpdate() throws RepositoryLocaleCreationException, ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException {
+    public void testIntegrityCheckerIsUsedInTmServiceUpdate() throws RepositoryLocaleCreationException, ExecutionException, InterruptedException, RepositoryNameAlreadyUsedException, AssetUpdateException {
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
 
         String frFR = "fr-FR";

--- a/webapp/src/test/java/com/box/l10n/mojito/service/pluralform/PluralFormForLocaleServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/pluralform/PluralFormForLocaleServiceTest.java
@@ -4,6 +4,8 @@ import com.box.l10n.mojito.entity.PluralFormForLocale;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import java.util.List;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -12,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class PluralFormForLocaleServiceTest extends ServiceTestBase {
 
+    static Logger logger = LoggerFactory.getLogger(PluralFormForLocaleServiceTest.class);
+
     @Autowired
     PluralFormForLocaleService pluralFormForLocaleService;
 
@@ -19,9 +23,30 @@ public class PluralFormForLocaleServiceTest extends ServiceTestBase {
     PluralFormForLocaleRepository pluralFormForLocaleRepository;
 
     @Test
-    public void testShowForms() {
+    public void testShowNewFormsSQL() {
+        
+        StringBuilder sb = new StringBuilder();
+             
         List<PluralFormForLocale> pluralFormsForLocales = pluralFormForLocaleService.getPluralFormsForLocales();
-      //  pluralFormForLocaleRepository.save(pluralFormsForLocales);
+        for (PluralFormForLocale pluralFormsForLocale : pluralFormsForLocales) {
+            PluralFormForLocale findByLocale = pluralFormForLocaleRepository.findByLocaleAndPluralForm(pluralFormsForLocale.getLocale(), pluralFormsForLocale.getPluralForm());
+
+            if (findByLocale == null) {
+                PluralFormForLocale savedPluralFormForLocale = pluralFormForLocaleRepository.save(pluralFormsForLocale);
+
+                sb.append("insert into plural_form_for_locale (locale_id, plural_form_id) values (").
+                        append(savedPluralFormForLocale.getLocale().getId()).
+                        append(",").
+                        append(savedPluralFormForLocale.getPluralForm().getId()).
+                        append(");\n");
+
+                logger.info("insert into plural_form_for_locale (locale_id, plural_form_id) values ({}, {});",
+                        savedPluralFormForLocale.getLocale().getId(),
+                        savedPluralFormForLocale.getPluralForm().getId());
+            }
+        }
+        
+        logger.info(sb.toString());
     }
 
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -11,9 +11,9 @@ import com.box.l10n.mojito.entity.TMTextUnitVariantComment;
 import com.box.l10n.mojito.okapi.ImportTranslationsFromLocalizedAssetStep.StatusForSourceEqTarget;
 import com.box.l10n.mojito.okapi.filters.MacStringsEncoder;
 import com.box.l10n.mojito.okapi.filters.XMLEncoder;
-import com.box.l10n.mojito.service.asset.AssetCreationException;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.asset.AssetUpdateException;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
@@ -245,6 +245,12 @@ public class TMServiceTest extends ServiceTestBase {
     public void testComputeTMTextUnitMD5() throws IOException {
         String computeTMTextUnitMD5 = tmService.computeTMTextUnitMD5("name", "this is the content", "some comment");
         assertEquals("3063c39d3cf8ab69bcabbbc5d7187dc9", computeTMTextUnitMD5);
+    }
+    
+    @Test
+    public void testComputeTMTextUnitMD5Null() throws IOException {
+        String computeTMTextUnitMD5 = tmService.computeTMTextUnitMD5(null, "this is the content", null);
+        assertEquals("ad549ec93687843d638c9a712dff0238", computeTMTextUnitMD5);
     }
 
     @Test
@@ -1347,7 +1353,7 @@ public class TMServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void testImportLocalizedAssetXLIFFApproved() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException {
+    public void testImportLocalizedAssetXLIFFApproved() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException, AssetUpdateException, AssetUpdateException {
 
         baseTestImportLocalizedAsset(StatusForSourceEqTarget.APPROVED);
 
@@ -1373,7 +1379,7 @@ public class TMServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void testImportLocalizedAssetXLIFFReviewNeeded() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException {
+    public void testImportLocalizedAssetXLIFFReviewNeeded() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException, AssetUpdateException {
 
         baseTestImportLocalizedAsset(StatusForSourceEqTarget.REVIEW_NEEDED);
 
@@ -1400,7 +1406,7 @@ public class TMServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void testImportLocalizedAssetXLIFFTranslationNeeded() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException {
+    public void testImportLocalizedAssetXLIFFTranslationNeeded() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException, AssetUpdateException {
 
         baseTestImportLocalizedAsset(StatusForSourceEqTarget.TRANSLATION_NEEDED);
 
@@ -1427,7 +1433,7 @@ public class TMServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void testImportLocalizedAssetXLIFFSkip() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException {
+    public void testImportLocalizedAssetXLIFFSkip() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException, AssetUpdateException {
 
         baseTestImportLocalizedAsset(StatusForSourceEqTarget.SKIPPED);
 
@@ -1450,7 +1456,7 @@ public class TMServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void testImportLocalizedAssetNotFullyTranslated() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException {
+    public void testImportLocalizedAssetNotFullyTranslated() throws RepositoryNameAlreadyUsedException, ExecutionException, InterruptedException, AssetUpdateException {
 
         baseTestImportLocalizedAsset(StatusForSourceEqTarget.APPROVED);
 
@@ -1479,7 +1485,7 @@ public class TMServiceTest extends ServiceTestBase {
 
     }
 
-    private void baseTestImportLocalizedAsset(StatusForSourceEqTarget sourceEqualTargetProcessing) throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException, AssetCreationException, RuntimeException {
+    private void baseTestImportLocalizedAsset(StatusForSourceEqTarget sourceEqualTargetProcessing) throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException, AssetUpdateException, AssetUpdateException {
         repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
         RepositoryLocale repoLocale;
         try {


### PR DESCRIPTION
- Virtual asset is an asset with virtual flag set to true (DB change)
- Push can only be done on normal asset while managing text units via 
APIs only work on virtual asset 
- Add new CLI command to create virtual asset
- WS/API provides way to add (or replace) text units, delete and get
source or localized text units