### PR TITLE
Fix repo update command bug

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
@@ -116,13 +116,13 @@ public class CLITestBase extends IOTestBase {
      * @return
      */
     public Repository createTestRepoUsingRepoService() throws Exception {
-        return createTestRepoUsingRepoService("repo");
+        return createTestRepoUsingRepoService("repo", false);
     }
 
-    public Repository createTestRepoUsingRepoService(String name) throws Exception {
+    public Repository createTestRepoUsingRepoService(String name, Boolean checkSLA) throws Exception {
 
         String repoName = testIdWatcher.getEntityName(name);
-        Repository repository = repositoryService.createRepository(repoName, repoName + " description", null, false);
+        Repository repository = repositoryService.createRepository(repoName, repoName + " description", null, checkSLA);
 
         repositoryService.addRepositoryLocale(repository, "fr-FR");
         repositoryService.addRepositoryLocale(repository, "fr-CA", "fr-FR", false);

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
@@ -382,8 +382,8 @@ public class PullCommandTest extends CLITestBase {
 
     @Test
     public void testLatestTMTextUnitVariant() throws Exception {
-        Repository repository1 = createTestRepoUsingRepoService("repo1");
-        Repository repository2 = createTestRepoUsingRepoService("repo2");
+        Repository repository1 = createTestRepoUsingRepoService("repo1", false);
+        Repository repository2 = createTestRepoUsingRepoService("repo2", false);
 
         getL10nJCommander().run("push", "-r", repository1.getName(),
                 "-s", getInputResourcesTestDir("source").getAbsolutePath());

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoUpdateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoUpdateCommandTest.java
@@ -56,8 +56,10 @@ public class RepoUpdateCommandTest extends CLITestBase {
 
     @Test
     public void testUpdateLocale() throws Exception {
-        Repository repository = createTestRepoUsingRepoService();
+        Repository repository = createTestRepoUsingRepoService("repo", true);
         String testRepoName = repository.getName();
+        Boolean testCheckSLA = repository.getCheckSLA();
+
         String newName = testRepoName + "_updated";
 
         getL10nJCommander().run(
@@ -71,6 +73,7 @@ public class RepoUpdateCommandTest extends CLITestBase {
 
         repository = repositoryRepository.findByName(newName);
         assertEquals(2, repository.getRepositoryLocales().size());
+        assertEquals(testCheckSLA, repository.getCheckSLA());
         for (RepositoryLocale repositoryLocale : repository.getRepositoryLocales()) {
             assertTrue("en".equals(repositoryLocale.getLocale().getBcp47Tag()) || "de-DE".equals(repositoryLocale.getLocale().getBcp47Tag()));
         }
@@ -246,10 +249,10 @@ public class RepoUpdateCommandTest extends CLITestBase {
         Repository repository = createTestRepoUsingRepoService();
         String testRepoName = repository.getName();
 
-        Repository repository2 = createTestRepoUsingRepoService("repo2");
+        Repository repository2 = createTestRepoUsingRepoService("repo2", false);
         String testRepoName2 = repository2.getName();
 
-        Repository repository3 = createTestRepoUsingRepoService("repo3");
+        Repository repository3 = createTestRepoUsingRepoService("repo3", false);
         String testRepoName3 = repository3.getName();
 
         getL10nJCommander().run(

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Repository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Repository.java
@@ -93,7 +93,7 @@ public class Repository extends AuditableEntity {
      */
     @JsonView(View.RepositorySummary.class)
     @Column(name = "checkSLA", nullable = false)
-    private Boolean checkSLA = false;
+    private Boolean checkSLA;
 
     public User getCreatedByUser() {
         return createdByUser;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
@@ -114,7 +114,7 @@ public class RepositoryService {
         repository = new Repository();
         repository.setName(name);
         repository.setDescription(description);
-        repository.setCheckSLA(checkSLA);
+        repository.setCheckSLA(checkSLA != null ? checkSLA : false );
         repository.setDropExporterType(dropExporterConfiguration.getType());
 
         if (sourceLocale == null) {
@@ -648,7 +648,6 @@ public class RepositoryService {
     public void updateRepository(Repository repository, String newName, String description, Boolean checkSLA, Set<RepositoryLocale> repositoryLocales, Set<AssetIntegrityChecker> assetIntegrityCheckers) throws RepositoryLocaleCreationException, RepositoryNameAlreadyUsedException {
 
         logger.debug("Update a repository with name: {}", repository.getName());
-        repository.setCheckSLA(checkSLA);
 
         if (newName != null) {
             // check duplicated name


### PR DESCRIPTION
When you call the repo update command but don't specify the
checkSLA flag, nulls the flag which makes it false.  This
adds a null check and a test case to ensure this doesn't happen
in the future.