### PR TITLE
Show - when there is no link config and no usages

### DIFF
--- a/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
@@ -299,7 +299,7 @@ let GitBlameInfoModal = React.createClass({
      */
     getLocationDefaultLabel() {
         const usages = this.getUsages();
-        if (usages !== null) {
+        if (usages !== null && usages.length > 0) {
             return usages.join("\n");
         } else {
             return '-';


### PR DESCRIPTION
Currently, nothing is shown if usages is an empty array and the link config is not defined.