### PR TITLE
Fix DropServiceTest flakiness

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -48,6 +48,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -680,6 +684,10 @@ public class DropServiceTest extends ServiceTestBase {
 
     @Test(expected = PollableTaskExecutionException.class)
     public void testCancelDropException() throws DropExporterException, ExecutionException, InterruptedException, CancelDropException {
+
+        DropService dropServiceSpy = spy(dropService);
+        doReturn(false).when(dropServiceSpy).isDropBeingProcessed(any(Drop.class));
+
         TMTestData tmTestData = new TMTestData(testIdWatcher);
 
         Repository repository = tmTestData.repository;
@@ -695,10 +703,11 @@ public class DropServiceTest extends ServiceTestBase {
         checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 1);
 
         logger.debug("Create an initial drop for the repository");
-        PollableFuture<Drop> startExportProcess = dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
+        PollableFuture<Drop> startExportProcess = dropServiceSpy.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
 
         Drop drop = startExportProcess.get();
-        PollableFuture<Drop> dropPollableFuture = dropService.cancelDrop(drop.getId(), PollableTask.INJECT_CURRENT_TASK);
+
+        PollableFuture<Drop> dropPollableFuture = dropServiceSpy.cancelDrop(drop.getId(), PollableTask.INJECT_CURRENT_TASK);
         PollableTask cancelDropPollableTask = dropPollableFuture.getPollableTask();
 
         logger.debug("Wait for cancellation to finish");


### PR DESCRIPTION
The test is expected to fail because cancel is called right after the drop is started and I guess the goal of the test was to reach CancelException.
Since this depends on the timing it seems that the export sometimes ends before the cancelation happen so the test fails. Use a spy to force 'isDropBeingProcessed()'