### PR TITLE
Add OAuth2 login

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>spring-security-aspects</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security.oauth</groupId>
+            <artifactId>spring-security-oauth2</artifactId>
+            <version>2.0.15.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
         </dependency>

--- a/webapp/src/main/java/com/box/l10n/mojito/security/AuditorAwareImpl.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/AuditorAwareImpl.java
@@ -14,9 +14,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuditorAwareImpl implements AuditorAware<User> {
 
-    @Autowired
-    UserRepository userRepository;
-
     @Override
     public User getCurrentAuditor() {
 

--- a/webapp/src/main/java/com/box/l10n/mojito/security/MyUserInfoTokenServices.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/MyUserInfoTokenServices.java
@@ -1,0 +1,63 @@
+package com.box.l10n.mojito.security;
+
+import org.slf4j.Logger;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Map;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class MyUserInfoTokenServices extends UserInfoTokenServices {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(MyUserInfoTokenServices.class);
+
+    UserDetailsServiceImpl userDetailsService;
+
+    public MyUserInfoTokenServices(UserDetailsServiceImpl userDetailsService, String userInfoEndpointUrl, String clientId) {
+        super(userInfoEndpointUrl, clientId);
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected Object getPrincipal(Map<String, Object> map) {
+        logger.debug("Get principal: {}", map);
+
+        UserDetails userDetails = null;
+
+        map = getMapWithUserInfo(map);
+        String username = (String) super.getPrincipal(map);
+
+        try {
+            logger.debug("Load principal: {}", username);
+            userDetails = userDetailsService.loadUserByUsername(username);
+        } catch (UsernameNotFoundException e) {
+            String givenName = (String) map.get("first_name");
+            String surname = (String) map.get("last_name");
+            String commonName = (String) map.get("name");
+            logger.debug("username: {}, giveName:{}, surname: {}, commonName: {}", username, givenName, surname, commonName);
+            userDetails = userDetailsService.createBasicUser(username, givenName, surname, commonName);
+        }
+
+        return userDetails;
+    }
+
+    /**
+     * Some API retruns the user info directly and some have one level of indirection with a key name called "user".
+     * This function get the map that contains user information.
+     *
+     * @param map from the response
+     * @return the map that contains the user info
+     */
+    private Map<String, Object> getMapWithUserInfo(Map<String, Object> map) {
+        Object user = map.get("user");
+        if (user instanceof Map) {
+            map = (Map<String, Object>) user;
+        }
+        return map;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/OAuth2ClientWithEncdedRedirectUriConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/OAuth2ClientWithEncdedRedirectUriConfiguration.java
@@ -1,0 +1,87 @@
+package com.box.l10n.mojito.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientContextFilter;
+import org.springframework.security.oauth2.client.resource.UserRedirectRequiredException;
+import org.springframework.security.oauth2.config.annotation.web.configuration.OAuth2ClientConfiguration;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Use that configuration to percent encode the redirect_uri when fetching the authorization token.
+ *
+ * For standard usage this should not be used.
+ *
+ * This is needed when integrating with an OAuth server that is not 100% compliant with the standard and requires
+ * the redirect URI to be percent encoded.
+ */
+@ConditionalOnProperty(value = "l10n.security.oauth2.encodeRedirectUri", havingValue = "true")
+@Configuration
+public class OAuth2ClientWithEncdedRedirectUriConfiguration extends OAuth2ClientConfiguration {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(OAuth2ClientWithEncdedRedirectUriConfiguration.class);
+
+    @Override
+    public OAuth2ClientContextFilter oauth2ClientContextFilter() {
+        return new OAuth2ClientContextFilter() {
+
+            private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+            /**
+             * Same implementation as parent class but skip "redirect_uri" in the builder and at it at the end with
+             * percent encoding
+             */
+            @Override
+            protected void redirectUser(UserRedirectRequiredException e, HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+                logger.debug("redirectUser with percent encoded redirect_uri");
+
+                String redirectUri = e.getRedirectUri();
+                UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(redirectUri);
+                Map<String, String> requestParams = e.getRequestParams();
+
+                String redirectUriParam = null;
+
+                for (Map.Entry<String, String> param : requestParams.entrySet()) {
+                    if ("redirect_uri".equals(param.getKey())) {
+                        redirectUriParam = param.getValue();
+                    } else {
+                        builder.queryParam(param.getKey(), param.getValue());
+                    }
+                }
+
+                if (e.getStateKey() != null) {
+                    builder.queryParam("state", e.getStateKey());
+                }
+
+                String uri = builder.build().encode().toUriString();
+
+                if (redirectUriParam != null) {
+                    uri += "&redirect_uri=" + URLEncoder.encode(redirectUriParam, StandardCharsets.UTF_8.toString());
+                }
+
+                this.redirectStrategy.sendRedirect(request, response, uri);
+            }
+
+            @Override
+            public void setRedirectStrategy(RedirectStrategy redirectStrategy) {
+                super.setRedirectStrategy(redirectStrategy);
+                this.redirectStrategy = redirectStrategy;
+            }
+        };
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -3,21 +3,34 @@ package com.box.l10n.mojito.security;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.Http401AuthenticationEntryPoint;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
+import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.AdviceMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.ldap.LdapAuthenticationProviderConfigurer;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientContextFilter;
+import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.config.annotation.authentication.configurers.ldap.LdapAuthenticationProviderConfigurer;
-import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
-import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
+
+import javax.servlet.Filter;
 
 /**
  * @author wyau
@@ -25,6 +38,7 @@ import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHtt
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true, mode = AdviceMode.ASPECTJ)
+@EnableOAuth2Client
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     /**
@@ -45,6 +59,12 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     UserDetailsContextMapperImpl userDetailsContextMapperImpl;
 
     @Autowired
+    OAuth2ClientContext oauth2ClientContext;
+
+    @Value("${l10n.security.oauth2.enabled:false}")
+    boolean oauth2Enabled = false;
+
+    @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
 
         for (SecurityConfig.AuthenticationType authenticationType : securityConfig.getAuthenticationType()) {
@@ -61,16 +81,16 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             }
         }
     }
- 
+
     void configureActiveDirectory(AuthenticationManagerBuilder auth) throws Exception {
         logger.debug("Configuring in active directory authentication");
         ActiveDirectoryAuthenticationProviderConfigurer<AuthenticationManagerBuilder> activeDirectoryManagerConfigurer = new ActiveDirectoryAuthenticationProviderConfigurer<>();
-        
+
         activeDirectoryManagerConfigurer.domain(activeDirectoryConfig.getDomain());
         activeDirectoryManagerConfigurer.url(activeDirectoryConfig.getUrl());
         activeDirectoryManagerConfigurer.rootDn(activeDirectoryConfig.getRootDn());
         activeDirectoryManagerConfigurer.userServiceDetailMapper(userDetailsContextMapperImpl);
-        
+
         auth.apply(activeDirectoryManagerConfigurer);
     }
 
@@ -109,22 +129,67 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.headers().cacheControl().disable();
 
         http.csrf().ignoringAntMatchers("/shutdown", "/api/rotation");
+
         http.authorizeRequests()
-                // TODO (move img to images)
-                // TODO (move intl to js/intl)
-                .antMatchers("/intl/*", "/img/*", "/fonts/*", "/webjars/**", "/cli/**", "/health").permitAll()
-                .regexMatchers("/login\\?.*").permitAll()
+                .antMatchers("/intl/*", "/img/*", "/fonts/*", "/login/**", "/webjars/**", "/cli/**", "/health").permitAll()
                 .antMatchers("/shutdown", "/api/rotation").hasIpAddress("127.0.0.1").anyRequest().permitAll()
                 .anyRequest().fullyAuthenticated()
                 .and()
                 .formLogin()
-                .loginPage("/login").permitAll()
+                .loginPage("/login")
                 .successHandler(new ShowPageAuthenticationSuccessHandler())
                 .and()
                 .logout().logoutSuccessUrl("/login?logout").permitAll();
 
+        if (oauth2Enabled) {
+            http.addFilterBefore(oauthFilter(), BasicAuthenticationFilter.class);
+        }
+
         http.exceptionHandling().defaultAuthenticationEntryPointFor(new Http401AuthenticationEntryPoint("API_UNAUTHORIZED"), new AntPathRequestMatcher("/api/*"));
-        http.exceptionHandling().defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint("/login"), new AntPathRequestMatcher("/*"));
+        http.exceptionHandling().defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint(oauth2Enabled ? "/login/oauth" : "/login"), new AntPathRequestMatcher("/*"));
+    }
+
+    private Filter oauthFilter() {
+        logger.debug("Setup SSO filter for oauth");
+        OAuth2ClientAuthenticationProcessingFilter oauth2Filter = new OAuth2ClientAuthenticationProcessingFilter(
+                "/login/oauth");
+        OAuth2RestTemplate auth2RestTemplate = new OAuth2RestTemplate(oauth2(), oauth2ClientContext);
+
+        oauth2Filter.setRestTemplate(auth2RestTemplate);
+        UserInfoTokenServices tokenServices = new UserInfoTokenServices(
+                oauth2Resource().getUserInfoUri(),
+                oauth2().getClientId());
+        tokenServices.setRestTemplate(auth2RestTemplate);
+
+        oauth2Filter.setTokenServices(new MyUserInfoTokenServices(
+                getUserDetailsService(),
+                oauth2Resource().getUserInfoUri(),
+                oauth2().getClientId()));
+
+        return oauth2Filter;
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "l10n.security.oauth2.enabled", havingValue = "true")
+    @ConfigurationProperties("l10n.security.oauth2.client")
+    public AuthorizationCodeResourceDetails oauth2() {
+        return new AuthorizationCodeResourceDetails();
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "l10n.security.oauth2.enabled", havingValue = "true")
+    @ConfigurationProperties("l10n.security.oauth2.resource")
+    public ResourceServerProperties oauth2Resource() {
+        return new ResourceServerProperties();
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "l10n.security.oauth2.enabled", havingValue = "true")
+    public FilterRegistrationBean oauth2ClientFilterRegistration(OAuth2ClientContextFilter filter) {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(filter);
+        registration.setOrder(-100);
+        return registration;
     }
 
     @Bean

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -111,6 +111,16 @@ l10n.PluralFormUpdater=true
 #l10n.security.ldap.managerDn={ACTUAL_VALUE}
 #l10n.security.ldap.managerPassword={ACTUAL_VALUE}
 
+## OAuth2 example configuration
+#l10n.security.oauth2.enabled=true
+#l10n.security.oauth2.client.clientId={ACTUAL_VALUE}
+#l10n.security.oauth2.client.clientSecret={ACTUAL_VALUE}
+#l10n.security.oauth2.client.accessTokenUri=https://github.com/login/oauth/access_token
+#l10n.security.oauth2.client.userAuthorizationUri=https://github.com/login/oauth/authorize
+#l10n.security.oauth2.client.useCurrentUri=false
+#l10n.security.oauth2.client.preEstablishedRedirectUri=http://localhost:8080/login/oauth
+#l10n.security.oauth2.resource.userInfoUri=https://api.github.com/user
+
 # SLA Checker
 #l10n.slaChecker.incidentCheck.cron=0 0/5 * * * ?
 #l10n.slaChecker.email.to=mojito@mojito.global


### PR DESCRIPTION
It is added in adding to the previous form login to allow both to work at the same time. The OAuth entry point is /login/oauth (form login stays on /login)

- Configure with l10n.security.oauth2 settings, to enable it: l10n.security.oauth2.enabled and then provide classic spring settings
- OAuth2ClientWithEncdedRedirectUriConfiguration is a non standard configuration to support server that requires the "redirect_url" to be percent encoded. Shouldn't be use for standard usage
- MyUserInfoTokenServices converts the oauth user into a Mojito user. If the Mojito user doesn't exist it is created doing its best to extract first/last/common names.
- WebSecurityConfig contains most of the configuration