### PR TITLE
dedupe asset text unit in master when pushing new branch

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/AssetExtractionStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/AssetExtractionStep.java
@@ -1,13 +1,18 @@
 package com.box.l10n.mojito.okapi;
 
 import com.box.l10n.mojito.entity.AssetExtraction;
+import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.Branch;
 import com.box.l10n.mojito.entity.PluralForm;
 import com.box.l10n.mojito.okapi.filters.PluralFormAnnotation;
 import com.box.l10n.mojito.okapi.filters.UsagesAnnotation;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
+import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
+import com.box.l10n.mojito.service.branch.BranchRepository;
 import com.box.l10n.mojito.service.pluralform.PluralFormService;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import net.sf.okapi.common.Event;
 import org.slf4j.Logger;
@@ -41,6 +46,12 @@ public class AssetExtractionStep extends AbstractMd5ComputationStep {
     @Autowired
     PluralFormService pluralFormService;
 
+    @Autowired
+    AssetTextUnitRepository assetTextUnitRepository;
+
+    @Autowired
+    BranchRepository branchRepository;
+
     Set<String> assetTextUnitMD5s;
 
     AssetExtraction assetExtraction;
@@ -67,6 +78,10 @@ public class AssetExtractionStep extends AbstractMd5ComputationStep {
     @Override
     protected Event handleStartDocument(Event event) {
         assetTextUnitMD5s = new HashSet<>();
+        Branch masterBranch = branchRepository.findByNameAndRepository("master", assetExtraction.getAsset().getRepository());
+        for (AssetTextUnit assetTextUnit : assetTextUnitRepository.findByBranch(masterBranch)) {
+            assetTextUnitMD5s.add(assetTextUnit.getMd5());
+        }
         return super.handleStartDocument(event);
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetTextUnit/AssetTextUnitRepository.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import com.box.l10n.mojito.entity.Branch;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -53,4 +54,5 @@ public interface AssetTextUnitRepository extends JpaRepository<AssetTextUnit, Lo
 
     List<AssetTextUnit> findByIdIn(List<Long> assetTextUnitIds);
 
+    List<AssetTextUnit> findByBranch(Branch branch);
 }


### PR DESCRIPTION
There can be lots of duplicate text units which already exist in master branch when new branch is being pushed. This is to dedupe asset text unit.