### PR TITLE
Update okapi 0.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.version>3.5.1</maven.compiler.version>
         <maven.deploy.version>2.8.2</maven.deploy.version>
         <maven.release.version>2.5.3</maven.release.version>
-        <okapi.version>0.32</okapi.version>
+        <okapi.version>0.36</okapi.version>
         <guava.version>19.0</guava.version>
         <hibernate.joda-time.version>1.3</hibernate.joda-time.version>
         <usertype.core.version>3.2.0.GA</usertype.core.version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -756,13 +756,4 @@
         </profile>
     </profiles>
 
-    <repositories>
-        <repository>
-            <id>okapi</id>
-            <name>okapi</name>
-            <url>http://repository-okapi.forge.cloudbees.com/release/</url>
-            <layout>default</layout>
-        </repository>
-    </repositories>
-
 </project>

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/SimpleEncoder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/SimpleEncoder.java
@@ -65,6 +65,11 @@ public class SimpleEncoder implements IEncoder {
     }
 
     @Override
+    public void reset() {
+
+    }
+
+    @Override
     public String toNative(String propertyName, String value) {
         // No changes for the other values
         return value;


### PR DESCRIPTION
0.32 is not available anymore. 0.36 is served from maven central so it won't prevent those kind of issues moving forward