### PR TITLE
Create WS to save and retrieve Git blame information of text units

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/AssetTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/AssetTextUnit.java
@@ -3,16 +3,9 @@ package com.box.l10n.mojito.entity;
 import com.box.l10n.mojito.entity.security.user.User;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import java.util.Set;
-import javax.persistence.CollectionTable;
+import javax.persistence.*;
+
 import org.springframework.data.annotation.CreatedBy;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.ForeignKey;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 /**
  * @author wyau
@@ -64,7 +57,7 @@ public class AssetTextUnit extends AuditableEntity {
     @Column(name = "plural_form_other", length = Integer.MAX_VALUE)
     protected String pluralFormOther;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "asset_text_unit_usages",
             joinColumns = @JoinColumn(name = "asset_text_unit_id"), foreignKey = @ForeignKey(name = "FK__ASSET_TEXT_UNIT_USAGES__ASSET_TEXT_UNIT__ID"))
     private Set<String> usages;

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/GitBlame.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/GitBlame.java
@@ -1,0 +1,79 @@
+package com.box.l10n.mojito.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * @author jaurambault
+ */
+@Entity
+@Table(
+        name = "git_blame",
+        indexes = {
+                @Index(name = "I__GIT_BLAME__AUTHOR_EMAIL", columnList = "author_email"),
+                @Index(name = "UK__GIT_BLAME__TM_TEXT_UNIT_ID", columnList = "tm_text_unit_id", unique = true)
+        }
+)
+public class GitBlame extends AuditableEntity {
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "tm_text_unit_id", foreignKey = @ForeignKey(name = "FK__GIT_BLAME__TM_TEXT_UNIT__ID"))
+    private TMTextUnit tmTextUnit;
+
+    @Column(name = "author_email")
+    private String authorEmail;
+
+    @Column(name = "author_name")
+    private String authorName;
+
+    @Column(name = "commit_time")
+    private String commitTime;
+
+    @Column(name = "commit_name")
+    private String commitName;
+
+    public TMTextUnit getTmTextUnit() {
+        return tmTextUnit;
+    }
+
+    public void setTmTextUnit(TMTextUnit tmTextUnit) {
+        this.tmTextUnit = tmTextUnit;
+    }
+
+    public String getAuthorEmail() {
+        return authorEmail;
+    }
+
+    public void setAuthorEmail(String authorEmail) {
+        this.authorEmail = authorEmail;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public void setAuthorName(String authorName) {
+        this.authorName = authorName;
+    }
+
+    public String getCommitTime() {
+        return commitTime;
+    }
+
+    public void setCommitTime(String commitTime) {
+        this.commitTime = commitTime;
+    }
+
+    public String getCommitName() {
+        return commitName;
+    }
+
+    public void setCommitName(String commitName) {
+        this.commitName = commitName;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
@@ -3,10 +3,13 @@ package com.box.l10n.mojito.rest.textunit;
 import com.box.l10n.mojito.entity.AssetTextUnit;
 import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant;
+import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.service.NormalizationUtils;
 import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.IntegrityCheckException;
+import com.box.l10n.mojito.service.gitblame.GitBlameService;
+import com.box.l10n.mojito.service.gitblame.GitBlameWithUsage;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TMService;
@@ -22,6 +25,8 @@ import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.service.tm.search.UsedFilter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.commons.collections.CollectionUtils;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,11 +39,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.collections.CollectionUtils;
-import org.joda.time.DateTime;
 
 /**
  * Webservices for the workbench. Allows to search for TextUnits and
@@ -75,30 +79,33 @@ public class TextUnitWS {
     @Autowired
     TextUnitBatchImporterService textUnitBatchImporterService;
 
+    @Autowired
+    GitBlameService gitBlameService;
+
     /**
      * Gets the TextUnits that matches the search parameters.
-     *
+     * <p>
      * It uses a filter logic. The dataset will be filtered down as more
      * criteria are specified (search for specific locales, string
      * name|target|source, etc).
      *
-     * @param repositoryIds mandatory if repositoryNames not provided
-     * @param repositoryNames mandatory if repositoryIds not provided
-     * @param name optional
-     * @param source optional
-     * @param target optional
-     * @param assetPath optional
-     * @param pluralFormOther optional
-     * @param pluralFormFiltered optional
-     * @param searchType optional, default is EXACT match
-     * @param localeTags optional
-     * @param usedFilter optional
-     * @param statusFilter optional
-     * @param doNotTranslateFilter
+     * @param repositoryIds           mandatory if repositoryNames not provided
+     * @param repositoryNames         mandatory if repositoryIds not provided
+     * @param name                    optional
+     * @param source                  optional
+     * @param target                  optional
+     * @param assetPath               optional
+     * @param pluralFormOther         optional
+     * @param pluralFormFiltered      optional
+     * @param searchType              optional, default is EXACT match
+     * @param localeTags              optional
+     * @param usedFilter              optional
+     * @param statusFilter            optional
+     * @param doNotTranslateFilter    optional
      * @param tmTextUnitCreatedBefore optional
-     * @param tmTExtunitCreatedAfter optional
-     * @param limit optional, default 10
-     * @param offset optional, default 0
+     * @param tmTextUnitCreatedAfter  optional
+     * @param limit                   optional, default 10
+     * @param offset                  optional, default 0
      * @return the TextUnits that matches the search parameters
      * @throws InvalidTextUnitSearchParameterException
      */
@@ -119,11 +126,12 @@ public class TextUnitWS {
             @RequestParam(value = "statusFilter", required = false) StatusFilter statusFilter,
             @RequestParam(value = "doNotTranslateFilter", required = false) Boolean doNotTranslateFilter,
             @RequestParam(value = "tmTextUnitCreatedBefore", required = false) DateTime tmTextUnitCreatedBefore,
-            @RequestParam(value = "tmTextUnitCreatedAfter", required = false) DateTime tmTExtunitCreatedAfter,
+            @RequestParam(value = "tmTextUnitCreatedAfter", required = false) DateTime tmTextUnitCreatedAfter,
             @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
             @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset) throws InvalidTextUnitSearchParameterException {
 
-        TextUnitSearcherParameters textUnitSearcherParameters = queryParamsToTextUnitSearcherParameters(repositoryIds, repositoryNames, name, source, target, assetPath, pluralFormOther, pluralFormFiltered, searchType, localeTags, usedFilter, statusFilter, doNotTranslateFilter, tmTextUnitCreatedBefore, tmTExtunitCreatedAfter);
+        TextUnitSearcherParameters textUnitSearcherParameters = queryParamsToTextUnitSearcherParameters(repositoryIds,
+                repositoryNames, name, source, target, assetPath, pluralFormOther, pluralFormFiltered, searchType, localeTags, usedFilter, statusFilter, doNotTranslateFilter, tmTextUnitCreatedBefore, tmTextUnitCreatedAfter);
         textUnitSearcherParameters.setLimit(limit);
         textUnitSearcherParameters.setOffset(offset);
         List<TextUnitDTO> search = textUnitSearcher.search(textUnitSearcherParameters);
@@ -147,7 +155,7 @@ public class TextUnitWS {
             @RequestParam(value = "usedFilter", required = false) UsedFilter usedFilter,
             @RequestParam(value = "statusFilter", required = false) StatusFilter statusFilter,
             @RequestParam(value = "doNotTranslateFilter", required = false) Boolean doNotTranslateFilter,
-            @RequestParam(value = "tmTextUnitCreatedBefore", required = false) DateTime tmTextUnitCreatedBefore,
+            @RequestParam(value = "tmTextUnitCreatedBe                                                           fore", required = false) DateTime tmTextUnitCreatedBefore,
             @RequestParam(value = "tmTextUnitCreatedAfter", required = false) DateTime tmTExtunitCreatedAfter) throws InvalidTextUnitSearchParameterException {
 
         TextUnitSearcherParameters textUnitSearcherParameters = queryParamsToTextUnitSearcherParameters(
@@ -161,27 +169,25 @@ public class TextUnitWS {
     }
 
     TextUnitSearcherParameters queryParamsToTextUnitSearcherParameters(
-            ArrayList<Long> repositoryIds, 
-            ArrayList<String> repositoryNames, 
-            String name, 
-            String source, 
-            String target, 
-            String assetPath, 
+            ArrayList<Long> repositoryIds,
+            ArrayList<String> repositoryNames,
+            String name,
+            String source,
+            String target,
+            String assetPath,
             String pluralFormOther,
             boolean pluralFormFiltered,
             SearchType searchType,
-            ArrayList<String> localeTags, 
-            UsedFilter usedFilter, 
-            StatusFilter statusFilter, 
-            Boolean doNotTranslateFilter, 
-            DateTime tmTextUnitCreatedBefore, 
+            ArrayList<String> localeTags,
+            UsedFilter usedFilter,
+            StatusFilter statusFilter,
+            Boolean doNotTranslateFilter,
+            DateTime tmTextUnitCreatedBefore,
             DateTime tmTextUnitCreatedAfter) throws InvalidTextUnitSearchParameterException {
 
-        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+        checkRepositoryParameters(repositoryIds, repositoryNames);
 
-        if (CollectionUtils.isEmpty(repositoryIds) && CollectionUtils.isEmpty(repositoryNames)) {
-            throw new InvalidTextUnitSearchParameterException("Repository ids or names must be provided");
-        }
+        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
 
         textUnitSearcherParameters.setRepositoryIds(repositoryIds);
         textUnitSearcherParameters.setRepositoryNames(repositoryNames);
@@ -205,14 +211,14 @@ public class TextUnitWS {
 
     /**
      * Creates a TextUnit.
-     *
+     * <p>
      * Correspond to adding a new TMTextUnitVariant (new translation) in the
      * system and to create the TMTextUnitCurrentVariant (to make the new
      * translation current).
      *
      * @param textUnitDTO data used to update the TMTextUnitCurrentVariant. {@link TextUnitDTO#getTmTextUnitId()},
      *                    {@link TextUnitDTO#getLocaleId()}, {@link TextUnitDTO#getTarget()} are
-     * the only 3 fields that are used for the update.
+     *                    the only 3 fields that are used for the update.
      * @return the created TextUnit (contains the new translation with its id)
      */
     @Transactional
@@ -235,7 +241,7 @@ public class TextUnitWS {
 
     /**
      * Imports batch of text units.
-     *
+     * <p>
      * Note that the status of the text unit is not taken in account nor the included in localized file attribute. For
      * now, the integrity checker is always applied and is used to determine the
      * {@link TMTextUnitVariant.Status}. TODO later we want to change that to look at the status provided.
@@ -252,13 +258,14 @@ public class TextUnitWS {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
-            List<TextUnitDTO>  textUnitDTOs = objectMapper.readValue(string, new TypeReference<List<TextUnitDTO>>(){});
+            List<TextUnitDTO> textUnitDTOs = objectMapper.readValue(string, new TypeReference<List<TextUnitDTO>>() {
+            });
             importTextUnitsBatch.setTextUnits(textUnitDTOs);
-        }  catch (Exception e) {
+        } catch (Exception e) {
             logger.debug("can't convert to list, try new formatTextUnitBatchImporterServiceTest", e);
             try {
                 importTextUnitsBatch = objectMapper.readValue(string, ImportTextUnitsBatch.class);
-            }  catch (Exception e2) {
+            } catch (Exception e2) {
                 throw new IllegalArgumentException("Can't deserialize text unit batch", e2);
             }
         }
@@ -273,13 +280,13 @@ public class TextUnitWS {
 
     /**
      * Deletes the TextUnit.
-     *
+     * <p>
      * Corresponds to removing the TmTextUnitCurrentVariant entry. This doesn't
      * remove the translation from the system, it just removes it from being the
      * current translation.
      *
      * @param textUnitId TextUnit id (maps to
-     * {@link TMTextUnitCurrentVariant#id})
+     *                   {@link TMTextUnitCurrentVariant#id})
      */
     @Transactional
     @RequestMapping(method = RequestMethod.DELETE, value = "/api/textunits/{textUnitId}")
@@ -298,7 +305,7 @@ public class TextUnitWS {
 
     @RequestMapping(method = RequestMethod.GET, value = "/api/textunits/check")
     public TMTextUnitIntegrityCheckResult checkTMTextUnit(@RequestParam(value = "textUnitId") Long textUnitId,
-            @RequestParam(value = "contentToCheck") String contentToCheck) {
+                                                          @RequestParam(value = "contentToCheck") String contentToCheck) {
         logger.debug("Checking TextUnit, id: {}", textUnitId);
 
         TMTextUnitIntegrityCheckResult result = new TMTextUnitIntegrityCheckResult();
@@ -325,4 +332,67 @@ public class TextUnitWS {
         return assetTextUnit.getUsages();
     }
 
+    /**
+     * Gets the GitBlame information that matches the search parameters.
+     * <p>
+     * It uses a filter logic. The dataset will be filtered down as more
+     * criteria are specified.
+     *
+     * @param repositoryIds           mandatory if repositoryNames not provided
+     * @param repositoryNames         mandatory if repositoryIds not provided
+     * @param usedFilter              optional
+     * @param statusFilter            optional
+     * @param doNotTranslateFilter    optional
+     * @param limit                   optional, default 10
+     * @param offset                  optional, default 0
+     * @return the GitBlame that matches the search parameters
+     * @throws InvalidTextUnitSearchParameterException
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/api/textunits/gitBlameWithUsages")
+    public List<GitBlameWithUsage> getGitBlameWithUsages(@RequestParam(value = "repositoryIds[]", required = false) ArrayList<Long> repositoryIds,
+                                                         @RequestParam(value = "repositoryNames[]", required = false) ArrayList<String> repositoryNames,
+                                                         @RequestParam(value = "usedFilter", required = false) UsedFilter usedFilter,
+                                                         @RequestParam(value = "statusFilter", required = false) StatusFilter statusFilter,
+                                                         @RequestParam(value = "doNotTranslateFilter", required = false) Boolean doNotTranslateFilter,
+                                                         @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
+                                                         @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset) throws InvalidTextUnitSearchParameterException {
+
+        logger.debug("getGitBlameWithUsages");
+        checkRepositoryParameters(repositoryIds, repositoryNames);
+
+        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+        textUnitSearcherParameters.setRepositoryIds(repositoryIds);
+        textUnitSearcherParameters.setRepositoryNames(repositoryNames);
+        textUnitSearcherParameters.setUsedFilter(usedFilter);
+        textUnitSearcherParameters.setStatusFilter(statusFilter);
+        textUnitSearcherParameters.setDoNotTranslateFilter(doNotTranslateFilter);
+
+        textUnitSearcherParameters.setForRootLocale(true);
+        textUnitSearcherParameters.setPluralFormsFiltered(false);
+        textUnitSearcherParameters.setLimit(limit);
+        textUnitSearcherParameters.setOffset(offset);
+
+        List<GitBlameWithUsage> gitBlameWithUsages = gitBlameService.getGitBlameWithUsages(textUnitSearcherParameters);
+        return gitBlameWithUsages;
+    }
+
+    /**
+     * Save the GitBlame information of the text units.
+     *
+     * @param gitBlameWithUsages
+     * @return
+     */
+    @RequestMapping(method = RequestMethod.POST, value = "/api/textUnits/gitBlameWithUsagesBatch")
+    public PollableTask saveGitBlameWithUsages(@RequestBody List<GitBlameWithUsage> gitBlameWithUsages) {
+        logger.debug("saveGitBlameWithUsages");
+        PollableFuture pollableFuture = gitBlameService.saveGitBlameWithUsages(gitBlameWithUsages);
+        return pollableFuture.getPollableTask();
+    }
+
+    void checkRepositoryParameters(@RequestParam(value = "repositoryIds[]", required = false) ArrayList<Long> repositoryIds,
+                                   @RequestParam(value = "repositoryNames[]", required = false) ArrayList<String> repositoryNames) throws InvalidTextUnitSearchParameterException {
+        if (CollectionUtils.isEmpty(repositoryIds) && CollectionUtils.isEmpty(repositoryNames)) {
+            throw new InvalidTextUnitSearchParameterException("Repository ids or names must be provided");
+        }
+    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
@@ -39,8 +39,10 @@ public interface AssetTextUnitRepository extends JpaRepository<AssetTextUnit, Lo
 
     void deleteByAssetExtractionId(Long assetExtractionId);
 
-    public List<AssetTextUnit> findByAssetExtractionIdAndName(Long assetExtractionId, String name);
+    List<AssetTextUnit> findByAssetExtractionIdAndName(Long assetExtractionId, String name);
 
-    public List<AssetTextUnit> findByAssetExtractionIdOrderByNameAsc(Long assetExtractionId);
-    
+    List<AssetTextUnit> findByAssetExtractionIdOrderByNameAsc(Long assetExtractionId);
+
+    List<AssetTextUnit> findByIdIn(List<Long> assetTextUnitIds);
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameRepository.java
@@ -1,0 +1,15 @@
+package com.box.l10n.mojito.service.gitblame;
+
+import com.box.l10n.mojito.entity.GitBlame;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+import java.util.List;
+
+
+@RepositoryRestResource(exported = false)
+public interface GitBlameRepository extends JpaRepository<GitBlame, Long>, JpaSpecificationExecutor<GitBlame> {
+
+    List<GitBlame> findByTmTextUnitIdIn(List<Long> ids);
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameService.java
@@ -1,0 +1,214 @@
+package com.box.l10n.mojito.service.gitblame;
+
+import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.GitBlame;
+import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
+import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
+import com.box.l10n.mojito.service.pollableTask.Pollable;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
+import com.box.l10n.mojito.service.pollableTask.PollableFutureTaskResult;
+import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author jaurambault
+ */
+@Component
+public class GitBlameService {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(GitBlameService.class);
+
+    @Autowired
+    TextUnitSearcher textUnitSearcher;
+
+    @Autowired
+    AssetTextUnitRepository assetTextUnitRepository;
+
+    @Autowired
+    TMTextUnitRepository tmTextUnitRepository;
+
+    @Autowired
+    GitBlameRepository gitBlameRepository;
+
+    @Autowired
+    QuartzPollableTaskScheduler quartzPollableTaskScheduler;
+
+    /**
+     * Gets the {@link GitBlameWithUsage} information that matches the search parameters.
+     *
+     * Use the {@link TextUnitSearcher#search(TextUnitSearcherParameters)} to get the text units for which information
+     * is required.
+     *
+     * For each of text unit DTO that the searcher returns, get the usage and the git blame information
+     * to build the payload returned.
+     *
+     * Usually this method should be called for the root locale since we're looking for information
+     * on the source ({@link com.box.l10n.mojito.entity.TMTextUnit} but the search parameters can actuall be anything.
+     *
+     * @param textUnitSearcherParameters
+     * @return
+     */
+    public List<GitBlameWithUsage> getGitBlameWithUsages(TextUnitSearcherParameters textUnitSearcherParameters) {
+
+        logger.debug("Get the text units required for Git blame operation");
+        List<TextUnitDTO> textUnitDTOS = textUnitSearcher.search(textUnitSearcherParameters);
+
+        List<GitBlameWithUsage> gitBlameWithUsages = convertTextUnitsDTOsToGitBlameWithUsages(textUnitDTOS);
+
+        if (!gitBlameWithUsages.isEmpty()) {
+            enrichTextUnitsWithUsages(gitBlameWithUsages);
+            enrichTextUnitsWithGitBlame(gitBlameWithUsages);
+        }
+
+        return gitBlameWithUsages;
+    }
+
+    List<GitBlameWithUsage> convertTextUnitsDTOsToGitBlameWithUsages(List<TextUnitDTO> textUnitDTOS) {
+        logger.debug("Convert text unit dto to text unit with usages");
+
+        List<GitBlameWithUsage> gitBlameWithUsages = new ArrayList<>();
+
+        for (TextUnitDTO textUnitDTO : textUnitDTOS) {
+            GitBlameWithUsage gitBlameWithUsage = new GitBlameWithUsage();
+            gitBlameWithUsage.setTmTextUnitId(textUnitDTO.getTmTextUnitId());
+            gitBlameWithUsage.setAssetTextUnitId(textUnitDTO.getAssetTextUnitId());
+            gitBlameWithUsage.setTextUnitName(textUnitDTO.getName());
+            gitBlameWithUsage.setContent(textUnitDTO.getSource());
+            gitBlameWithUsage.setComment(textUnitDTO.getComment());
+            gitBlameWithUsages.add(gitBlameWithUsage);
+        }
+        return gitBlameWithUsages;
+    }
+
+    void enrichTextUnitsWithGitBlame(List<GitBlameWithUsage> gitBlameWithUsages) {
+        logger.debug("Enrich text unit with git info");
+        List<Long> tmTextUnitIds = new ArrayList<>();
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            tmTextUnitIds.add(gitBlameWithUsage.getTmTextUnitId());
+        }
+
+        logger.debug("Fetch the Git blame info");
+        Map<Long, GitBlame> currentGitBlameForTmTextUnitIds = getCurrentGitBlameForTmTextUnitIds(tmTextUnitIds);
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            gitBlameWithUsage.setGitBlame(currentGitBlameForTmTextUnitIds.get(gitBlameWithUsage.getTmTextUnitId()));
+        }
+    }
+
+    void enrichTextUnitsWithUsages(List<GitBlameWithUsage> gitBlameWithUsages) {
+        logger.debug("Enrich text unit with usages");
+        Map<Long, GitBlameWithUsage> assetTextUnitIdToGitBlameWithUsage = new HashMap<>();
+
+        for (GitBlameWithUsage textUnitWithUsage : gitBlameWithUsages) {
+            if (textUnitWithUsage.getAssetTextUnitId() != null) {
+                assetTextUnitIdToGitBlameWithUsage.put(textUnitWithUsage.getAssetTextUnitId(), textUnitWithUsage);
+            }
+        }
+
+        logger.debug("Fetch the asset text unit information");
+        List<AssetTextUnit> assetTextUnits = assetTextUnitRepository.findByIdIn(new ArrayList<Long>(assetTextUnitIdToGitBlameWithUsage.keySet()));
+
+        for (AssetTextUnit assetTextUnit : assetTextUnits) {
+            GitBlameWithUsage gitBlameWithUsage = assetTextUnitIdToGitBlameWithUsage.get(assetTextUnit.getId());
+            gitBlameWithUsage.setUsages(assetTextUnit.getUsages());
+        }
+    }
+
+    /**
+     * Save the GitBlame information for a list of {@link com.box.l10n.mojito.entity.TMTextUnit}. The text units
+     * are identified by the {@link GitBlame#getId()} and the git blame info come for the {@link GitBlameWithUsage#getGitBlame()}
+     * method.
+     *
+     * @param gitBlameWithUsages
+     * @return
+     */
+    @Pollable(async = true, message = "Save git blame information")
+    @Transactional
+    public PollableFuture saveGitBlameWithUsages(List<GitBlameWithUsage> gitBlameWithUsages) {
+
+        HashMap<Long, GitBlameWithUsage> gitBlameWithUsagesByTmTextUnitId = getGitBlameWithUsagesByTmTextUnitId(gitBlameWithUsages);
+
+        Map<Long, GitBlame> currentGitBlameForTmTextUnitIds = getCurrentGitBlameForTmTextUnitIds(new ArrayList<Long>(gitBlameWithUsagesByTmTextUnitId.keySet()));
+
+        for (Map.Entry<Long, GitBlameWithUsage> gitBlameWithUsageEntry : gitBlameWithUsagesByTmTextUnitId.entrySet()) {
+            Long tmTextUnitId = gitBlameWithUsageEntry.getKey();
+            GitBlameWithUsage gitBlameWithUsage = gitBlameWithUsageEntry.getValue();
+
+            GitBlame gitBlame = currentGitBlameForTmTextUnitIds.get(tmTextUnitId);
+
+            if (gitBlame == null) {
+                logger.debug("No GitBlame information for tmTextUnitId: {}", tmTextUnitId);
+                gitBlame = new GitBlame();
+                gitBlame.setTmTextUnit(tmTextUnitRepository.getOne(tmTextUnitId));
+            } else {
+                logger.debug("Found GitBlame for tmTextUnitId: {}, update", tmTextUnitId);
+            }
+
+            gitBlame.setAuthorEmail(gitBlameWithUsage.getGitBlame().getAuthorEmail());
+            gitBlame.setAuthorName(gitBlameWithUsage.getGitBlame().getAuthorName());
+            gitBlame.setCommitName(gitBlameWithUsage.getGitBlame().getCommitName());
+            gitBlame.setCommitTime(gitBlameWithUsage.getGitBlame().getCommitTime());
+
+            gitBlameRepository.save(gitBlame);
+        }
+
+        return new PollableFutureTaskResult();
+    }
+
+    Map<Long, GitBlame> getCurrentGitBlameForTmTextUnitIds(List<Long> tmTextUnitIds) {
+        Map<Long, GitBlame> gitBlameMap = new HashMap<>();
+
+        List<GitBlame> byTmTextUnitIdIn = gitBlameRepository.findByTmTextUnitIdIn(tmTextUnitIds);
+
+        for (GitBlame gitBlame : byTmTextUnitIdIn) {
+            gitBlameMap.put(gitBlame.getTmTextUnit().getId(), gitBlame);
+        }
+
+        return gitBlameMap;
+    }
+
+    /**
+     * Builds a map from {@link com.box.l10n.mojito.entity.TMTextUnit#id} id to {@link GitBlameWithUsage}, removing
+     * dupplicates entries for a given {@link com.box.l10n.mojito.entity.TMTextUnit#id}. The first entry in the list
+     * will be used to get the git information. This is useful in case where there are multiple entries for different
+     * plural forms. The client may end up sending the same information for each form but we just need to save it
+     * once since it is the same entity. We take arbitrarly the first entity.
+     *
+     * @param gitBlameWithUsages
+     * @return
+     */
+    HashMap<Long, GitBlameWithUsage> getGitBlameWithUsagesByTmTextUnitId(List<GitBlameWithUsage> gitBlameWithUsages) {
+
+        HashMap<Long, GitBlameWithUsage> tmTextUnitIdToGitBlameWithUsage = new HashMap();
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            Long tmTextUnitId = gitBlameWithUsage.getTmTextUnitId();
+
+            if (tmTextUnitIdToGitBlameWithUsage.get(tmTextUnitId) == null) {
+                tmTextUnitIdToGitBlameWithUsage.put(tmTextUnitId, gitBlameWithUsage);
+            } else {
+                logger.debug("Already provided, skip it for tmTextUnitId: {}", tmTextUnitId);
+            }
+        }
+
+        return tmTextUnitIdToGitBlameWithUsage;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameWithUsage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameWithUsage.java
@@ -1,0 +1,78 @@
+package com.box.l10n.mojito.service.gitblame;
+
+import com.box.l10n.mojito.entity.GitBlame;
+
+import java.util.Set;
+
+public class GitBlameWithUsage {
+
+    Set<String> usages;
+
+    String textUnitName;
+
+    Long tmTextUnitId;
+
+    Long assetTextUnitId;
+
+    String content;
+
+    String comment;
+
+    GitBlame gitBlame;
+
+    public Set<String> getUsages() {
+        return usages;
+    }
+
+    public void setUsages(Set<String> usages) {
+        this.usages = usages;
+    }
+
+    public String getTextUnitName() {
+        return textUnitName;
+    }
+
+    public void setTextUnitName(String textUnitName) {
+        this.textUnitName = textUnitName;
+    }
+
+    public Long getTmTextUnitId() {
+        return tmTextUnitId;
+    }
+
+    public void setTmTextUnitId(Long tmTextUnitId) {
+        this.tmTextUnitId = tmTextUnitId;
+    }
+
+    public Long getAssetTextUnitId() {
+        return assetTextUnitId;
+    }
+
+    public void setAssetTextUnitId(Long assetTextUnitId) {
+        this.assetTextUnitId = assetTextUnitId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public GitBlame getGitBlame() {
+        return gitBlame;
+    }
+
+    public void setGitBlame(GitBlame gitBlame) {
+        this.gitBlame = gitBlame;
+    }
+}

--- a/webapp/src/main/resources/db/migration/V30__Add_Git_Blame.sql
+++ b/webapp/src/main/resources/db/migration/V30__Add_Git_Blame.sql
@@ -1,0 +1,4 @@
+create table git_blame (id bigint not null auto_increment, created_date datetime, last_modified_date datetime, author_email varchar(255), author_name varchar(255), commit_name varchar(255), commit_time varchar(255), tm_text_unit_id bigint not null, primary key (id));
+alter table git_blame add constraint UK__GIT_BLAME__TM_TEXT_UNIT_ID unique (tm_text_unit_id);
+create index I__GIT_BLAME__AUTHOR_EMAIL on git_blame (author_email);
+alter table git_blame add constraint FK__GIT_BLAME__TM_TEXT_UNIT__ID foreign key (tm_text_unit_id) references tm_text_unit (id);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/gitblame/GitBlameServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/gitblame/GitBlameServiceTest.java
@@ -1,0 +1,127 @@
+package com.box.l10n.mojito.service.gitblame;
+
+import com.box.l10n.mojito.entity.GitBlame;
+import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import com.box.l10n.mojito.service.tm.TMTestData;
+import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
+import com.box.l10n.mojito.test.TestIdWatcher;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class GitBlameServiceTest extends ServiceTestBase {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(GitBlameServiceTest.class);
+
+    @Rule
+    public TestIdWatcher testIdWatcher = new TestIdWatcher();
+
+    @Autowired
+    GitBlameService gitBlameService;
+
+    @Test
+    public void getGitBlameWithUsages() throws Exception {
+        TMTestData tmTestData = new TMTestData(testIdWatcher);
+
+        TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+        textUnitSearcherParameters.setRepositoryIds(tmTestData.repository.getId());
+        textUnitSearcherParameters.setForRootLocale(true);
+        textUnitSearcherParameters.setPluralFormsFiltered(false);
+
+        List<GitBlameWithUsage> gitBlameWithUsages = gitBlameService.getGitBlameWithUsages(textUnitSearcherParameters);
+
+        Assert.assertEquals(3, gitBlameWithUsages.size());
+
+        logger.debug("Check none of the entry have git information");
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            logger.info(gitBlameWithUsage.getTextUnitName());
+            Assert.assertNull(gitBlameWithUsage.getGitBlame());
+        }
+
+        logger.debug("Save GitBlame");
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            GitBlame gitBlame = new GitBlame();
+            gitBlame.setAuthorName(gitBlameWithUsage.getTextUnitName() + "-author-name");
+            gitBlame.setAuthorEmail(gitBlameWithUsage.getTextUnitName() + "-author-email");
+            gitBlame.setCommitName(gitBlameWithUsage.getTextUnitName() + "-commit-name");
+            gitBlame.setCommitTime(gitBlameWithUsage.getTextUnitName() + "-commit-time");
+            gitBlameWithUsage.setGitBlame(gitBlame);
+        }
+
+        gitBlameService.saveGitBlameWithUsages(gitBlameWithUsages).get();
+        List<GitBlameWithUsage> gitBlameWithUsagesAfterSave = gitBlameService.getGitBlameWithUsages(textUnitSearcherParameters);
+
+        Assert.assertEquals(3, gitBlameWithUsages.size());
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            GitBlame gitBlame = gitBlameWithUsage.getGitBlame();
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-author-name", gitBlame.getAuthorName());
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-author-email", gitBlame.getAuthorEmail());
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-commit-name", gitBlame.getCommitName());
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-commit-time", gitBlame.getCommitTime());
+        }
+
+        logger.info("Update GitBlame");
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            GitBlame gitBlame = new GitBlame();
+            gitBlame.setAuthorName(gitBlameWithUsage.getTextUnitName() + "-author-name-up");
+            gitBlame.setAuthorEmail(gitBlameWithUsage.getTextUnitName() + "-author-email-up");
+            gitBlame.setCommitName(gitBlameWithUsage.getTextUnitName() + "-commit-name-up");
+            gitBlame.setCommitTime(gitBlameWithUsage.getTextUnitName() + "-commit-time-up");
+            gitBlameWithUsage.setGitBlame(gitBlame);
+        }
+
+        gitBlameService.saveGitBlameWithUsages(gitBlameWithUsages).get();
+
+        List<GitBlameWithUsage> gitBlameWithUsagesAfterUpdate = gitBlameService.getGitBlameWithUsages(textUnitSearcherParameters);
+
+        Assert.assertEquals(3, gitBlameWithUsagesAfterUpdate.size());
+
+        for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
+            GitBlame gitBlame = gitBlameWithUsage.getGitBlame();
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-author-name-up", gitBlame.getAuthorName());
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-author-email-up", gitBlame.getAuthorEmail());
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-commit-name-up", gitBlame.getCommitName());
+            Assert.assertEquals(gitBlameWithUsage.getTextUnitName() + "-commit-time-up", gitBlame.getCommitTime());
+        }
+    }
+
+    @Test
+    public void testgetGitBlameWithUsagesByTmTextUnitIdRemovesDupplicates() {
+
+        List<GitBlameWithUsage> gitBlameWithUsages = new ArrayList<>();
+
+        GitBlameWithUsage gitBlameWithUsage = new GitBlameWithUsage();
+        gitBlameWithUsage.setTmTextUnitId(1L);
+        gitBlameWithUsages.add(gitBlameWithUsage);
+
+        gitBlameWithUsage = new GitBlameWithUsage();
+        gitBlameWithUsage.setTmTextUnitId(2L);
+        gitBlameWithUsages.add(gitBlameWithUsage);
+
+        gitBlameWithUsage = new GitBlameWithUsage();
+        gitBlameWithUsage.setTmTextUnitId(1L);
+        gitBlameWithUsages.add(gitBlameWithUsage);
+
+        gitBlameWithUsage = new GitBlameWithUsage();
+        gitBlameWithUsage.setTmTextUnitId(3L);
+        gitBlameWithUsages.add(gitBlameWithUsage);
+
+        Set<Long> gitBlameWithUsagesByTmTextUnitId = gitBlameService.getGitBlameWithUsagesByTmTextUnitId(gitBlameWithUsages).keySet();
+        Assert.assertEquals(Sets.newHashSet(1L, 2L, 3L), gitBlameWithUsagesByTmTextUnitId);
+    }
+
+}


### PR DESCRIPTION
The git blame information is linked to the text unit (since it is coming linked to the source strings). It is up to the client to gather the git blame information. It can use the text unit "usages" information when available (eg. PO files).

- Add a new entity/table "GitBlame/git_blame" that is reference the TMTextUnit entity
- Create a service to retrieve git blame information. It takes TextUnitSearcher parameters that is used to find what text unit to be returned and then enrich them with the usage and git blame information
- Create a service to save the git blame information, it works in batch mode and the payload is basically what comes from the "get" service with the git information added to it.
- Add 2 WS matching: GET /api/textUnits/gitBlameWithUsages and POST /api/textUnits/gitBlameWithUsagesBatch