### PR TITLE
Add front-end for git-blame information in Workbench

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/react/OpengrokConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/OpengrokConfig.java
@@ -14,6 +14,8 @@ public class OpengrokConfig {
 
     String server;
 
+    String extractedFilePrefix;
+
     Map<String, String> repositoryMapping = new HashMap<>();
 
     public String getServer() {
@@ -22,6 +24,14 @@ public class OpengrokConfig {
 
     public void setServer(String server) {
         this.server = server;
+    }
+
+    public String getExtractedFilePrefix() {
+        return extractedFilePrefix;
+    }
+
+    public void setExtractedFilePrefix(String extractedFilePrefix) {
+        this.extractedFilePrefix = extractedFilePrefix;
     }
 
     public Map<String, String> getRepositoryMapping() {

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -527,3 +527,66 @@ screenshots.reviewModal.needsReview=Needs Review
 # Message shown in the modal header to ask the user if he to open Mojito the
 # translation he just clicked on
 ict.modal.title=Open Mojito to edit or review the translation?
+
+# Label for button to open git-blame modal
+workbench.gitBlameModal.info=Text info
+
+# Label for text unit information in git-blame modal
+textUnit.gitBlameModal.textUnit=Text unit
+
+# Label for text unit's repository name in git-blame modal
+textUnit.gitBlameModal.repository=Repository
+
+# Label for text unit's asset path in git-blame modal
+textUnit.gitBlameModal.assetPath=AssetPath
+
+# Label for text unit's source in git-blame modal
+textUnit.gitBlameModal.source=Source
+
+# Label for text unit's target in git-blame modal
+textUnit.gitBlameModal.target=Target
+
+# Label for text unit's target locale in git-blame modal
+textUnit.gitBlameModal.locale=Locale
+
+# Label for text unit's created date and time in git-blame modal. This is when the text unit was originally pushed into the repo
+textUnit.gitBlameModal.created=Created
+
+# Label for text unit's translated date and time in git-blame modal. This is when the text unit has been translated
+textUnit.gitBlameModal.translated=Translated
+
+# Label for text unit's plural form in git-blame modal
+textUnit.gitBlameModal.pluralForm=PluralForm
+
+# Label for text unit's plural other form in git-blame modal
+textUnit.gitBlameModal.pluralFormOther=PluralFormOther
+
+# Label for text unit's comment in git-blame modal
+textUnit.gitBlameModal.comment=Comment
+
+# Label for text unit's target comment in git-blame modal
+textUnit.gitBlameModal.targetComment=TargetComment
+
+# Label for git blame information in git-blame modal
+textUnit.gitBlameModal.gitBlame=Git blame
+
+# Label for code author name in git-blame modal
+textUnit.gitBlameModal.authorName=Author
+
+# Label for code author email in git-blame modal
+textUnit.gitBlameModal.authorEmail=Email
+
+# Label for code commit name in git-blame modal
+textUnit.gitBlameModal.commit=Commit
+
+# Label for code commit date in git-blame modal
+textUnit.gitBlameModal.commitDate=Commit date
+
+# Label for code location in git-blame modal
+textUnit.gitBlameModal.location=Location
+
+# Label for additional debug information in git-blame modal
+textUnit.gitBlameModal.debug=Debug
+
+# Button to close for git-blame modal
+textUnit.gitBlameModal.close=Close

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -586,7 +586,7 @@ textUnit.gitBlameModal.commitDate=Commit date
 textUnit.gitBlameModal.location=Location
 
 # Label for additional debug information in git-blame modal
-textUnit.gitBlameModal.debug=Debug
+textUnit.gitBlameModal.more=More
 
 # Button to close for git-blame modal
 textUnit.gitBlameModal.close=Close

--- a/webapp/src/main/resources/public/js/actions/workbench/GitBlameActions.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/GitBlameActions.js
@@ -1,0 +1,15 @@
+import alt from "../../alt";
+
+class GitBlameActions {
+
+    constructor() {
+        this.generateActions(
+            "openWithTextUnit",
+            "getGitBlameInfoSuccess",
+            "getGitBlameInfoError",
+            "close"
+        );
+    }
+}
+
+export default alt.createActions(GitBlameActions);

--- a/webapp/src/main/resources/public/js/actions/workbench/SearchDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/SearchDataSource.js
@@ -50,7 +50,7 @@ const SearchDataSource = {
             }
 
             if (!searchParams.translate && !searchParams.doNotTranslate) {
-                returnEmptry = true;
+                returnEmpty = true;
             } else if (searchParams.translate && !searchParams.doNotTranslate) {
                 textUnitSearcherParameters.doNotTranslateFilter(false);
             } else if (!searchParams.translate && searchParams.doNotTranslate) {

--- a/webapp/src/main/resources/public/js/actions/workbench/TextUnitDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/TextUnitDataSource.js
@@ -2,6 +2,7 @@ import Error from "../../utils/Error";
 import TextUnitError from "../../utils/TextUnitError";
 import TextUnitClient from "../../sdk/TextUnitClient";
 import WorkbenchActions from "./WorkbenchActions";
+import GitBlameActions from "./GitBlameActions";
 
 const TextUnitDataSource = {
     performSaveTextUnit: {
@@ -51,6 +52,14 @@ const TextUnitDataSource = {
         },
         success: WorkbenchActions.saveVirtualAssetTextUnitSuccess,
         error: WorkbenchActions.saveVirtualAssetTextUnitError
+    },
+
+    getGitBlameInfo: {
+        remote(gitBlameStoreState, textUnit) {
+            return TextUnitClient.getGitBlameInfo(textUnit);
+        },
+        success: GitBlameActions.getGitBlameInfoSuccess,
+        error: GitBlameActions.getGitBlameInfoError
     }
 };
 

--- a/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
@@ -173,19 +173,18 @@ let GitBlameInfoModal = React.createClass({
         if (textUnit == null || usages == null)
             return null;
 
+        if (usages.length === 0) {
+            usages = [textUnit.getAssetPath()];
+        }
+
         if (this.props.appConfig.opengrok.server === null)
             return this.getUsages().join('\n');
 
         let repo = textUnit.getRepositoryName();
 
-        if (usages.length === 0) {
-            if (repo === "android")
-                usages = [textUnit.getAssetPath()];
-            else
-                return null;
-        }
         let links = [];
         for (let usage of usages) {
+            usage = usage.replace(this.props.appConfig.opengrok.extractedFilePrefix, "");
             let link = this.props.appConfig.opengrok.server;
             for (let repoKey in this.props.appConfig.opengrok.repositoryMapping){
                 if (repo === repoKey) {

--- a/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
@@ -1,0 +1,255 @@
+import PropTypes from 'prop-types';
+import React from "react";
+import {FormattedMessage, injectIntl} from "react-intl";
+import {Button, Panel, Accordion, Modal} from "react-bootstrap";
+import {withAppConfig} from "../../utils/AppConfig";
+
+
+let GitBlameInfoModal = React.createClass({
+
+    propTypes() {
+        return {
+            "show": PropTypes.bool.isRequired,
+            "textUnit": PropTypes.object.isRequired,
+            "gitBlameWithUsage": PropTypes.object.isRequired
+        };
+    },
+
+    getDefaultProps() {
+        return {
+            "show": false,
+            "textUnit": null,
+            "gitBlameWithUsage": null
+        };
+    },
+
+    /**
+     * @returns {string} The title of the modal is the name of the text unit
+     */
+    getTitle() {
+        if (this.props.textUnit == null)
+            return "";
+        return this.props.textUnit.getName();
+    },
+
+    /**
+     * @param label  The label for the data to display
+     * @param data   The data to display
+     * @returns {*}  The row of label:data to display in the modal
+     */
+    displayInfo(label, data) {
+        let gitBlameClass = "";
+        if (data == null) {
+            gitBlameClass = " git-blame-unused";
+            data = "-";
+        }
+
+        return (
+            <div className={"row git-blame"}>
+                <label className={"col-sm-4 git-blame-label"}>{label}</label>
+                <div className={"col-sm-8 git-blame-info" + gitBlameClass}>{data}</div>
+            </div>
+        );
+    },
+
+    /**
+     * @param labelId  The labelId for the formatted message
+     * @param data     The data to display
+     * @returns {*}    The row of label:data to display in the modal
+     */
+    displayInfoWithId(labelId, data) {
+        return this.displayInfo(this.props.intl.formatMessage({ id: labelId }), data);
+    },
+
+    /**
+     * @returns {*} Generates the content for the text unit information section
+     */
+    renderTextUnitInfo() {
+        if (this.props.textUnit === null)
+            return "";
+        return (
+            <div>
+                {this.displayInfoWithId("textUnit.gitBlameModal.repository", this.props.textUnit.getRepositoryName())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.assetPath", this.props.textUnit.getAssetPath())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.source", this.props.textUnit.getSource())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.target", this.props.textUnit.getTarget())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.locale", this.props.textUnit.getTargetLocale())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.created", this.convertDateTime(this.props.textUnit.getTmTextUnitCreatedDate()))}
+                {this.displayInfoWithId("textUnit.gitBlameModal.translated", this.convertDateTime(this.props.textUnit.getCreatedDate()))}
+                {this.displayInfoWithId("textUnit.gitBlameModal.pluralForm", this.props.textUnit.getPluralForm())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.pluralFormOther", this.props.textUnit.getPluralFormOther())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.comment", this.props.textUnit.getComment())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.targetComment", this.props.textUnit.getTargetComment())}
+            </div>);
+    },
+
+    /**
+     * @returns {*} Generates the content for the git blame information section
+     */
+    renderGitBlameInfo() {
+        return (
+            <div>
+                {this.displayInfoWithId("textUnit.gitBlameModal.authorName", this.getAuthorName())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.authorEmail", this.getAuthorEmail())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.commit", this.getCommitName())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.commitDate", this.convertDateTime(this.getCommitTime()))}
+                {this.displayInfoWithId("textUnit.gitBlameModal.location", this.getOpenGrokLocation())}
+            </div>
+        )
+    },
+
+    /**
+     * @returns {*} Generates the content for the debug section (additional text unit information)
+     */
+    renderDebugInfo() {
+        if (this.props.textUnit === null)
+            return "";
+        return (
+            <div className="panel-body">
+                {this.displayInfo("TmTextUnitId", this.props.textUnit.getTmTextUnitId())}
+                {this.displayInfo("TmTextUnitVariantId", this.props.textUnit.getTmTextUnitVariantId())}
+                {this.displayInfo("TmTextUnitCurrentVariantId", this.props.textUnit.getTmTextUnitCurrentVariantId())}
+                {this.displayInfo("AssetTextUnitId", this.props.textUnit.getAssetId())}
+                {this.displayInfo("LastSuccessfulAsset\nExtractionId", this.props.textUnit.getLastSuccessfulAssetExtractionId())}
+                {this.displayInfo("AssetExtractionId", this.props.textUnit.getAssetExtractionId())}
+            </div>
+        );
+    },
+
+    /**
+     * @param property The property of the GitBlame object to retrieve
+     * @returns {*}    The value of the given property of the GitBlame object
+     */
+    getGitBlameProperty(property) {
+        if (this.props.gitBlameWithUsage == null || this.props.gitBlameWithUsage["gitBlame"] == null)
+            return null;
+        return this.props.gitBlameWithUsage["gitBlame"][property];
+    },
+
+    /**
+     * @returns {str} The code author of the current text unit
+     */
+    getAuthorName() {
+        return this.getGitBlameProperty("authorName");
+    },
+
+    /**
+     * @returns {str} The email of the code author of the current text unit
+     */
+    getAuthorEmail() {
+        return this.getGitBlameProperty("authorEmail");
+    },
+
+    /**
+     * @returns {str} The commit name of the current text unit
+     */
+    getCommitName() {
+        return this.getGitBlameProperty("commitName");
+    },
+
+    /**
+     * @returns {int} The commit time (in ms) of the current text unit
+     */
+    getCommitTime() {
+        return parseInt(this.getGitBlameProperty("commitTime")) * 1000;
+    },
+
+    /**
+     * @returns {*} A list of usages of the current text unit, or null if there are none
+     */
+    getUsages() {
+        if (this.props.gitBlameWithUsage == null || this.props.gitBlameWithUsage["usages"] == null)
+            return null;
+        return this.props.gitBlameWithUsage["usages"];
+    },
+
+    /**
+     * @returns {*} Converts the list of usages of the text unit to a list of links to given text unit
+     */
+    getOpenGrokLocation() {
+        let textUnit = this.props.textUnit;
+        let usages = this.getUsages();
+
+        if (textUnit == null || usages == null)
+            return null;
+
+        if (this.props.appConfig.opengrok.server === null)
+            return this.getUsages().join('\n');
+
+        let repo = textUnit.getRepositoryName();
+
+        if (usages.length === 0) {
+            if (repo === "android")
+                usages = [textUnit.getAssetPath()];
+            else
+                return null;
+        }
+        let links = [];
+        for (let usage of usages) {
+            let link = this.props.appConfig.opengrok.server;
+            for (let repoKey in this.props.appConfig.opengrok.repositoryMapping){
+                if (repo === repoKey) {
+                    link += this.props.appConfig.opengrok.repositoryMapping[repoKey];
+                    break;
+                }
+            }
+            link += usage.replace(":", "#");
+            links.push(<div key={usage}><a href={link}>{usage}</a></div>);
+        }
+
+        return links;
+    },
+
+    /**
+     * @param date   An integer representing a datetime
+     * @returns {*}  Human readable version of the given datetime
+     *
+     */
+    convertDateTime(date) {
+        if (date === null || isNaN(date))
+            return null;
+
+        return (this.props.intl.formatDate(date) + ", " + this.props.intl.formatTime(date));
+    },
+
+    /**
+     * Closes the modal and calls the parent action handler to mark the modal as closed
+     */
+    closeModal() {
+        this.props.onCloseModal();
+    },
+
+    render() {
+        return (
+            <Modal show={this.props.show} onHide={this.closeModal}>
+                <Modal.Header closeButton>
+                    <Modal.Title>{this.getTitle()}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className={"row"}>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.gitBlameModal.textUnit"}/></h4></div>
+                    </div>
+                    {this.renderTextUnitInfo()}
+                    <hr />
+                    <div className={"row"}>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.gitBlameModal.gitBlame"}/></h4></div>
+                        <div className={"col-sm-8"}>{this.props.loading ? (<span className="glyphicon glyphicon-refresh spinning" />) : ""}</div>
+                    </div>
+                    {this.renderGitBlameInfo()}
+                    <hr />
+                    <div className={"row"}>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.gitBlameModal.debug"}/></h4></div>
+                    </div>
+                    {this.renderDebugInfo()}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button bsStyle="primary" onClick={this.closeModal}>
+                        <FormattedMessage id={"textUnit.gitBlameModal.close"}/>
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+    );
+    }
+});
+
+export default withAppConfig(injectIntl(GitBlameInfoModal));

--- a/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from "react";
 import {FormattedMessage, injectIntl} from "react-intl";
-import {Button, Panel, Accordion, Modal} from "react-bootstrap";
+import {Button, Modal} from "react-bootstrap";
 import {withAppConfig} from "../../utils/AppConfig";
 
 
@@ -27,9 +27,7 @@ let GitBlameInfoModal = React.createClass({
      * @returns {string} The title of the modal is the name of the text unit
      */
     getTitle() {
-        if (this.props.textUnit == null)
-            return "";
-        return this.props.textUnit.getName();
+        return this.props.textUnit == null ? "" : this.props.textUnit.getName();
     },
 
     /**
@@ -65,22 +63,22 @@ let GitBlameInfoModal = React.createClass({
      * @returns {*} Generates the content for the text unit information section
      */
     renderTextUnitInfo() {
-        if (this.props.textUnit === null)
-            return "";
-        return (
-            <div>
-                {this.displayInfoWithId("textUnit.gitBlameModal.repository", this.props.textUnit.getRepositoryName())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.assetPath", this.props.textUnit.getAssetPath())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.source", this.props.textUnit.getSource())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.target", this.props.textUnit.getTarget())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.locale", this.props.textUnit.getTargetLocale())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.created", this.convertDateTime(this.props.textUnit.getTmTextUnitCreatedDate()))}
-                {this.displayInfoWithId("textUnit.gitBlameModal.translated", this.convertDateTime(this.props.textUnit.getCreatedDate()))}
-                {this.displayInfoWithId("textUnit.gitBlameModal.pluralForm", this.props.textUnit.getPluralForm())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.pluralFormOther", this.props.textUnit.getPluralFormOther())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.comment", this.props.textUnit.getComment())}
-                {this.displayInfoWithId("textUnit.gitBlameModal.targetComment", this.props.textUnit.getTargetComment())}
-            </div>);
+        return this.props.textUnit === null ? "" :
+            (
+                <div>
+                    {this.displayInfoWithId("textUnit.gitBlameModal.repository", this.props.textUnit.getRepositoryName())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.assetPath", this.props.textUnit.getAssetPath())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.source", this.props.textUnit.getSource())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.target", this.props.textUnit.getTarget())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.locale", this.props.textUnit.getTargetLocale())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.created", this.convertDateTime(this.props.textUnit.getTmTextUnitCreatedDate()))}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.translated", this.convertDateTime(this.props.textUnit.getCreatedDate()))}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.pluralForm", this.props.textUnit.getPluralForm())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.pluralFormOther", this.props.textUnit.getPluralFormOther())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.comment", this.props.textUnit.getComment())}
+                    {this.displayInfoWithId("textUnit.gitBlameModal.targetComment", this.props.textUnit.getTargetComment())}
+                </div>
+            );
     },
 
     /**
@@ -93,7 +91,7 @@ let GitBlameInfoModal = React.createClass({
                 {this.displayInfoWithId("textUnit.gitBlameModal.authorEmail", this.getAuthorEmail())}
                 {this.displayInfoWithId("textUnit.gitBlameModal.commit", this.getCommitName())}
                 {this.displayInfoWithId("textUnit.gitBlameModal.commitDate", this.convertDateTime(this.getCommitTime()))}
-                {this.displayInfoWithId("textUnit.gitBlameModal.location", this.getOpenGrokLocation())}
+                {this.displayInfoWithId("textUnit.gitBlameModal.location", this.getLocation())}
             </div>
         )
     },
@@ -102,18 +100,17 @@ let GitBlameInfoModal = React.createClass({
      * @returns {*} Generates the content for the debug section (additional text unit information)
      */
     renderDebugInfo() {
-        if (this.props.textUnit === null)
-            return "";
-        return (
-            <div className="panel-body">
-                {this.displayInfo("TmTextUnitId", this.props.textUnit.getTmTextUnitId())}
-                {this.displayInfo("TmTextUnitVariantId", this.props.textUnit.getTmTextUnitVariantId())}
-                {this.displayInfo("TmTextUnitCurrentVariantId", this.props.textUnit.getTmTextUnitCurrentVariantId())}
-                {this.displayInfo("AssetTextUnitId", this.props.textUnit.getAssetId())}
-                {this.displayInfo("LastSuccessfulAsset\nExtractionId", this.props.textUnit.getLastSuccessfulAssetExtractionId())}
-                {this.displayInfo("AssetExtractionId", this.props.textUnit.getAssetExtractionId())}
-            </div>
-        );
+        return this.props.textUnit === null ? "" :
+             (
+                <div className="panel-body">
+                    {this.displayInfo("TmTextUnitId", this.props.textUnit.getTmTextUnitId())}
+                    {this.displayInfo("TmTextUnitVariantId", this.props.textUnit.getTmTextUnitVariantId())}
+                    {this.displayInfo("TmTextUnitCurrentVariantId", this.props.textUnit.getTmTextUnitCurrentVariantId())}
+                    {this.displayInfo("AssetTextUnitId", this.props.textUnit.getAssetId())}
+                    {this.displayInfo("LastSuccessfulAsset\nExtractionId", this.props.textUnit.getLastSuccessfulAssetExtractionId())}
+                    {this.displayInfo("AssetExtractionId", this.props.textUnit.getAssetExtractionId())}
+                </div>
+            );
     },
 
     /**
@@ -121,9 +118,10 @@ let GitBlameInfoModal = React.createClass({
      * @returns {*}    The value of the given property of the GitBlame object
      */
     getGitBlameProperty(property) {
-        if (this.props.gitBlameWithUsage == null || this.props.gitBlameWithUsage["gitBlame"] == null)
-            return null;
-        return this.props.gitBlameWithUsage["gitBlame"][property];
+        let value = null;
+        if (this.props.gitBlameWithUsage != null && this.props.gitBlameWithUsage["gitBlame"] != null)
+            value = this.props.gitBlameWithUsage["gitBlame"][property];
+        return value;
     },
 
     /**
@@ -166,22 +164,29 @@ let GitBlameInfoModal = React.createClass({
     /**
      * @returns {*} Converts the list of usages of the text unit to a list of links to given text unit
      */
-    getOpenGrokLocation() {
+    getLocation() {
         let textUnit = this.props.textUnit;
         let usages = this.getUsages();
 
-        if (textUnit == null || usages == null)
+        if (textUnit == null || usages == null) {
             return null;
+        }
 
         if (usages.length === 0) {
             usages = [textUnit.getAssetPath()];
         }
 
-        if (this.props.appConfig.opengrok.server === null)
-            return this.getUsages().join('\n');
+        let links = usages.join('\n');
 
-        let repo = textUnit.getRepositoryName();
+        if (this.props.appConfig.opengrok.server !== null) {
+            links = this.getOpenGrokLinks(usages);
+        }
 
+        return links;
+    },
+
+    getOpenGrokLinks(usages) {
+        let repo = this.props.textUnit.getRepositoryName();
         let links = [];
         for (let usage of usages) {
             usage = usage.replace(this.props.appConfig.opengrok.extractedFilePrefix, "");
@@ -195,7 +200,6 @@ let GitBlameInfoModal = React.createClass({
             link += usage.replace(":", "#");
             links.push(<div key={usage}><a href={link}>{usage}</a></div>);
         }
-
         return links;
     },
 
@@ -205,10 +209,13 @@ let GitBlameInfoModal = React.createClass({
      *
      */
     convertDateTime(date) {
-        if (date === null || isNaN(date))
+        if (date === null || isNaN(date)) {
             return null;
+        }
 
-        return (this.props.intl.formatDate(date) + ", " + this.props.intl.formatTime(date));
+        let options = {year: 'numeric', month: 'numeric', day: 'numeric',
+            hour: 'numeric', minute: 'numeric'};
+        return (this.props.intl.formatDate(date, options));
     },
 
     /**
@@ -237,7 +244,7 @@ let GitBlameInfoModal = React.createClass({
                     {this.renderGitBlameInfo()}
                     <hr />
                     <div className={"row"}>
-                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.gitBlameModal.debug"}/></h4></div>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.gitBlameModal.more"}/></h4></div>
                     </div>
                     {this.renderDebugInfo()}
                 </Modal.Body>

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -15,6 +15,7 @@ import TextUnitStore from "../../stores/workbench/TextUnitStore";
 import TextUnitsReviewModal from "./TextUnitsReviewModal";
 import TextUnitSDK from "../../sdk/TextUnit";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
+import GitBlameActions from "../../actions/workbench/GitBlameActions";
 import Locales from "../../utils/Locales";
 import {
     Alert,
@@ -636,6 +637,13 @@ let TextUnit = React.createClass({
             "bcp47Tags": RepositoryStore.getAllBcp47TagsForRepositoryIds(SearchParamsStore.getState().repoIds),
         });
     },
+
+    onTextUnitInfoClick(e){
+
+        e.stopPropagation();
+
+        GitBlameActions.openWithTextUnit(this.props.textUnit);
+    },
     
     /**
      * Handle click on the asset path icon: stop event propagation (no need to bubble
@@ -798,6 +806,8 @@ let TextUnit = React.createClass({
     renderName() {
         let assetPathWithZeroWidthSpace = this.addZeroWidthSpace(this.props.textUnit.getAssetPath()); // to make the tooltip text to wrap
         let assetPathTooltip = <Tooltip id="{this.props.textUnit.getId()}-assetPath">{assetPathWithZeroWidthSpace}</Tooltip>;
+        let assetPathWithGitInfoTooltip =
+            <Tooltip id="{this.props.textUnit.getId()}-gitInfo">{this.props.intl.formatMessage( {id: 'workbench.gitBlameModal.info'} )}</Tooltip>;
 
         return (<span className="clickable textunit-name"
                       onClick={this.onStringIdClick}>
@@ -805,6 +815,11 @@ let TextUnit = React.createClass({
                     <OverlayTrigger placement="top" overlay={assetPathTooltip}>
                         <span className="textunit-assetpath glyphicon glyphicon-level-up mls" 
                                onClick={this.onAssetPathClick} />
+                    </OverlayTrigger>
+
+                    <OverlayTrigger placement="top" overlay={assetPathWithGitInfoTooltip}>
+                        <span className="textunit-gitInfo glyphicon glyphicon-info-sign mls"
+                              onClick={this.onTextUnitInfoClick} />
                     </OverlayTrigger>
                 </span>
         );

--- a/webapp/src/main/resources/public/js/components/workbench/Workbench.js
+++ b/webapp/src/main/resources/public/js/components/workbench/Workbench.js
@@ -22,6 +22,11 @@ import SearchConstants from "../../utils/SearchConstants";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 
 import LocationHistory from "../../utils/LocationHistory";
+import AltContainer from "alt-container";
+import GitBlameStore from "../../stores/workbench/GitBlameStore";
+import GitBlameInfoModal from "./GitBlameInfoModal";
+import GitBlameActions from "../../actions/workbench/GitBlameActions";
+import {OverlayTrigger, Tooltip} from "react-bootstrap";
 
 let Workbench = React.createClass({
 
@@ -29,7 +34,8 @@ let Workbench = React.createClass({
 
     statics: {
         storeListeners: {
-            "onSearchParamsStoreChanged": SearchParamsStore
+            "onSearchParamsStoreChanged": SearchParamsStore,
+            "onGitBlameStoreUpdated": GitBlameStore
         }
     },
 
@@ -40,6 +46,10 @@ let Workbench = React.createClass({
      */
     onSearchParamsStoreChanged: function (searchParams) {
         this.updateLocationForSearchParam(searchParams);
+    },
+
+    onGitBlameStoreUpdated(store) {
+        this.setState({"isShowGitBlameModal": store.show});
     },
     
     /**
@@ -88,6 +98,9 @@ let Workbench = React.createClass({
                 <div className="mtl mbl">
                     <SearchResults />
                 </div>
+                <AltContainer store={GitBlameStore}>
+                    <GitBlameInfoModal onCloseModal={GitBlameActions.close}/>
+                </AltContainer>
 
             </div>
         );

--- a/webapp/src/main/resources/public/js/sdk/TextUnit.js
+++ b/webapp/src/main/resources/public/js/sdk/TextUnit.js
@@ -3,10 +3,10 @@ import _ from "lodash";
 /**
  * Used to communicate with textunits WS (search for translated/untranslated strings, create/update new translation)
  *
- * A TextUnit is bound to a TmTextUnit and a target locale. It reprensents a current translation or an untranslated string.
+ * A TextUnit is bound to a TmTextUnit and a target locale. It represents a current translation or an untranslated string.
  *
- * A TmTextUnit is the entity that represent only a string that needs to be translated, it's not bound to a target locale.
- * Mutliple TmTextUnitVariant (translation) are linked to a TmTextUnit.
+ * A TmTextUnit is the entity that represents only a string that needs to be translated, it's not bound to a target locale.
+ * Multiple TmTextUnitVariant (translation) are linked to a TmTextUnit.
  *
  */
 export default
@@ -222,6 +222,30 @@ class TextUnit {
 
     setDoNotTranslate(doNotTranslate) {
         this.data.doNotTranslate = doNotTranslate;
+    }
+
+    getRepositoryName() {
+        return this.data.repositoryName;
+    }
+
+    setRepositoryName(repositoryName) {
+        this.data.repositoryName = repositoryName;
+    }
+
+    getTmTextUnitCreatedDate() {
+        return this.data.tmTextUnitCreatedDate;
+    }
+
+    setTmTextUnitCreatedDate(tmTextUnitCreatedDate) {
+        this.data.tmTextUnitCreatedDate = tmTextUnitCreatedDate;
+    }
+
+    getCreatedDate() {
+        return this.data.createdDate;
+    }
+
+    setCreatedDate(createdDate) {
+        this.data.createdDate = createdDate;
     }
 
     /**

--- a/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
+++ b/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
@@ -94,6 +94,15 @@ class TextUnitClient extends BaseClient {
         return this.baseUrl + 'virtualAssets/' + assetId + '/textUnits';
     }
 
+    /**
+     * Gets the GitBlameWithUsage that matches the given textUnit.
+     * @param textUnit
+     * @returns {Promise}
+     */
+    getGitBlameInfo(textUnit) {
+        return this.get(this.getUrl() + "/gitBlameWithUsages", {"tmTextUnitId": textUnit.getTmTextUnitId()});
+    }
+
 
     getEntityName() {
         return 'textunits';

--- a/webapp/src/main/resources/public/js/stores/workbench/GitBlameStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/GitBlameStore.js
@@ -1,0 +1,52 @@
+import alt from "../../alt";
+import Error from "../../utils/Error";
+import TextUnit from "../../sdk/TextUnit";
+import TextUnitDataSource from "../../actions/workbench/TextUnitDataSource";
+import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
+import SearchParamsStore from "./SearchParamsStore";
+import {StatusCommonTypes} from "../../components/screenshots/StatusCommon";
+import GitBlameActions from "../../actions/workbench/GitBlameActions";
+
+class GitBlameStore {
+
+    constructor() {
+        this.setDefaultState();
+        this.bindActions(GitBlameActions);
+        this.registerAsync(TextUnitDataSource);
+    }
+
+    setDefaultState() {
+        this.show = false;
+        this.textUnit = null;
+        this.gitBlameWithUsage = null;
+        this.loading = false;
+    }
+
+    close() {
+        this.show = false;
+    }
+
+    openWithTextUnit(textUnit) {
+        console.log("GitBlameStore::openWithTextUnit");
+
+        this.show = true;
+        this.textUnit = textUnit;
+        this.gitBlameWithUsage = null;
+        this.loading = true;
+        this.getInstance().getGitBlameInfo(textUnit);
+
+    }
+
+    onGetGitBlameInfoSuccess(gitBlameWithUsage) {
+        console.log("GitBlameStore::onGetGitBlameInfoSuccess");
+        this.gitBlameWithUsage = gitBlameWithUsage[0];
+        this.loading = false;
+    }
+
+    onGetGitBlameInfoError(errorResponse) {
+        console.log("GitBlameStore::onGetGitBlameInfoError");
+        this.loading = false;
+    }
+}
+
+export default alt.createStore(GitBlameStore, 'GitBlameStore');

--- a/webapp/src/main/resources/public/js/stores/workbench/GitBlameStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/GitBlameStore.js
@@ -34,7 +34,6 @@ class GitBlameStore {
         this.gitBlameWithUsage = null;
         this.loading = true;
         this.getInstance().getGitBlameInfo(textUnit);
-
     }
 
     onGetGitBlameInfoSuccess(gitBlameWithUsage) {

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -167,6 +167,7 @@ a.label-container:hover {
 /** MODAL */
 .modal-content {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    word-wrap: break-word;
 }
 
 /** emphasis */
@@ -416,11 +417,11 @@ div.textunit label {
     white-space: pre-wrap;
 }
 
-.textunit-name:hover .textunit-assetpath {
+.textunit:hover .textunit-assetpath, .textunit:hover .textunit-gitInfo {
     visibility: visible;
 }
 
-.textunit-name .textunit-assetpath {
+.textunit-name .textunit-assetpath, .textunit-name .textunit-gitInfo {
     visibility: hidden;
     color: $brand-success;
 }
@@ -458,6 +459,18 @@ div.textunit div.targetstring-container {
 div.targetstring-container textarea {
     max-width: 100%;
     outline: invert;
+}
+
+.git-blame-label {
+    text-align: right;
+}
+
+.git-blame-info {
+    word-wrap: break-word;
+}
+
+.git-blame-unused {
+    color: $gray-light;
 }
 
 /**

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -167,7 +167,6 @@ a.label-container:hover {
 /** MODAL */
 .modal-content {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    word-wrap: break-word;
 }
 
 /** emphasis */


### PR DESCRIPTION
When the information button is clicked, displays information about the current text unit:
- text unit information
- git blame information
- debug/additional text unit information