### PR TITLE
Fix typo that was causing asset_path to be undefined in query

### DIFF
--- a/webapp/src/main/resources/public/js/ict/IctModalContainer.js
+++ b/webapp/src/main/resources/public/js/ict/IctModalContainer.js
@@ -55,7 +55,7 @@ class IctModalContainer extends React.Component {
             'repoName': this.state.selectedTextUnit.repositoryName,
             'locales': this.state.selectedTextUnit.locale,
             'searchText': this.state.selectedTextUnit.textUnitName,
-            'asset_path': this.state.selectedTextUnit.asset_path
+            'asset_path': this.state.selectedTextUnit.assetName
         });
         window.open(url + query);
     }


### PR DESCRIPTION
`asset_path` in the query should be assigned to `this.state.selectedTextUnit.assetName`, otherwise it will be assigned `undefined`