### PR TITLE
Fix OAuth redirect when session expires

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/react/LoginConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/LoginConfig.java
@@ -1,0 +1,19 @@
+package com.box.l10n.mojito.react;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoginConfig {
+
+    @Autowired
+    OAuth2Config oauth2;
+
+    public OAuth2Config getOauth2() {
+        return oauth2;
+    }
+
+    public void setOauth2(OAuth2Config oauth2) {
+        this.oauth2 = oauth2;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/react/OAuth2Config.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/OAuth2Config.java
@@ -1,0 +1,19 @@
+package com.box.l10n.mojito.react;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("l10n.security.oauth2")
+public class OAuth2Config {
+
+    Boolean enabled = false;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/react/ReactAppConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/ReactAppConfig.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.react;
 
+import nu.validator.htmlparser.annotation.Auto;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
@@ -10,11 +12,22 @@ public class ReactAppConfig {
     @Autowired
     OpengrokConfig opengrok;
 
+    @Autowired
+    LoginConfig login;
+
     public OpengrokConfig getOpengrok() {
         return opengrok;
     }
 
     public void setOpengrok(OpengrokConfig opengrok) {
         this.opengrok = opengrok;
+    }
+
+    public LoginConfig getLogin() {
+        return login;
+    }
+
+    public void setLogin(LoginConfig login) {
+        this.login = login;
     }
 }

--- a/webapp/src/main/resources/public/js/app.js
+++ b/webapp/src/main/resources/public/js/app.js
@@ -135,7 +135,12 @@ function startApp(messages) {
         function okOnClick() {
             let pathNameStrippedLeadingSlash = location.pathname.substr(1 + CONTEXT_PATH.length, location.pathname.length);
             let currentLocation = pathNameStrippedLeadingSlash + window.location.search;
-            window.location.href = UrlHelper.getUrlWithContextPath("/login?") + $.param({"showPage": currentLocation});
+
+            if (APP_CONFIG.login.oauth2.enabled) {
+                window.location.href = UrlHelper.getUrlWithContextPath(currentLocation);
+            } else {
+                window.location.href = UrlHelper.getUrlWithContextPath("/login?") + $.param({"showPage": currentLocation});
+            }
         }
 
         ReactDOM.render(


### PR DESCRIPTION
We want to prompt for login again and reload the app in the proper state (that doesn't fully work but nothing new..)

- It was going to the old login page
- We need to let the frontend know that oauth is enabled (hence adding those config)
- In the frontend for oauth we redirect to the current page and for default login we redirect to spring url with show page.
- Note that the redirect don't work for links from repository to workbench (relatively annoying) and within the workbench (not to bad)