### PR TITLE
Extract usages of text units from the PO files

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/AssetTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/AssetTextUnit.java
@@ -2,8 +2,11 @@ package com.box.l10n.mojito.entity;
 
 import com.box.l10n.mojito.entity.security.user.User;
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import java.util.Set;
+import javax.persistence.CollectionTable;
 import org.springframework.data.annotation.CreatedBy;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
 import javax.persistence.Index;
@@ -57,10 +60,15 @@ public class AssetTextUnit extends AuditableEntity {
     @ManyToOne
     @JoinColumn(name = "plural_form_id", foreignKey = @ForeignKey(name = "FK__ASSET_TEXT_UNIT__PLURAL_FORM__ID"))
     protected PluralForm pluralForm;
-    
+
     @Column(name = "plural_form_other", length = Integer.MAX_VALUE)
     protected String pluralFormOther;
-   
+
+    @ElementCollection
+    @CollectionTable(name = "asset_text_unit_usages",
+            joinColumns = @JoinColumn(name = "asset_text_unit_id"), foreignKey = @ForeignKey(name = "FK__ASSET_TEXT_UNIT_USAGES__ASSET_TEXT_UNIT__ID"))
+    private Set<String> usages;
+
     public User getCreatedByUser() {
         return createdByUser;
     }
@@ -132,5 +140,13 @@ public class AssetTextUnit extends AuditableEntity {
     public void setPluralFormOther(String pluralFormOther) {
         this.pluralFormOther = pluralFormOther;
     }
- 
+
+    public Set<String> getUsages() {
+        return usages;
+    }
+
+    public void setUsages(Set<String> usages) {
+        this.usages = usages;
+    }
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/AssetExtractionStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/AssetExtractionStep.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.okapi;
 
 import com.box.l10n.mojito.entity.PluralForm;
 import com.box.l10n.mojito.okapi.filters.PluralFormAnnotation;
+import com.box.l10n.mojito.okapi.filters.UsagesAnnotation;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
 import com.box.l10n.mojito.service.pluralform.PluralFormService;
 import java.util.HashSet;
@@ -83,14 +84,34 @@ public class AssetExtractionStep extends AbstractMd5ComputationStep {
                     pluralForm = pluralFormService.findByPluralFormString(annotation.getName());
                     pluralFormOther = annotation.getOtherName();
                 }
-
-                assetExtractionService.createAssetTextUnit(assetExtractionId, name, source, comments, pluralForm, pluralFormOther);
+                
+                assetExtractionService.createAssetTextUnit(
+                        assetExtractionId, 
+                        name, 
+                        source, 
+                        comments, 
+                        pluralForm, 
+                        pluralFormOther,
+                        getUsages());
+                
             } else {
                 logger.debug("Duplicate assetTextUnit found, skip it");
             }
         }
 
         return event;
+    }
+
+    Set<String> getUsages() {
+        Set<String> usages = null;
+        
+        UsagesAnnotation usagesAnnotation = textUnit.getAnnotation(UsagesAnnotation.class);
+        
+        if (usagesAnnotation != null) {
+            usages = usagesAnnotation.getUsages();
+        }
+        
+        return usages;
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/UsagesAnnotation.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/UsagesAnnotation.java
@@ -1,0 +1,22 @@
+package com.box.l10n.mojito.okapi.filters;
+
+import java.util.Set;
+import net.sf.okapi.common.annotation.IAnnotation;
+
+/**
+ *
+ * @author jaurambault
+ */
+public class UsagesAnnotation implements IAnnotation {
+
+    Set<String> usages;
+
+    public UsagesAnnotation(Set<String> usageLocations) {
+        this.usages = usageLocations;
+    }
+
+    public Set<String> getUsages() {
+        return usages;
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
@@ -1,7 +1,9 @@
 package com.box.l10n.mojito.rest.textunit;
 
+import com.box.l10n.mojito.entity.AssetTextUnit;
 import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant;
 import com.box.l10n.mojito.service.NormalizationUtils;
+import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.IntegrityCheckException;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TMService;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 
 /**
@@ -57,6 +60,9 @@ public class TextUnitWS {
 
     @Autowired
     TMTextUnitIntegrityCheckService tmTextUnitIntegrityCheckService;
+
+    @Autowired
+    AssetTextUnitRepository assetTextUnitRepository;
 
     /**
      * Gets the TextUnits that matches the search parameters.
@@ -99,11 +105,11 @@ public class TextUnitWS {
             @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset) throws InvalidTextUnitSearchParameterException {
 
         TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
-                        
+
         if (CollectionUtils.isEmpty(repositoryIds) && CollectionUtils.isEmpty(repositoryNames)) {
             throw new InvalidTextUnitSearchParameterException("Repository ids or names must be provided");
         }
-        
+
         textUnitSearcherParameters.setRepositoryIds(repositoryIds);
         textUnitSearcherParameters.setRepositoryNames(repositoryNames);
         textUnitSearcherParameters.setName(name);
@@ -122,7 +128,7 @@ public class TextUnitWS {
         if (usedFilter != null) {
             textUnitSearcherParameters.setUsedFilter(usedFilter);
         }
-        
+
         if (statusFilter != null) {
             textUnitSearcherParameters.setStatusFilter(statusFilter);
         }
@@ -172,7 +178,8 @@ public class TextUnitWS {
      * remove the translation from the system, it just removes it from being the
      * current translation.
      *
-     * @param textUnitId TextUnit id (maps to {@link TMTextUnitCurrentVariant#id})
+     * @param textUnitId TextUnit id (maps to
+     * {@link TMTextUnitCurrentVariant#id})
      */
     @Transactional
     @RequestMapping(method = RequestMethod.DELETE, value = "/api/textunits/{textUnitId}")
@@ -191,7 +198,7 @@ public class TextUnitWS {
 
     @RequestMapping(method = RequestMethod.GET, value = "/api/textunits/check")
     public TMTextUnitIntegrityCheckResult checkTMTextUnit(@RequestParam(value = "textUnitId") Long textUnitId,
-                                                          @RequestParam(value = "contentToCheck") String contentToCheck) {
+            @RequestParam(value = "contentToCheck") String contentToCheck) {
         logger.debug("Checking TextUnit, id: {}", textUnitId);
 
         TMTextUnitIntegrityCheckResult result = new TMTextUnitIntegrityCheckResult();
@@ -205,4 +212,12 @@ public class TextUnitWS {
 
         return result;
     }
+    
+    @RequestMapping(method = RequestMethod.GET, value = "/api/assetTextUnits/{assetTextUnitId}/usages")
+    public Set<String> getAssetTextUnitUsages(@PathVariable Long assetTextUnitId) {
+        logger.debug("Get usages of asset text unit for id: {}", assetTextUnitId);
+        AssetTextUnit assetTextUnit = assetTextUnitRepository.findOne(assetTextUnitId);
+        return assetTextUnit.getUsages();
+    }
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
@@ -297,7 +297,8 @@ public class VirtualAssetService {
                     content,
                     comment,
                     pluralForm,
-                    pluralFormOther);
+                    pluralFormOther,
+                    null);
 
             logger.debug("Look for an existing TmTextunit");
             TMTextUnit tmTextUnit = tmTextUnitRepository.findFirstByAssetAndMd5(asset, assetTextUnit.getMd5());

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
@@ -18,6 +18,7 @@ import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.pollableTask.PollableFutureTaskResult;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Future;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
@@ -138,7 +139,7 @@ public class AssetExtractionService {
      * @return The created AssetTextUnit
      */
     public AssetTextUnit createAssetTextUnit(Long assetExtractionId, String name, String content, String comment) {
-        return createAssetTextUnit(assetExtractionId, name, content, comment, null, null);
+        return createAssetTextUnit(assetExtractionId, name, content, comment, null, null, null);
     }
      
     /**
@@ -150,10 +151,18 @@ public class AssetExtractionService {
      * @param comment           Comment for the TextUnit
      * @param pluralForm        optional plural form
      * @param pluralFormOther   optional other plural form
+     * @param usages            optional usages in the code source
      * @return The created AssetTextUnit
      */
     @Transactional
-    public AssetTextUnit createAssetTextUnit(Long assetExtractionId, String name, String content, String comment, PluralForm pluralForm, String pluralFormOther) {
+    public AssetTextUnit createAssetTextUnit(
+            Long assetExtractionId, 
+            String name, 
+            String content, 
+            String comment, 
+            PluralForm pluralForm, 
+            String pluralFormOther,
+            Set<String> usages) {
 
         logger.debug("Adding AssetTextUnit for assetExtractionId: {}\nname: {}\ncontent: {}\ncomment: {}\n", assetExtractionId, name, content, comment);
 
@@ -166,6 +175,7 @@ public class AssetExtractionService {
         assetTextUnit.setContentMd5(DigestUtils.md5Hex(content));
         assetTextUnit.setPluralForm(pluralForm);
         assetTextUnit.setPluralFormOther(pluralFormOther);
+        assetTextUnit.setUsages(usages);
 
         assetTextUnitRepository.save(assetTextUnit);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
@@ -31,6 +31,7 @@ public class TextUnitDTO {
     private String pluralFormOther;
     private String repositoryName;
     private String assetPath;
+    private Long assetTextUnitId;
 
     public Long getTmTextUnitId() {
         return tmTextUnitId;
@@ -208,6 +209,14 @@ public class TextUnitDTO {
 
     public void setAssetPath(String assetPath) {
         this.assetPath = assetPath;
+    }
+
+    public Long getAssetTextUnitId() {
+        return assetTextUnitId;
+    }
+
+    public void setAssetTextUnitId(Long assetTextUnitId) {
+        this.assetTextUnitId = assetTextUnitId;
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTONativeObjectMapper.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTONativeObjectMapper.java
@@ -48,6 +48,7 @@ public class TextUnitDTONativeObjectMapper implements NativeObjectMapper<TextUni
         t.setPluralFormOther(cr.getString(idx++));
         t.setRepositoryName(cr.getString(idx++));
         t.setAssetPath(cr.getString(idx++));
+        t.setAssetTextUnitId(cr.getLong(idx++));
 
         return t;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -135,7 +135,8 @@ public class TextUnitSearcher {
                 addProjection("pf.name", "pluralForm").
                 addProjection("tu.plural_form_other", "pluralFormOther").
                 addProjection("r.name", "repositoryName").
-                addProjection("a.path", "assetPath")         
+                addProjection("a.path", "assetPath").
+                addProjection("atu.id", "assetTextUnitId")         
         );
 
         logger.debug("Add search filters");

--- a/webapp/src/main/resources/db/migration/V20__asset_text_unit_usages.sql
+++ b/webapp/src/main/resources/db/migration/V20__asset_text_unit_usages.sql
@@ -1,0 +1,2 @@
+create table asset_text_unit_usages (asset_text_unit_id bigint not null, usages varchar(255));
+alter table asset_text_unit_usages add constraint FK__ASSET_TEXT_UNIT_USAGES__ASSET_TEXT_UNIT__ID foreign key (asset_text_unit_id) references asset_text_unit (id);

--- a/webapp/src/test/java/com/box/l10n/mojito/okapi/filters/POFilterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/okapi/filters/POFilterTest.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.okapi.filters;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -21,6 +23,38 @@ public class POFilterTest {
         POFilter poFilter = new POFilter();
         poFilter.loadMsgIDFromParent();
         assertNull(poFilter.msgID);
+    }
+
+    @Test
+    public void getUsagesFromSkeleton() {
+        String skeleton = "#. Comments\n"
+                + "#: core/logic/week_in_review_email_logic.py:49\n"
+                + "#: core/logic/week_in_review_email_logic.py:72\n"
+                + "msgid \"repin\"\n"
+                + "msgid_plural \"repins\"\n"
+                + "msgstr[0] \"repin-ru\"\n"
+                + "msgstr[1] \"repins-ru-1\"\n"
+                + "msgstr[2] \"repins-ru-2\"\n";
+
+        POFilter poFilter = new POFilter();
+        List<String> usages = new ArrayList<>(poFilter.getUsagesFromSkeleton(skeleton));
+        
+        assertEquals("core/logic/week_in_review_email_logic.py:49", usages.get(0));
+        assertEquals("core/logic/week_in_review_email_logic.py:72", usages.get(1));
+    }
+    
+    @Test
+    public void getUsagesFromSkeletonNone() {
+        String skeleton = "#. Comments\n"
+                + "msgid \"repin\"\n"
+                + "msgid_plural \"repins\"\n"
+                + "msgstr[0] \"repin-ru\"\n"
+                + "msgstr[1] \"repins-ru-1\"\n"
+                + "msgstr[2] \"repins-ru-2\"\n";
+
+        POFilter poFilter = new POFilter();
+        List<String> usages = new ArrayList<>(poFilter.getUsagesFromSkeleton(skeleton));
+        assertEquals(0, usages.size());
     }
 
 }


### PR DESCRIPTION
- Extract the usage (reference) from #: comments in the PO file 
- Update AssetTextUnit to save the usage information
- Add the asset text unit id to the TextUnitDTO for TextUnitWS
- Add WS to query usages for a given asset unit id