### PR TITLE
Fix import localized asset when some text unit are unused.

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
@@ -309,4 +309,26 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
         checkExpectedGeneratedResources();
     }
 
+
+    @Test
+    public void importUnused() throws Exception {
+        Repository repository = createTestRepoUsingRepoService();
+
+        getL10nJCommander().run("push", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source").getAbsolutePath());
+
+        getL10nJCommander().run("push", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath());
+
+        getL10nJCommander().run("import", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-t", getInputResourcesTestDir("translations").getAbsolutePath());
+
+        getL10nJCommander().run("pull", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-t", getTargetTestDir().getAbsolutePath());
+
+        checkExpectedGeneratedResources();
+    }
+
 }

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/expected/demo_fr-CA.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/expected/demo_fr-CA.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1 fr-CA

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/expected/demo_fr-FR.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/expected/demo_fr-FR.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1 fr-FR

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/expected/demo_ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/expected/demo_ja-JP.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1 ja-JP

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/source/demo.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/source/demo.properties
@@ -1,0 +1,2 @@
+# comment 1
+k1=v1

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/source2/demo.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/source2/demo.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/translations/demo_fr-CA.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/translations/demo_fr-CA.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1 fr-CA

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/translations/demo_fr-FR.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/translations/demo_fr-FR.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1 fr-FR

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/translations/demo_ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importUnused/input/translations/demo_ja-JP.properties
@@ -1,0 +1,2 @@
+# comment 1 update
+k1=v1 ja-JP

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/TranslateStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/TranslateStep.java
@@ -99,7 +99,7 @@ public class TranslateStep extends AbstractMd5ComputationStep {
 
         if (textUnit.isTranslatable()) {
 
-            String translation = translatorWithInheritance.getTranslation(name, source, md5);
+            String translation = translatorWithInheritance.getTranslation(source, md5);
 
             if (translation == null && InheritanceMode.REMOVE_UNTRANSLATED.equals(inheritanceMode)) {
                 logger.debug("Remove untranslated text unit");

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/VirtualAssetService.java
@@ -199,7 +199,6 @@ public class VirtualAssetService {
         for (AssetTextUnit assetTextUnit : findByAssetExtractionAssetId) {
 
             String translation = translatorWithInheritance.getTranslation(
-                    assetTextUnit.getName(),
                     assetTextUnit.getContent(),
                     assetTextUnit.getMd5()
             );

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
@@ -6,6 +6,8 @@ import com.box.l10n.mojito.entity.TMTextUnit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -22,6 +24,8 @@ public interface TMTextUnitRepository extends JpaRepository<TMTextUnit, Long> {
 
     List<TMTextUnit> findByTm_id(Long tmId);
         
+    List<TMTextUnit> findByIdIn(Collection<Long> ids);
+
     List<TMTextUnit> findByAsset(Asset asset);
     List<TMTextUnit> findByAssetId(Long assetId);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TranslatorWithInheritance.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TranslatorWithInheritance.java
@@ -69,12 +69,10 @@ public class TranslatorWithInheritance {
     }
 
     public String getTranslation(
-            String name,
             String source,
             String md5) {
 
-        TextUnitDTO textUnitDTO = getTextUnitDTO(name, source, md5);
-
+        TextUnitDTO textUnitDTO = getTextUnitDTO(md5);
         return getTranslationFromTextUnitDTO(textUnitDTO, source);
     }
 
@@ -91,12 +89,9 @@ public class TranslatorWithInheritance {
         return translation;
     }
 
-    public TextUnitDTO getTextUnitDTO(
-            String name,
-            String source,
-            String md5) {
+    public TextUnitDTO getTextUnitDTO(String md5) {
 
-        logger.debug("Look for a textUnitDTO in target locale: {} for text unit with name: {}", repositoryLocale.getLocale().getBcp47Tag(), name);
+        logger.debug("Look for a textUnitDTO in target locale: {} for text unit with md5: {}", repositoryLocale.getLocale().getBcp47Tag(), md5);
         TextUnitDTO textUnitDTO = getTextUnitDTO(md5, repositoryLocale.getLocale().getId());
 
         if (textUnitDTO != null) {


### PR DESCRIPTION
The new implementation import the translation for the current/used text unit that has the given name. Previous implementation was not checking the used status and may have imported the translation on an unused text unit with same name.