### PR TITLE
support for ellipsis entity in Android resource file

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XMLEncoder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XMLEncoder.java
@@ -64,6 +64,7 @@ public class XMLEncoder extends net.sf.okapi.common.encoder.XMLEncoder {
             replacement = "<$2$3>";
         }
         text = ANDROID_HTML.matcher(text).replaceAll(replacement);
+        text = text.replace("…", "&#8230;");
         text = text.replaceAll("\n", "\\\\n");
         text = text.replaceAll("\r", "\\\\r");
         text = escapeDoubleQuotes(text);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -803,6 +803,11 @@ public class TMServiceTest extends ServiceTestBase {
      * <b>bold</b>, <i>italian</i> and <u>underline</u> should be in localized
      * file as-is.
      *
+     * Need to support use of &#8230; in Android resource files. Use of &#8230;
+     * instead of '…' (3 dots) for ellipsis has these benefits:
+     * 1) Accessibility: the talk back does not say dot dot dot
+     * 2) The OS will not introduce a return carriage in the middle of the dots
+     *
      * @throws Exception
      */
     @Test
@@ -823,6 +828,7 @@ public class TMServiceTest extends ServiceTestBase {
                 + "    <string description=\"Example html markup string3\" name=\"welcome3\">Welcome to <u>Android</u>!</string>\n"
                 + "    <string name=\"subheader_text1\">\\\'Make sure you\\\'d \\\"escaped\\\" special characters like quotes &amp; ampersands.\\n</string>\n"
                 + "    <string name=\"subheader_text2\">\"This'll also work\"</string>\n"
+                + "    <string name=\"subheader_text3\">Filter by&#8230;</string>\n"
                 + "</resources>";
         asset = assetService.createAsset(repo.getId(), assetContent, "res/values/strings.xml");
         asset = assetRepository.findOne(asset.getId());


### PR DESCRIPTION
Android team has asked that we support `&#8230;` instead of &#8230; for elipsis. The benefits are:

- Accessibility: the talk back does not say: dot dot dot
- You are sure that the OS will not introduce a return carriage in the middle of the dots
