### PR TITLE
Update git-blame command to run without -ft parameter

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GitBlameCommand.java
@@ -136,11 +136,8 @@ public class GitBlameCommand extends Command {
 
             offset += numGitBlameWithUsages;
 
-            if (fileType != null && GitBlameType.TEXT_UNIT_USAGES.equals(fileType.getGitBlameType())) {
-                blameWithTextUnitUsages(getGitBlameWithUsagesToProcess);
-            } else {
-                blameSourceFiles(getGitBlameWithUsagesToProcess);
-            }
+            blameWithTextUnitUsages(getGitBlameWithUsagesToProcess);
+            blameSourceFiles(getGitBlameWithUsagesToProcess);
 
             pollableTasks.add(gitBlameWithUsageClient.saveGitBlameWithUsages(getGitBlameWithUsagesToProcess));
         } while (numGitBlameWithUsages == BATCH_SIZE);
@@ -196,6 +193,10 @@ public class GitBlameCommand extends Command {
         ArrayList<FileMatch> sourceFileMatches = commandHelper.getSourceFileMatches(commandDirectories, fileType, sourceLocale, sourcePathFilterRegex);
 
         for (FileMatch sourceFileMatch : sourceFileMatches) {
+
+            if (GitBlameType.TEXT_UNIT_USAGES.equals(sourceFileMatch.getFileType().getGitBlameType())) {
+                continue;
+            }
 
             Path sourceRelativePath = gitRepository.getDirectory().getParentFile().toPath().relativize(sourceFileMatch.getPath());
             BlameResult blameResultForFile = gitRepository.getBlameResultForFile(sourceRelativePath.toString());


### PR DESCRIPTION
Previously, when running the git-blame command without a -ft, it would default to getting the git blame for the source file even when there are usages. Now git blame will be run over the text unit usages, if any, before getting the git blame of the source file.