### PR TITLE
Fix push command when looking up for the branch

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
@@ -51,6 +51,8 @@ public class L10nJCommander {
 
     boolean systemExitEnabled = true;
 
+    int exitCode;
+
     /**
      * Wrapped {@link JCommander} that is re-created for each call of
      * {@link #run}.
@@ -221,6 +223,7 @@ public class L10nJCommander {
     }
 
     public void exitWithError(int exitCode) {
+        this.exitCode = exitCode;
 
         if (isSystemExitEnabled()) {
             System.exit(exitCode);
@@ -246,4 +249,7 @@ public class L10nJCommander {
         this.systemExitEnabled = systemExitEnabled;
     }
 
+    public int getExitCode() {
+        return exitCode;
+    }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -125,13 +125,17 @@ public class PushCommand extends Command {
 
         Branch branch = repositoryClient.getBranch(repository.getId(), branchName);
 
-        logger.debug("process deleted assets here");
-        Set<Long> assetIds = Sets.newHashSet(assetClient.getAssetIds(repository.getId(), false, false, branch.getId()));
+        if (branch == null) {
+            logger.debug("No branch in the repository, no asset must have been pushed yet, no need to delete");
+        } else {
+            logger.debug("process deleted assets here");
+            Set<Long> assetIds = Sets.newHashSet(assetClient.getAssetIds(repository.getId(), false, false, branch.getId()));
 
-        assetIds.removeAll(usedAssetIds);
-        if (!assetIds.isEmpty()) {
-            assetClient.deleteAssetsInBranch(assetIds, branch.getId());
-            consoleWriter.newLine().a("Delete assets from repository, ids: ").fg(Ansi.Color.CYAN).a(assetIds.toString()).println(2);
+            assetIds.removeAll(usedAssetIds);
+            if (!assetIds.isEmpty()) {
+                assetClient.deleteAssetsInBranch(assetIds, branch.getId());
+                consoleWriter.newLine().a("Delete assets from repository, ids: ").fg(Ansi.Color.CYAN).a(assetIds.toString()).println(2);
+            }
         }
 
         consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
@@ -293,6 +293,14 @@ public class PushCommandTest extends CLITestBase {
         assertEquals("ja-JP", targetTextUnitDTOS.get(2).getTargetLocale());
     }
 
+    @Test
+    public void testInitialPushWithNofile() throws Exception {
+        Repository repository = createTestRepoUsingRepoService();
+        L10nJCommander l10nJCommander = getL10nJCommander();
+        l10nJCommander.run("push", "-r", repository.getName(), "-s", getInputResourcesTestDir().getAbsolutePath());
+        assertEquals(0, l10nJCommander.getExitCode());
+    }
+
     private void checkNumberOfUsedUntranslatedTextUnit(Repository repository, List<String> locales, int expectedNumberOfUnstranslated) {
         checkNumberOfUntranslatedTextUnit(repository, locales, true, expectedNumberOfUnstranslated);
     }

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PushCommandTest/testInitialPushWithNofile/input/empty
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PushCommandTest/testInitialPushWithNofile/input/empty
@@ -1,0 +1,1 @@
+empty file for test

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
@@ -125,18 +125,17 @@ public class RepositoryClient extends BaseClient {
     }
 
     /**
-     *
      * @param repositoryId
      * @param exportedXliffContent
-     * @param updateTM indicates if the TM should be updated or if the translation
-     * can be imported assuming that there is no translation yet.
+     * @param updateTM             indicates if the TM should be updated or if the translation
+     *                             can be imported assuming that there is no translation yet.
      * @return
      * @throws ResourceNotCreatedException
      */
     public void importRepository(Long repositoryId, String exportedXliffContent, boolean updateTM) throws ResourceNotCreatedException {
 
         String pathToImport = getBasePathForResource(repositoryId, "xliffImport");
-        
+
         ImportRepositoryBody importRepositoryBody = new ImportRepositoryBody();
         importRepositoryBody.setXliffContent(exportedXliffContent);
         importRepositoryBody.setUpdateTM(updateTM);
@@ -152,7 +151,7 @@ public class RepositoryClient extends BaseClient {
             }
         }
     }
-    
+
     /**
      * Deletes a {@link Repository} by the {@link Repository#name}
      *
@@ -167,18 +166,17 @@ public class RepositoryClient extends BaseClient {
 
     /**
      * Updates a {@link Repository}
-     * 
+     *
      * @param name
      * @param newName
      * @param description
      * @param repositoryLocales With id, and repository id not set
      * @param integrityCheckers
-     * @throws
-     * com.box.l10n.mojito.rest.client.exception.RepositoryNotFoundException
+     * @throws com.box.l10n.mojito.rest.client.exception.RepositoryNotFoundException
      * @throws com.box.l10n.mojito.rest.client.exception.ResourceNotUpdatedException
      */
     public void updateRepository(String name, String newName, String description, Boolean checkSLA, Set<RepositoryLocale> repositoryLocales, Set<IntegrityChecker> integrityCheckers) throws RepositoryNotFoundException, ResourceNotUpdatedException {
-        
+
         logger.debug("Updating repository by name = [{}]", name);
         Repository repository = getRepositoryByName(name);
 
@@ -216,7 +214,15 @@ public class RepositoryClient extends BaseClient {
     }
 
     public Branch getBranch(Long repositoryId, String branchName) {
-        return getBranches(repositoryId, branchName).get(0);
+        Branch branch = null;
+
+        List<Branch> branches = getBranches(repositoryId, branchName);
+
+        if (!branches.isEmpty()) {
+            branch = branches.get(0);
+        }
+
+        return branch;
     }
 
 }


### PR DESCRIPTION
If running the push command against a repository where no asset were uploaded yet (hence no branch created) and the local filesystem scan resulted in finding no asset then the command failed since no branch was ever created and the delete portion relied on it

fix #372