### PR TITLE
Add option "--override" to GitBlameCommand to override entries with i…

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameOverrideConverter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameOverrideConverter.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+
+import java.util.Arrays;
+
+/**
+ *
+ * @author jaurambault
+ */
+public class GitBlameOverrideConverter implements IStringConverter<GitBlameCommand.OverrideType> {
+
+    @Override
+    public GitBlameCommand.OverrideType convert(String value) {
+
+        GitBlameCommand.OverrideType overrideType = null;
+
+        if (value != null) {
+            try {
+                overrideType = GitBlameCommand.OverrideType.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException iae) {
+                String msg = "Invalid overrideType type [" + value + "], should be one of: " + Arrays.toString(GitBlameCommand.OverrideType.values());
+                throw new ParameterException(msg);
+            }
+        }
+
+        return overrideType;
+    }
+
+}


### PR DESCRIPTION
…nformation already computed

Can target only entries for which the information was computed but missing: NO_INFO or ALL. Default is NONE, no overriding.