### PR TITLE
Fix GitBlameCommand.getGitRepository function

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameCommand.java
@@ -225,7 +225,7 @@ public class GitBlameCommand extends Command {
 
             try {
                 gitRepository = builder
-                        .findGitDir(new File(sourceDirectoryParam))
+                        .findGitDir(new File(commandDirectories.sourceDirectoryPath.toString()))
                         .readEnvironment()
                         .build();
             } catch (IOException ioe) {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameCommand.java
@@ -225,7 +225,7 @@ public class GitBlameCommand extends Command {
 
             try {
                 gitRepository = builder
-                        .findGitDir(new File(commandDirectories.sourceDirectoryPath.toString()))
+                        .findGitDir(new File(commandDirectories.getSourceDirectoryPath().toString()))
                         .readEnvironment()
                         .build();
             } catch (IOException ioe) {

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GitBlameCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GitBlameCommandTest.java
@@ -168,7 +168,8 @@ public class GitBlameCommandTest extends CLITestBase {
         String filepath = sourceDirectory.getAbsolutePath();
 
         GitBlameCommand gitBlameCommand = new GitBlameCommand();
-        gitBlameCommand.sourceDirectoryParam = filepath;
+        gitBlameCommand.commandDirectories = new CommandDirectories(filepath);
+
 
         org.eclipse.jgit.lib.Repository repository = gitBlameCommand.getGitRepository();
 
@@ -182,7 +183,8 @@ public class GitBlameCommandTest extends CLITestBase {
         String filepath = sourceDirectory.getAbsolutePath();
 
         GitBlameCommand gitBlameCommand = new GitBlameCommand();
-        gitBlameCommand.sourceDirectoryParam = filepath;
+        gitBlameCommand.commandDirectories = new CommandDirectories(filepath);
+
         org.eclipse.jgit.lib.Repository repository = gitBlameCommand.getGitRepository();
         String relativePath = repository.getDirectory().toPath().getParent().relativize(sourceDirectory.toPath()).toString();
         relativePath = relativePath + "/res/values/strings.xml";


### PR DESCRIPTION
Fix NullPointerException thrown when -s parameter is not specified