### PR TITLE
Keep track of the branch creator/owner.

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/UserDeleteCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/UserDeleteCommandTest.java
@@ -37,7 +37,7 @@ public class UserDeleteCommandTest extends CLITestBase {
         String givenName = "Test";
         String commonName = "Test Mojito";
         
-        userService.createUserWithRole(username, password, Role.USER, givenName, surname, commonName);
+        userService.createUserWithRole(username, password, Role.USER, givenName, surname, commonName, false);
         User user = userRepository.findByUsername(username);
         assertNotNull(user);
         

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/UserUpdateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/UserUpdateCommandTest.java
@@ -129,7 +129,7 @@ public class UserUpdateCommandTest extends CLITestBase {
         if (rolename != null) {
             role = Role.valueOf(rolename);
         }
-        User user = userService.createUserWithRole(username, password, role, givenName, surname, commonName);
+        User user = userService.createUserWithRole(username, password, role, givenName, surname, commonName, false);
         return user;
     }
     

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Branch.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Branch.java
@@ -1,11 +1,9 @@
 package com.box.l10n.mojito.entity;
 
+import com.box.l10n.mojito.entity.security.user.User;
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import org.hibernate.envers.Audited;
-import org.hibernate.envers.RelationTargetAuditMode;
+import org.springframework.data.annotation.CreatedBy;
 
-import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -16,7 +14,7 @@ import javax.persistence.Table;
 
 /**
  * Entity to manage branches of an {@link Asset}.
- *
+ * <p>
  * The branch name can be {@code null}. This will be used when no branch is provided to the system. Note {@code null}
  * complicates query when searching by name and {@link com.box.l10n.mojito.service.branch.BranchService#findByNameAndRepository(String, Repository)}
  * should be used instead of {@link com.box.l10n.mojito.service.branch.BranchRepository#findByNameAndRepository(String, Repository)}
@@ -40,6 +38,14 @@ public class Branch extends BaseEntity {
     @Column(name = "name")
     String name;
 
+    @CreatedBy
+    @ManyToOne
+    @JoinColumn(name = BaseEntity.CreatedByUserColumnName, foreignKey = @ForeignKey(name = "FK__BRANCH__USER__ID"))
+    protected User createdByUser;
+
+    @Column(name = "deleted", nullable = false)
+    Boolean deleted = false;
+
     public Repository getRepository() {
         return repository;
     }
@@ -54,5 +60,21 @@ public class Branch extends BaseEntity {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public User getCreatedByUser() {
+        return createdByUser;
+    }
+
+    public void setCreatedByUser(User createdByUser) {
+        this.createdByUser = createdByUser;
+    }
+
+    public Boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(Boolean deleted) {
+        this.deleted = deleted;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/security/user/User.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/security/user/User.java
@@ -35,8 +35,6 @@ public class User extends AuditableEntity implements Serializable {
 
     public static final int NAME_MAX_LENGTH = 255;
 
-
-    
     @Basic(optional = false)
     @Column(name = "username")
     @JsonView(View.IdAndName.class)        
@@ -58,6 +56,18 @@ public class User extends AuditableEntity implements Serializable {
     @Column(name = "common_name")
     @JsonView(View.IdAndName.class)
     String commonName;
+
+    /**
+     * Sets this flag if the user is created by a process that don't have all the information. Eg. pushing an asset
+     * for a branch with an owner. If the owner is not in the system yet, the user will be created but the information
+     * will be minimal.
+     *
+     * Usually user are created the first time the user connect to the system via LDAP or OAuth and have more information
+     * Partially created user can be updated later when the first login happens.
+     *
+     */
+    @Column(name = "partially_created")
+    Boolean partiallyCreated = false;
 
     @JsonManagedReference
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
@@ -131,5 +141,13 @@ public class User extends AuditableEntity implements Serializable {
 
     public void setCommonName(String commonName) {
         this.commonName = commonName;
+    }
+
+    public Boolean getPartiallyCreated() {
+        return partiallyCreated;
+    }
+
+    public void setPartiallyCreated(Boolean partiallyCreated) {
+        this.partiallyCreated = partiallyCreated;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/security/UserWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/security/UserWS.java
@@ -82,7 +82,7 @@ public class UserWS {
         }
 
         User createdUser = userService.createUserWithRole(user.getUsername(), user.getPassword(), role,
-                user.getGivenName(), user.getSurname(), user.getCommonName());
+                user.getGivenName(), user.getSurname(), user.getCommonName(), false);
 
         return new ResponseEntity<>(createdUser, HttpStatus.CREATED);
     }
@@ -127,7 +127,7 @@ public class UserWS {
             role = Role.valueOf(authority.getAuthority());
         }
         
-        userService.saveUserWithRole(userToUpdate, user.getPassword(), role, user.getGivenName(), user.getSurname(), user.getCommonName());
+        userService.saveUserWithRole(userToUpdate, user.getPassword(), role, user.getGivenName(), user.getSurname(), user.getCommonName(), false);
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceImpl.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceImpl.java
@@ -3,12 +3,12 @@ package com.box.l10n.mojito.security;
 import com.box.l10n.mojito.entity.security.user.User;
 import com.box.l10n.mojito.service.security.user.UserRepository;
 import com.box.l10n.mojito.service.security.user.UserService;
-import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -24,9 +24,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Autowired
     UserRepository userRepository;
 
-    @Autowired
-    UserService userService;
-
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username);
@@ -36,25 +33,5 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         }
 
         return new UserDetailsImpl(user);
-    }
-
-    /**
-     * Create user with the username
-     *
-     * @param username username name of the user to be created
-     * @param givenName
-     * @param surname
-     * @param commonName
-     */
-    protected UserDetails createBasicUser(String username, String givenName, String surname, String commonName) {
-        logger.info("Creating user: {}", username);
-
-        String randomPassword = RandomStringUtils.randomAlphanumeric(15);
-        User userWithRole = userService.createUserWithRole(username, randomPassword, Role.USER, givenName, surname, commonName);
-
-        logger.debug("Manually setting created by user to system user because at this point, there isn't an authenticated user context");
-        userService.updateCreatedByUserToSystemUser(userWithRole);
-
-        return new UserDetailsImpl(userWithRole);
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -25,7 +25,6 @@ import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
 import org.springframework.security.oauth2.client.filter.OAuth2ClientContextFilter;
 import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
-import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -161,7 +160,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         tokenServices.setRestTemplate(auth2RestTemplate);
 
         oauth2Filter.setTokenServices(new MyUserInfoTokenServices(
-                getUserDetailsService(),
                 oauth2Resource().getUserInfoUri(),
                 oauth2().getClientId()));
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetcontent/AssetContentService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetcontent/AssetContentService.java
@@ -3,7 +3,9 @@ package com.box.l10n.mojito.service.assetcontent;
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.AssetContent;
 import com.box.l10n.mojito.entity.Branch;
+import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.branch.BranchService;
+import com.box.l10n.mojito.service.security.user.UserService;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +47,7 @@ public class AssetContentService {
      * @return
      */
     public AssetContent createAssetContent(Asset asset, String content) {
-        Branch branch = branchService.getOrCreateBranch(asset.getRepository(), null);
+        Branch branch = branchService.getOrCreateBranch(asset.getRepository(), null, null);
         return createAssetContent(asset, content, branch);
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchService.java
@@ -2,11 +2,10 @@ package com.box.l10n.mojito.service.branch;
 
 import com.box.l10n.mojito.entity.Branch;
 import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.security.user.User;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import javax.persistence.EntityManager;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -28,34 +27,30 @@ public class BranchService {
     @Autowired
     BranchRepository branchRepository;
 
-    @Autowired
-    EntityManager entityManager;
-
-    public Branch createBranch(Repository repository, String branchName) {
+    public Branch createBranch(Repository repository, String branchName, User createdByUser) {
 
         logger.debug("getOrCreateBranch, name: {}, repository id: {}", branchName, repository.getId());
 
         Branch branch = new Branch();
         branch.setName(branchName);
         branch.setRepository(repository);
+        branch.setCreatedByUser(createdByUser);
 
         branch = branchRepository.save(branch);
 
         return branch;
     }
 
-
-    public Branch getOrCreateBranch(Repository repository, String branchName) {
+    public Branch getOrCreateBranch(Repository repository, String branchName, User createdByUser) {
 
         logger.debug("getOrCreateBranch, name: {}, repository id: {}", branchName, repository.getId());
 
         Branch branch = branchRepository.findByNameAndRepository(branchName, repository);
 
         if (branch == null) {
-            branch = createBranch(repository, branchName);
+            branch = createBranch(repository, branchName, createdByUser);
         }
 
         return branch;
     }
-
 }

--- a/webapp/src/main/resources/db/migration/V34__Add_Branch_owner.sql
+++ b/webapp/src/main/resources/db/migration/V34__Add_Branch_owner.sql
@@ -1,0 +1,5 @@
+alter table user add column partially_created bit not null default false;
+
+alter table branch add column deleted bit not null default false;
+alter table branch add column created_by_user_id bigint;
+alter table branch add constraint FK__BRANCH__USER__ID foreign key (created_by_user_id) references user (id);

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/WithDefaultTestUserSecurityContextFactory.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/WithDefaultTestUserSecurityContextFactory.java
@@ -1,14 +1,17 @@
 package com.box.l10n.mojito.rest;
 
 import com.box.l10n.mojito.bootstrap.BootstrapConfig;
+import com.box.l10n.mojito.entity.security.user.User;
 import com.box.l10n.mojito.rest.annotation.WithDefaultTestUser;
+import com.box.l10n.mojito.security.UserDetailsImpl;
+import com.box.l10n.mojito.service.security.user.UserRepository;
+import com.box.l10n.mojito.service.security.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 import org.springframework.stereotype.Component;
 
@@ -16,22 +19,18 @@ import org.springframework.stereotype.Component;
  * @author wyau
  */
 @Component
-public class WithDefaultTestUserSecurityContextFactory implements
-        WithSecurityContextFactory<WithDefaultTestUser> {
+public class WithDefaultTestUserSecurityContextFactory implements WithSecurityContextFactory<WithDefaultTestUser> {
 
     @Autowired
     BootstrapConfig bootstrapConfig;
 
-    UserDetailsService userDetailsService;
-
     @Autowired
-    public WithDefaultTestUserSecurityContextFactory(UserDetailsService userDetailsService) {
-        this.userDetailsService = userDetailsService;
-    }
+    UserRepository userRepository;
 
     @Override
     public SecurityContext createSecurityContext(WithDefaultTestUser annotation) {
-        UserDetails principal = userDetailsService.loadUserByUsername(bootstrapConfig.getDefaultUser().getUsername());
+        User user = userRepository.findByUsername(bootstrapConfig.getDefaultUser().getUsername());
+        UserDetails principal = new UserDetailsImpl(user);
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 principal, principal.getPassword(), principal.getAuthorities());
         SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/webapp/src/test/java/com/box/l10n/mojito/security/UserDetailsContextMapperImplTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/security/UserDetailsContextMapperImplTest.java
@@ -1,5 +1,8 @@
 package com.box.l10n.mojito.security;
 
+import com.box.l10n.mojito.entity.security.user.User;
+import com.box.l10n.mojito.service.security.user.UserRepository;
+import com.box.l10n.mojito.service.security.user.UserService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -11,6 +14,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.util.Assert;
 
+import static org.mockito.Mockito.*;
+
 /**
  * @author wyau
  */
@@ -21,44 +26,39 @@ public class UserDetailsContextMapperImplTest {
     UserDetailsContextMapperImpl userDetailsContextMapper;
 
     @Mock
-    UserDetailsServiceImpl userDetailsService;
+    UserService userService;
+
+    @Mock
+    UserRepository userRepository;
 
     @Test
     public void testMapUserFromContextWhenUserNameIsNotFound() throws Exception {
-        Mockito.when(userDetailsService.loadUserByUsername(Mockito.anyString()))
-                .thenThrow(new UsernameNotFoundException(""));
+        when(userRepository.findByUsername(anyString())).thenReturn(null);
 
-        Mockito.when(userDetailsService.createBasicUser(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                Mockito.anyString())).thenReturn(Mockito.mock(UserDetails.class));
+        when(userService.createOrUpdateBasicUser(anyObject(), anyString(), anyString(), anyString(),
+                anyString())).thenReturn(mock(User.class));
 
-        DirContextOperations dirContextOperations = Mockito.mock(DirContextOperations.class);
-        Mockito.when(dirContextOperations.getStringAttribute("givenname")).thenReturn("givename");
-        Mockito.when(dirContextOperations.getStringAttribute("sn")).thenReturn("sn");
-        Mockito.when(dirContextOperations.getStringAttribute("cn")).thenReturn("cn");
+        DirContextOperations dirContextOperations = mock(DirContextOperations.class);
+        when(dirContextOperations.getStringAttribute("givenname")).thenReturn("givename");
+        when(dirContextOperations.getStringAttribute("sn")).thenReturn("sn");
+        when(dirContextOperations.getStringAttribute("cn")).thenReturn("cn");
 
         UserDetails userDetails = userDetailsContextMapper.mapUserFromContext(dirContextOperations, "testUsername", null);
 
         Assert.notNull(userDetails);
-        Mockito.verify(dirContextOperations, Mockito.times(3)).getStringAttribute(Mockito.anyString());
+        verify(dirContextOperations, times(3)).getStringAttribute(anyString());
     }
 
     @Test
     public void testMapUserFromContextWhenUserNameIsFound() throws Exception {
-        Mockito.when(userDetailsService.loadUserByUsername(Mockito.anyString())).thenReturn(Mockito.mock(UserDetails.class));
+        when(userRepository.findByUsername(anyString())).thenReturn(mock(User.class));
 
-        Mockito.when(userDetailsService.createBasicUser(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                Mockito.anyString())).thenReturn(Mockito.mock(UserDetails.class));
-
-        DirContextOperations dirContextOperations = Mockito.mock(DirContextOperations.class);
-        Mockito.when(dirContextOperations.getStringAttribute("givenname")).thenReturn("givename");
-        Mockito.when(dirContextOperations.getStringAttribute("sn")).thenReturn("sn");
-        Mockito.when(dirContextOperations.getStringAttribute("cn")).thenReturn("cn");
-
+        DirContextOperations dirContextOperations = mock(DirContextOperations.class);
         UserDetails userDetails = userDetailsContextMapper.mapUserFromContext(dirContextOperations, "testUsername", null);
 
         Assert.notNull(userDetails);
-        Mockito.verify(dirContextOperations, Mockito.never()).getStringAttribute(Mockito.anyString());
-        Mockito.verify(userDetailsService, Mockito.never()).createBasicUser(Mockito.anyString(),
-                        Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        verify(dirContextOperations, never()).getStringAttribute(anyString());
+        verify(userService, never()).createOrUpdateBasicUser(anyObject(), anyString(),
+                        anyString(), anyString(), anyString());
     }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionServiceTest.java
@@ -744,9 +744,9 @@ public class AssetExtractionServiceTest extends ServiceTestBase {
 
         Asset asset = assetService.createAsset(repository.getId(), assetPath, false);
 
-        Branch master = branchService.createBranch(asset.getRepository(), "master");
-        Branch branch1 = branchService.createBranch(asset.getRepository(), "branch1");
-        Branch branch2 = branchService.createBranch(asset.getRepository(), "branch2");
+        Branch master = branchService.createBranch(asset.getRepository(), "master", null);
+        Branch branch1 = branchService.createBranch(asset.getRepository(), "branch1", null);
+        Branch branch2 = branchService.createBranch(asset.getRepository(), "branch2", null);
 
         AssetContent assetContent = assetContentService.createAssetContent(asset, masterContent, master);
         assetExtractionService.processAssetAsync(assetContent.getId(), null, null).get();

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetcontent/AssetContentServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetcontent/AssetContentServiceTest.java
@@ -80,7 +80,7 @@ public class AssetContentServiceTest extends ServiceTestBase {
         assertEquals("fortest1-content2", assetContents.get(2).getContent());
         assertEquals("fortest2-content1", assetContents.get(3).getContent());
 
-        Branch branch1 = branchService.getOrCreateBranch(fortest1.getRepository(), "branch1");
+        Branch branch1 = branchService.getOrCreateBranch(fortest1.getRepository(), "branch1", null);
         AssetContent forTest2Content1Branch1 = assetContentService.createAssetContent(fortest1, "fortest2-content1-branch1", branch1);
         assetContents = assetContentRepository.findByAssetRepositoryIdAndBranchName(repository.getId(), null);
         assertEquals(4L, assetContents.size());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/BranchServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/BranchServiceTest.java
@@ -37,7 +37,7 @@ public class BranchServiceTest extends ServiceTestBase {
     @Test
     public void createBranch() throws RepositoryNameAlreadyUsedException {
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
-        Branch master = branchService.createBranch(repository, "master");
+        Branch master = branchService.createBranch(repository, "master", null);
 
         Branch fromFind = branchRepository.findByNameAndRepository("master", repository);
         assertEquals("master", fromFind.getName());
@@ -51,7 +51,7 @@ public class BranchServiceTest extends ServiceTestBase {
         Branch before = branchRepository.findByNameAndRepository("master", repository);
         assertNull(before);
 
-        Branch create = branchService.getOrCreateBranch(repository, "master");
+        Branch create = branchService.getOrCreateBranch(repository, "master", null);
         assertEquals("master", create.getName());
         assertEquals(repository.getId(), create.getRepository().getId());
 
@@ -59,7 +59,7 @@ public class BranchServiceTest extends ServiceTestBase {
         assertEquals("master", fromFind.getName());
         assertEquals(repository.getId(), fromFind.getRepository().getId());
 
-        Branch get = branchService.getOrCreateBranch(repository, "master");
+        Branch get = branchService.getOrCreateBranch(repository, "master", null);
         assertEquals(create.getId(), get.getId());
     }
 
@@ -72,7 +72,7 @@ public class BranchServiceTest extends ServiceTestBase {
         Branch before = branchRepository.findByNameAndRepository(branchName, repository);
         assertNull(before);
 
-        Branch create = branchService.getOrCreateBranch(repository, branchName);
+        Branch create = branchService.getOrCreateBranch(repository, branchName, null);
         assertEquals(branchName, create.getName());
         assertEquals(repository.getId(), create.getRepository().getId());
 
@@ -80,7 +80,7 @@ public class BranchServiceTest extends ServiceTestBase {
         assertEquals(branchName, fromFind.getName());
         assertEquals(repository.getId(), fromFind.getRepository().getId());
 
-        Branch get = branchService.getOrCreateBranch(repository, branchName);
+        Branch get = branchService.getOrCreateBranch(repository, branchName, null);
         assertEquals(create.getId(), get.getId());
     }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/security/user/UserServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/security/user/UserServiceTest.java
@@ -34,7 +34,7 @@ public class UserServiceTest extends ServiceTestBase {
         Role userRole = Role.USER;
         String expectedAuthorityName = userService.createAuthorityName(userRole);
 
-        User userWithRole = userService.createUserWithRole(username, pwd, userRole, givenName, surname, commonName);
+        User userWithRole = userService.createUserWithRole(username, pwd, userRole, givenName, surname, commonName, false);
 
         User byUsername = userRepository.findByUsername(username);
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -781,23 +781,23 @@ public class TMServiceTest extends ServiceTestBase {
         exportAssetAsXLIFF = removeIdsAndDatesFromJson(exportAssetAsXLIFF);
         logger.debug(exportAssetAsXLIFF);
 
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<xliff version=\"1.2\" xmlns=\"urn:oasis:names:tc:xliff:document:1.2\" xmlns:okp=\"okapi-framework:xliff-extensions\">\n"
-                + "<file original=\"test-asset-path.xliff\" source-language=\"en\" target-language=\"fr-FR\" datatype=\"x-undefined\" okp:inputEncoding=\"UTF-8\">\n"
-                + "<body>\n"
-                + "<trans-unit id=\"\" resname=\"application_name\" xml:space=\"preserve\">\n"
-                + "<source xml:lang=\"en\">Application Name</source>\n"
-                + "<target xml:lang=\"fr-FR\">Nom de l'application</target>\n"
-                + "<note>{\"sourceComment\":\"This text is shown in the start screen of the application. Keep it short.\",\"targetComment\":null,\"includedInLocalizedFile\":true,\"status\":\"APPROVED\",\"variantComments\":[],\"pluralForm\":null,\"pluralFormOther\":null}</note>\n"
-                + "</trans-unit>\n"
-                + "<trans-unit id=\"\" resname=\"home\" xml:space=\"preserve\">\n"
-                + "<source xml:lang=\"en\">Home</source>\n"
-                + "<target xml:lang=\"fr-FR\">Page d'accueil</target>\n"
-                + "<note>{\"sourceComment\":\"This is the text displayed in the link that takes the user to the home page.\",\"targetComment\":\"this string has some comments\",\"includedInLocalizedFile\":false,\"status\":\"REVIEW_NEEDED\",\"variantComments\":[{\"severity\":\"INFO\",\"type\":\"LEVERAGING\",\"content\":\"Leveraging\",\"createdByUser\":{\"username\":\"admin\",\"enabled\":true,\"surname\":null,\"givenName\":null,\"commonName\":null,\"authorities\":[{\"authority\":\"ROLE_ADMIN\"}]}},{\"severity\":\"ERROR\",\"type\":\"INTEGRITY_CHECK\",\"content\":\"Failed Integrity Check\",\"createdByUser\":{\"username\":\"admin\",\"enabled\":true,\"surname\":null,\"givenName\":null,\"commonName\":null,\"authorities\":[{\"authority\":\"ROLE_ADMIN\"}]}}],\"pluralForm\":null,\"pluralFormOther\":null}</note>\n"
-                + "</trans-unit>\n"
-                + "</body>\n"
-                + "</file>\n"
-                + "</xliff>\n", exportAssetAsXLIFF);
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<xliff version=\"1.2\" xmlns=\"urn:oasis:names:tc:xliff:document:1.2\" xmlns:okp=\"okapi-framework:xliff-extensions\">\n" +
+                "<file original=\"test-asset-path.xliff\" source-language=\"en\" target-language=\"fr-FR\" datatype=\"x-undefined\" okp:inputEncoding=\"UTF-8\">\n" +
+                "<body>\n" +
+                "<trans-unit id=\"\" resname=\"application_name\" xml:space=\"preserve\">\n" +
+                "<source xml:lang=\"en\">Application Name</source>\n" +
+                "<target xml:lang=\"fr-FR\">Nom de l'application</target>\n" +
+                "<note>{\"sourceComment\":\"This text is shown in the start screen of the application. Keep it short.\",\"targetComment\":null,\"includedInLocalizedFile\":true,\"status\":\"APPROVED\",\"variantComments\":[],\"pluralForm\":null,\"pluralFormOther\":null}</note>\n" +
+                "</trans-unit>\n" +
+                "<trans-unit id=\"\" resname=\"home\" xml:space=\"preserve\">\n" +
+                "<source xml:lang=\"en\">Home</source>\n" +
+                "<target xml:lang=\"fr-FR\">Page d'accueil</target>\n" +
+                "<note>{\"sourceComment\":\"This is the text displayed in the link that takes the user to the home page.\",\"targetComment\":\"this string has some comments\",\"includedInLocalizedFile\":false,\"status\":\"REVIEW_NEEDED\",\"variantComments\":[{\"severity\":\"INFO\",\"type\":\"LEVERAGING\",\"content\":\"Leveraging\",\"createdByUser\":{\"username\":\"admin\",\"enabled\":true,\"surname\":null,\"givenName\":null,\"commonName\":null,\"partiallyCreated\":false,\"authorities\":[{\"authority\":\"ROLE_ADMIN\"}]}},{\"severity\":\"ERROR\",\"type\":\"INTEGRITY_CHECK\",\"content\":\"Failed Integrity Check\",\"createdByUser\":{\"username\":\"admin\",\"enabled\":true,\"surname\":null,\"givenName\":null,\"commonName\":null,\"partiallyCreated\":false,\"authorities\":[{\"authority\":\"ROLE_ADMIN\"}]}}],\"pluralForm\":null,\"pluralFormOther\":null}</note>\n" +
+                "</trans-unit>\n" +
+                "</body>\n" +
+                "</file>\n" +
+                "</xliff>\n", exportAssetAsXLIFF);
     }
 
     private String removeIdsAndDatesFromJson(String xliff) {


### PR DESCRIPTION
For now the creator comes form the security context. We'll provide and option in the "push" command later to override (use to push branch on behalf of a user).

This commit just adds the createdByUser attribute to the branch entity and adds logic to set it when processing an asset. It will creates a partial user if needed.

When automation jobs process a branch on behalf of a user, that user may not be in Mojito yet. It will create a partial user (since the name is only available at that point) which will be updated with more information the first time the user logs in.