### PR TITLE
Improve GitBlame performance and fix some hedge cases

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/LineMissingException.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/LineMissingException.java
@@ -1,0 +1,7 @@
+package com.box.l10n.mojito.cli.command;
+
+public class LineMissingException extends Exception {
+    public LineMissingException(String message) {
+        super(message);
+    }
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/GitBlameWithUsageClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/GitBlameWithUsageClient.java
@@ -27,7 +27,7 @@ public class GitBlameWithUsageClient extends BaseClient {
     }
 
     public List<GitBlameWithUsage> getGitBlameWithUsages(Long repositoryId, Integer offset, Integer batchSize) {
-
+        logger.debug("getGitBlameWithUsages");
         Map<String, String> filterParams = new HashMap<>();
 
         filterParams.put("repositoryIds[]", repositoryId.toString());
@@ -40,9 +40,10 @@ public class GitBlameWithUsageClient extends BaseClient {
                 filterParams);
     }
 
-    public PollableTask saveGitInfoForTextUnits(List<GitBlameWithUsage> gitInfoForTextUnits) {
+    public PollableTask saveGitBlameWithUsages(List<GitBlameWithUsage> gitBlameWithUsages) {
+        logger.debug("saveGitBlameWithUsages");
         return authenticatedRestTemplate.postForObject(getBasePathForEntity() + "/gitBlameWithUsagesBatch",
-                gitInfoForTextUnits, PollableTask.class
+                gitBlameWithUsages, PollableTask.class
         );
 
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/GitBlame.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/GitBlame.java
@@ -1,7 +1,11 @@
 package com.box.l10n.mojito.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
@@ -23,6 +27,7 @@ public class GitBlame extends AuditableEntity {
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "tm_text_unit_id", foreignKey = @ForeignKey(name = "FK__GIT_BLAME__TM_TEXT_UNIT__ID"))
+    @JsonIgnore
     private TMTextUnit tmTextUnit;
 
     @Column(name = "author_email")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/gitblame/GitBlameService.java
@@ -111,6 +111,7 @@ public class GitBlameService {
         for (GitBlameWithUsage gitBlameWithUsage : gitBlameWithUsages) {
             gitBlameWithUsage.setGitBlame(currentGitBlameForTmTextUnitIds.get(gitBlameWithUsage.getTmTextUnitId()));
         }
+        logger.debug("End enrich text unit with git info");
     }
 
     void enrichTextUnitsWithUsages(List<GitBlameWithUsage> gitBlameWithUsages) {
@@ -130,6 +131,8 @@ public class GitBlameService {
             GitBlameWithUsage gitBlameWithUsage = assetTextUnitIdToGitBlameWithUsage.get(assetTextUnit.getId());
             gitBlameWithUsage.setUsages(assetTextUnit.getUsages());
         }
+
+        logger.debug("End enrich text unit with usages");
     }
 
     /**
@@ -183,8 +186,14 @@ public class GitBlameService {
 
         List<GitBlame> byTmTextUnitIdIn = gitBlameRepository.findByTmTextUnitIdIn(tmTextUnitIds);
 
+        int i = 0;
         for (GitBlame gitBlame : byTmTextUnitIdIn) {
-            gitBlameMap.put(gitBlame.getTmTextUnit().getId(), gitBlame);
+            try {
+                gitBlameMap.put(gitBlame.getTmTextUnit().getId(), gitBlame);
+                i++;
+            } catch(Exception e) {
+                logger.error("getCurrentGitBlameForTmTextUnitIds, id: {} after: {}", gitBlame.getId(), i);
+            }
         }
 
         return gitBlameMap;


### PR DESCRIPTION
- The command was to process big project. Added cache and improved the WS payload to speedup the overall process
- Handle error for symlinks or files that are moved/removed
- Show information about which batch is being process to see the evolution of the task
- Only process entries where there is no blame information yet (can add an option later to force update those record but not sure yet about the need for it)