### PR TITLE
Removed unnecessary normalization

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -32,7 +32,6 @@ import com.box.l10n.mojito.okapi.qualitycheck.Parameters;
 import com.box.l10n.mojito.okapi.qualitycheck.QualityCheckStep;
 import com.box.l10n.mojito.rest.asset.FilterConfigIdOverride;
 import com.box.l10n.mojito.security.AuditorAwareImpl;
-import com.box.l10n.mojito.service.NormalizationUtils;
 import com.box.l10n.mojito.service.WordCountService;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.assetExtraction.extractor.AssetExtractor;
@@ -1041,16 +1040,15 @@ public class TMService {
         PollableFutureTaskResult<String> pollableFutureTaskResult = new PollableFutureTaskResult<>();
 
         String xliff = exportAssetAsXLIFF(assetId, bcp47Tag);
-        String normalized = NormalizationUtils.normalize(xliff);
 
         TMXliff tmXliff = tmXliffRepository.findOne(tmXliffId);
         tmXliff.setAsset(assetRepository.findOne(assetId));
         tmXliff.setLocale(localeService.findByBcp47Tag(bcp47Tag));
-        tmXliff.setContent(normalized);
+        tmXliff.setContent(xliff);
         tmXliff.setPollableTask(currentTask);
         tmXliffRepository.save(tmXliff);
 
-        pollableFutureTaskResult.setResult(normalized);
+        pollableFutureTaskResult.setResult(xliff);
         return pollableFutureTaskResult;
     }
 


### PR DESCRIPTION
Text normalization causes significant slowness in exporting Hindi and Bengali TM as xliff. Normalization is required when strings are imported. For exporting strings, it's not necessary.