### PR TITLE
MOJI-677: add a confirmation dialog box while cancelling a drop

### DIFF
--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -370,6 +370,18 @@ drops.controlbar.button.tooltip.import=Import Request
 # Tooltip on cancel drop button
 drops.controlbar.button.tooltip.cancel=Cancel Request
 
+# Title of the confirmation dialog box when a user attempts to cancel a review or translation request
+drops.confirm.cancel.model.title=Really Cancel?
+
+# Body of the confirmation dialog box when a user attempts to cancel a review or translation request
+drops.confirm.cancel.model.body=Are you sure you want to cancel this request?
+
+# Label on the confirm button of the confirmation dialog box when a user attempts to cancel a review or translation request
+drops.confirm.cancel.model.confirm=Yes
+
+# Label on the cancel button of the confirmation dialog box when a user attempts to cancel the cancellation a review or translation request
+drops.confirm.cancel.model.cancel=No
+
 # Label to show project requests where translations are in progress
 drops.inProgress=In Progress
 

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -371,7 +371,7 @@ drops.controlbar.button.tooltip.import=Import Request
 drops.controlbar.button.tooltip.cancel=Cancel Request
 
 # Title of the confirmation dialog box when a user attempts to cancel a review or translation request
-drops.confirm.cancel.model.title=Really Cancel?
+drops.confirm.cancel.model.title=Confirm Cancel
 
 # Body of the confirmation dialog box when a user attempts to cancel a review or translation request
 drops.confirm.cancel.model.body=Are you sure you want to cancel this request?

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -165,7 +165,7 @@ let Drops = React.createClass({
     },
 
     /**
-     * Hande import onclick event
+     * Handle import onclick event
      */
     onClickImport(dropId, repoId) {
         this.showAlert(this.props.intl.formatMessage({id: "drops.beingImported.alert"}));
@@ -176,7 +176,7 @@ let Drops = React.createClass({
     },
 
     /**
-     * handle cancel Drop onclick event
+     * handle cancel drop onclick event
      * @param {Number} dropId
      * @param {Number} repoId
      */
@@ -189,9 +189,7 @@ let Drops = React.createClass({
     },
 
     /**
-     * handle cancel Drop onclick event
-     * @param {Number} dropId
-     * @param {Number} repoId
+     * handle cancel drop confirmation
      */
     onConfirmCancel() {
         let dropId = this.state.cancelDropId, repoId = this.state.cancelRepoId;
@@ -210,9 +208,7 @@ let Drops = React.createClass({
     },
 
     /**
-     * handle cancel Drop onclick event
-     * @param {Number} dropId
-     * @param {Number} repoId
+     * handle cancel drop not confirmed
      */
     onCancelCancel() {
         this.setState({

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -69,9 +69,7 @@ let Drops = React.createClass({
             /** @type {Boolean} */
             "showCancelModal": false,
             /** @type {Number} */
-            "cancelDropId": null,
-            /** @type {Number} */
-            "cancelRepoId": null
+            "cancelDropId": null
         };
     },
 
@@ -184,7 +182,6 @@ let Drops = React.createClass({
         this.setState({
             "showCancelModal": true,
             "cancelDropId": dropId,
-            "cancelRepoId": repoId
         });
     },
 
@@ -192,7 +189,7 @@ let Drops = React.createClass({
      * handle cancel drop confirmation
      */
     onConfirmCancel() {
-        let dropId = this.state.cancelDropId, repoId = this.state.cancelRepoId;
+        let dropId = this.state.cancelDropId;
 
         this.showAlert(this.props.intl.formatMessage({id: "drops.beingCanceled.alert"}));
         let cancelDropConfig = new CancelDropConfig(dropId, null);
@@ -202,8 +199,7 @@ let Drops = React.createClass({
 
         this.setState({
             "showCancelModal": false,
-            "cancelDropId": null,
-            "cancelRepoId": null
+            "cancelDropId": null
         })
     },
 
@@ -213,8 +209,7 @@ let Drops = React.createClass({
     onCancelCancel() {
         this.setState({
             "showCancelModal": false,
-            "cancelDropId": null,
-            "cancelRepoId": null
+            "cancelDropId": null
         });
     },
 

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -24,6 +24,7 @@ import DropStore from "../../stores/drop/DropStore";
 import ImportDropConfig from "../../sdk/drop/ImportDropConfig";
 import NewDropModal from "./NewDropModal";
 import RepositoryActions from "../../actions/RepositoryActions";
+import ConfirmationModal from "../widgets/ConfirmationModal";
 
 let Drops = React.createClass({
     mixins: [FluxyMixin],
@@ -64,6 +65,13 @@ let Drops = React.createClass({
 
             /** @type {Drop} */
             "selectedDrop": null,
+
+            /** @type {Boolean} */
+            "showCancelModal": false,
+            /** @type {Number} */
+            "cancelDropId": null,
+            /** @type {Number} */
+            "cancelRepoId": null
         };
     },
 
@@ -173,11 +181,45 @@ let Drops = React.createClass({
      * @param {Number} repoId
      */
     onClickCancel(dropId, repoId) {
+        this.setState({
+            "showCancelModal": true,
+            "cancelDropId": dropId,
+            "cancelRepoId": repoId
+        });
+    },
+
+    /**
+     * handle cancel Drop onclick event
+     * @param {Number} dropId
+     * @param {Number} repoId
+     */
+    onConfirmCancel() {
+        let dropId = this.state.cancelDropId, repoId = this.state.cancelRepoId;
+
         this.showAlert(this.props.intl.formatMessage({id: "drops.beingCanceled.alert"}));
         let cancelDropConfig = new CancelDropConfig(dropId, null);
         DropActions.cancelRequest(cancelDropConfig);
 
         this.delayGetNewRequests(500);
+
+        this.setState({
+            "showCancelModal": false,
+            "cancelDropId": null,
+            "cancelRepoId": null
+        })
+    },
+
+    /**
+     * handle cancel Drop onclick event
+     * @param {Number} dropId
+     * @param {Number} repoId
+     */
+    onCancelCancel() {
+        this.setState({
+            "showCancelModal": false,
+            "cancelDropId": null,
+            "cancelRepoId": null
+        });
     },
 
     /**
@@ -535,6 +577,13 @@ let Drops = React.createClass({
     render() {
         return (
             <div>
+                <ConfirmationModal showModal={this.state.showCancelModal}
+                    modalTitleMessage="drops.confirm.cancel.model.title"
+                    modalBodyMessage="drops.confirm.cancel.model.body"
+                    confirmButtonLabel="drops.confirm.cancel.model.confirm"
+                    cancelButtonLabel="drops.confirm.cancel.model.cancel"
+                    onCancelledCallback={this.onCancelCancel}
+                    onConfirmedCallback={this.onConfirmCancel}/>
                 <ReactSidebarResponsive ref="sideBar" sidebar={this.getSideBarContent()}
                          rootClassName="side-bar-root-container"
                          sidebarClassName="side-bar-container"

--- a/webapp/src/main/resources/public/js/components/widgets/ConfirmationModal.js
+++ b/webapp/src/main/resources/public/js/components/widgets/ConfirmationModal.js
@@ -1,0 +1,50 @@
+/**
+ * Generic confirmation modal. You must supply the body message and the confirm and cancel
+ * button callbacks, as well as the confirm and cancel button labels.
+ */
+import PropTypes from 'prop-types';
+import React from "react";
+import {FormattedMessage} from "react-intl";
+import {Button, Modal} from "react-bootstrap";
+
+let ConfirmationModal = React.createClass({
+
+    propTypes: {
+        "showModal": PropTypes.bool.isRequired,
+        "modalTitleMessage": PropTypes.string.isRequired,
+        "modalBodyMessage": PropTypes.string.isRequired,
+        "onCancelledCallback": PropTypes.func.isRequired,
+        "onConfirmedCallback": PropTypes.func.isRequired,
+        "confirmButtonLabel": PropTypes.func.isRequired,
+        "cancelButtonLabel": PropTypes.func.isRequired
+    },
+
+    getDefaultProps() {
+        return {
+            "showModal": false
+        };
+    },
+
+    render() {
+        return (
+            <Modal show={this.props.showModal} onHide={this.props.onCancelledCallback}>
+                <Modal.Header closeButton>
+                    <Modal.Title><FormattedMessage id={this.props.modalTitleMessage}/></Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <FormattedMessage id={this.props.modalBodyMessage}/>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button bsStyle="danger" onClick={this.props.onConfirmedCallback}>
+                        <FormattedMessage id={this.props.confirmButtonLabel}/>
+                    </Button>
+                    <Button onClick={this.props.onCancelledCallback}>
+                        <FormattedMessage id={this.props.cancelButtonLabel}/>
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+});
+
+export default ConfirmationModal;


### PR DESCRIPTION
Make sure the user does not accidentally cancel the drop by throwing up a simple confirmation dialog first.