### PR TITLE
Add an option to not filter plural for a locale.

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
@@ -76,8 +76,9 @@ public class TextUnitWS {
      * @param name optional
      * @param source optional
      * @param target optional
-     * @param assetPath
+     * @param assetPath optional
      * @param pluralFormOther optional
+     * @param pluralFormFiltered optional
      * @param searchType optional, default is EXACT match
      * @param localeTags optional
      * @param usedFilter optional
@@ -97,6 +98,7 @@ public class TextUnitWS {
             @RequestParam(value = "target", required = false) String target,
             @RequestParam(value = "assetPath", required = false) String assetPath,
             @RequestParam(value = "pluralFormOther", required = false) String pluralFormOther,
+            @RequestParam(value = "pluralFormFiltered", required = false, defaultValue = "true") boolean pluralFormFiltered,
             @RequestParam(value = "searchType", required = false, defaultValue = "EXACT") SearchType searchType,
             @RequestParam(value = "localeTags[]", required = false) ArrayList<String> localeTags,
             @RequestParam(value = "usedFilter", required = false) UsedFilter usedFilter,
@@ -117,6 +119,7 @@ public class TextUnitWS {
         textUnitSearcherParameters.setTarget(target);
         textUnitSearcherParameters.setAssetPath(assetPath);
         textUnitSearcherParameters.setPluralFormOther(pluralFormOther);
+        textUnitSearcherParameters.setPluralFormsFiltered(pluralFormFiltered);
         textUnitSearcherParameters.setSearchType(searchType);
         textUnitSearcherParameters.setRootLocaleExcluded(false);
 
@@ -132,7 +135,7 @@ public class TextUnitWS {
         if (statusFilter != null) {
             textUnitSearcherParameters.setStatusFilter(statusFilter);
         }
-
+        
         textUnitSearcherParameters.setLimit(limit);
         textUnitSearcherParameters.setOffset(offset);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -32,6 +32,7 @@ public class TextUnitSearcherParameters {
     String md5;
     boolean rootLocaleExcluded = true;
     boolean untranslatedOrTranslationNeeded = false;
+    boolean pluralFormsFiltered = true;
 
     public String getName() {
         return name;
@@ -189,4 +190,11 @@ public class TextUnitSearcherParameters {
         this.repositoryNames = repositoryNames;
     }
 
+    public boolean isPluralFormsFiltered() {
+        return pluralFormsFiltered;
+    }
+
+    public void setPluralFormsFiltered(boolean pluralFormsFiltered) {
+        this.pluralFormsFiltered = pluralFormsFiltered;
+    }
 }


### PR DESCRIPTION
This allows to easily fetch all the plural forms of string when call the WS for the root locale