### PR TITLE
fix repo locale stats toggle

### DIFF
--- a/webapp/src/main/resources/public/js/components/repositories/Repositories.js
+++ b/webapp/src/main/resources/public/js/components/repositories/Repositories.js
@@ -41,7 +41,7 @@ let Repositories = React.createClass({
     },
 
     onLocalesButtonToggle(repoId) {
-        if (repoId === this.state.activeRepoId) {
+        if (this.state.isLocaleStatsShown && repoId === this.state.activeRepoId) {
             this.onCloseRequestedRepoLocaleStats();
         } else {
             this.onShowRequestedRepoLocaleStats(repoId);
@@ -49,10 +49,6 @@ let Repositories = React.createClass({
     },
 
     onShowRequestedRepoLocaleStats(repoId) {
-        if (this.state.activeRepoId) {
-            this.refs["repositoryRow" + this.state.activeRepoId].setInActive();
-        }
-
         this.setState({
             "isLocaleStatsShown": true,
             "activeRepoId": repoId
@@ -60,10 +56,6 @@ let Repositories = React.createClass({
     },
 
     onCloseRequestedRepoLocaleStats() {
-        if (this.state.activeRepoId) {
-            this.refs["repositoryRow" + this.state.activeRepoId].setInActive();
-        }
-
         this.setState({
             "isLocaleStatsShown": false,
             "activeRepoId": null


### PR DESCRIPTION
The repo locale stats doesn't close on the Repositories page. It works fine on Project Requests page.

![toggle-lang-details mov](https://user-images.githubusercontent.com/17402500/51150271-6db05600-181a-11e9-91e3-8761a5d3aa0d.gif)
