### PR TITLE
fixing intermittent screenshot tests failures

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/rest/screenshot/ScreenshotWSTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/screenshot/ScreenshotWSTest.java
@@ -81,6 +81,7 @@ public class ScreenshotWSTest extends WSTestBase {
         com.box.l10n.mojito.rest.entity.Repository r = new com.box.l10n.mojito.rest.entity.Repository();
         r.setName(repository.getName());
         r.setId(repository.getId());
+        screenshotRun.setName("screenshotrun");
         screenshotRun.setRepository(r);
         
         com.box.l10n.mojito.rest.entity.Screenshot screenshot1 = new com.box.l10n.mojito.rest.entity.Screenshot();


### PR DESCRIPTION
@aurambaj I sometimes run into intermittent test failures from ScreenshotServiceTest. The failures are coming from tests that query screenshots for specific repository sometimes return two more screenshots than expected. 

It only happens when I run all unit tests in webapp. If I only run ScreenshotServiceTest, it works fine.

I also noticed that it works if I comment out the test in ScreenshotWSTest or assign the name for the screenshot run. What happens if ScreenshotRun name is null? Do you know why it causes intermittent failures?