### PR TITLE
Implemented partially imported drop

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
@@ -96,6 +96,10 @@ public class Drop extends AuditableEntity {
     @JsonView(View.DropSummary.class)
     protected Boolean importFailed;
 
+    @JsonView(View.DropSummary.class)
+    @Column(name = "partiallyImported")
+    private Boolean partiallyImported = false;
+
     public User getCreatedByUser() {
         return createdByUser;
     }
@@ -191,6 +195,14 @@ public class Drop extends AuditableEntity {
 
     public void setImportFailed(Boolean importFailed) {
         this.importFailed = importFailed;
+    }
+
+    public Boolean getPartiallyImported() {
+        return partiallyImported;
+    }
+
+    public void setPartiallyImported(Boolean partiallyImported) {
+        this.partiallyImported = partiallyImported;
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
@@ -97,7 +97,7 @@ public class Drop extends AuditableEntity {
     protected Boolean importFailed;
 
     @JsonView(View.DropSummary.class)
-    @Column(name = "partiallyImported")
+    @Column(name = "partially_imported")
     private Boolean partiallyImported = false;
 
     public User getCreatedByUser() {

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TranslationKit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TranslationKit.java
@@ -108,6 +108,10 @@ public class TranslationKit extends AuditableEntity {
     @Column(name = "word_count")
     private Long wordCount;
 
+    @JsonView(View.DropSummary.class)
+    @Column(name = "imported")
+    private Boolean imported = false;
+
     @ElementCollection
     @CollectionTable(name = "translation_kit_not_found_text_unit_ids",
             joinColumns = @JoinColumn(name = "TRANSLATION_KIT_ID"), foreignKey = @ForeignKey(name = "FK__TRANSLATION_KIT_NOT_FOUND_TEXT_UNIT_IDS__TRANSLATION_KIT__ID"))
@@ -117,6 +121,14 @@ public class TranslationKit extends AuditableEntity {
     @ManyToOne
     @JoinColumn(name = BaseEntity.CreatedByUserColumnName, foreignKey = @ForeignKey(name = "FK__TRANSLATION_KIT__USER__ID"))
     protected User createdByUser;
+
+    public Boolean getImported() {
+        return imported;
+    }
+
+    public void setImported(Boolean imported) {
+        this.imported = imported;
+    }
 
     public User getCreatedByUser() {
         return createdByUser;

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropSpecification.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropSpecification.java
@@ -32,12 +32,14 @@ public class DropSpecification {
                 Predicate predicate;
 
                 if (imported) {
-                    predicate = builder.and(builder.isNotNull(root.get(Drop_.lastImportedDate)),
+                    predicate = builder.and(builder.isFalse(root.get(Drop_.partiallyImported)),
+                            builder.isNotNull(root.get(Drop_.lastImportedDate)),
                             builder.or(builder.isNull(root.get(Drop_.importFailed)), builder.isFalse(root.get(Drop_.importFailed))),
                             builder.isNotNull(root.get(Drop_.importPollableTask)),
                             builder.isNotNull(root.join(Drop_.importPollableTask, JoinType.LEFT).get(PollableTask_.finishedDate)));
                 } else {
-                    predicate = builder.or(builder.isNull(root.get(Drop_.lastImportedDate)),
+                    predicate = builder.or(builder.isTrue(root.get(Drop_.partiallyImported)),
+                            builder.isNull(root.get(Drop_.lastImportedDate)),
                             builder.isTrue(root.get(Drop_.importFailed)),
                             builder.isNull(root.get(Drop_.importPollableTask)),
                             builder.isNull(root.join(Drop_.importPollableTask, JoinType.LEFT).get(PollableTask_.finishedDate)));

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import static org.springframework.data.jpa.domain.Specifications.where;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -159,6 +160,24 @@ public class DropWS {
         cancelDropConfig.setPollableTask(cancelDropFuture.getPollableTask());
 
         return cancelDropConfig;
+    }
+
+    /**
+     * WS to force complete a partially imported drop
+     *
+     * @param dropId
+     * @throws DropWithIdNotFoundException
+     */
+    @RequestMapping(value = "/api/drops/complete/{dropId}", method = RequestMethod.POST)
+    public void completeDropById(@PathVariable Long dropId) throws DropWithIdNotFoundException {
+        Drop drop = dropRepository.findOne(dropId);
+
+        if (drop == null) {
+            throw new DropWithIdNotFoundException(dropId);
+        }
+
+        dropService.completeDrop(drop);
+
     }
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWithIdNotFoundException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWithIdNotFoundException.java
@@ -1,0 +1,15 @@
+package com.box.l10n.mojito.rest.drop;
+
+import com.box.l10n.mojito.rest.EntityWithIdNotFoundException;
+
+/**
+ *
+ * @author jyi
+ */
+public class DropWithIdNotFoundException extends EntityWithIdNotFoundException {
+
+    public DropWithIdNotFoundException(Long id) {
+        super("Drop", id);
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service to generate {@link Drop}s.
@@ -418,5 +419,16 @@ public class DropService {
      */
     protected boolean hasDropExportStart(Drop drop) {
         return drop.getDropExporterConfig() != null;
+    }
+
+    /**
+     * Force complete a partially imported drop
+     *
+     * @param drop
+     */
+    @Transactional
+    public void completeDrop(Drop drop) {
+        drop.setPartiallyImported(Boolean.FALSE);
+        dropRepository.save(drop);
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitRepository.java
@@ -1,6 +1,9 @@
 package com.box.l10n.mojito.service.translationkit;
 
+import com.box.l10n.mojito.entity.Drop;
+import com.box.l10n.mojito.entity.Locale;
 import com.box.l10n.mojito.entity.TranslationKit;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
@@ -9,5 +12,9 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
  */
 @RepositoryRestResource(exported = false)
 public interface TranslationKitRepository extends JpaRepository<TranslationKit, Long> {
+
+    List<TranslationKit> findByDropId(Long dropId);
+
+    TranslationKit findByDropAndLocale(Drop drop, Locale locale);
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
@@ -275,8 +275,28 @@ public class TranslationKitService {
         translationKit.setNumSourceEqualsTarget(translationKitTextUnitRepository.countByTranslationKitAndSourceEqualsTargetTrue(translationKit));
         translationKit.setNumBadLanguageDetections(translationKitTextUnitRepository.countByTranslationKitAndDetectedLanguageNotEqualsDetectedLanguageExpected(translationKit));
         translationKit.setNotFoundTextUnitIds(notFoundTextUnitIds);
+        if (translationKit.getNumTranslatedTranslationKitUnits() > 0) {
+            translationKit.setImported(true);
+        }
 
         translationKitRepository.save(translationKit);
+        checkForPartiallyImported(translationKit.getDrop().getId());
+
+    }
+
+    @Transactional
+    public void checkForPartiallyImported(Long dropId) {
+        Drop drop = dropRepository.findOne(dropId);
+        List<TranslationKit> translationKits = translationKitRepository.findByDropId(drop.getId());
+        boolean partiallyImported = false;
+        for (TranslationKit translationKit : translationKits) {
+            if (!translationKit.getImported()) {
+                partiallyImported = true;
+                break;
+            }
+        }
+        drop.setPartiallyImported(partiallyImported);
+        dropRepository.save(drop);
     }
 
     /**

--- a/webapp/src/main/resources/db/migration/V44__Add_imported.sql
+++ b/webapp/src/main/resources/db/migration/V44__Add_imported.sql
@@ -1,2 +1,2 @@
-alter table `drop` add column partiallyImported bit not null default false;
+alter table `drop` add column partially_imported bit not null default false;
 alter table translation_kit add column imported bit not null default false;

--- a/webapp/src/main/resources/db/migration/V44__Add_imported.sql
+++ b/webapp/src/main/resources/db/migration/V44__Add_imported.sql
@@ -1,0 +1,2 @@
+alter table `drop` add column partiallyImported bit not null default false;
+alter table translation_kit add column imported bit not null default false;

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -404,6 +404,9 @@ drops.tableHeader.repository=Repository
 # Table header title for translation request - status of the translation req
 drops.tableHeader.status=Status
 
+# Label to show done - meaning that it was imported successfully
+drops.table.row.imported=Imported
+
 # Modal title for making a new translation request
 drops.newRequestModal.title=Select a Repository to Create a Request
 
@@ -424,6 +427,9 @@ drops.status.exportFailed=Export Failed
 
 # Status label for drop when it has failed to import
 drops.status.importFailed=Import Failed
+
+# Status label for drop when it has been partially imported
+drops.status.partiallyImported=Partially Imported
 
 # Status label for drop when it has been imported
 drops.status.imported=Imported

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -449,6 +449,9 @@ drops.status.inReview=In Review
 # Tooltip on import drop button
 drops.controlbar.button.tooltip.import=Import Request
 
+# Tooltip on complete drop button
+drops.controlbar.button.tooltip.complete=Complete Request
+
 # Tooltip on cancel drop button
 drops.controlbar.button.tooltip.cancel=Cancel Request
 

--- a/webapp/src/main/resources/public/js/actions/drop/dropActions.js
+++ b/webapp/src/main/resources/public/js/actions/drop/dropActions.js
@@ -19,6 +19,9 @@ class dropActions {
             "importRequest",
             "importRequestSuccess",
             "importRequestError",
+            "completeRequest",
+            "completeRequestSuccess",
+            "completeRequestError",
             "cancelRequest",
             "cancelRequestSuccess",
             "cancelRequestError"

--- a/webapp/src/main/resources/public/js/components/drops/DropDetail.js
+++ b/webapp/src/main/resources/public/js/components/drops/DropDetail.js
@@ -38,6 +38,13 @@ let DropDetail = React.createClass({
         let translationKits = Locales.sortByDisplayName(this.props.drop.translationKits, translationKit => translationKit.locale.bcp47Tag);
 
         let rows = translationKits.map(tk => {
+            let importLabel = tk.imported ?
+                (
+                    <Label bsStyle="success" className="mrs">
+                        <FormattedMessage id="drops.table.row.imported"/>
+                    </Label>
+                ) : "";
+
             return <tr key={"DropDetail.row." + tk.localeDisplayName}>
                 <td>
                     <div>
@@ -45,6 +52,7 @@ let DropDetail = React.createClass({
                               to='/workbench'>{tk.localeDisplayName}</Link>
                     </div>
                 </td>
+                <td>{importLabel}</td>
                 <td><FormattedNumber value={tk.wordCount}/></td>
             </tr>;
         });
@@ -56,6 +64,7 @@ let DropDetail = React.createClass({
                             <thead>
                             <tr>
                                 <th><FormattedMessage id="drops.tableHeader.locales" /></th>
+                                <th></th>
                                 <th><FormattedMessage id="drops.tableHeader.wordCount" /></th>
                             </tr>
                             </thead>

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -174,6 +174,15 @@ let Drops = React.createClass({
     },
 
     /**
+     * Handle complete onclick event
+     */
+    onClickComplete(dropId) {
+        DropActions.completeRequest(dropId);
+
+        this.delayGetNewRequests(500);
+    },
+
+    /**
      * handle cancel drop onclick event
      * @param {Number} dropId
      * @param {Number} repoId
@@ -320,6 +329,7 @@ let Drops = React.createClass({
         let repoId = drop.repository.id;
 
         let importTitle = <Tooltip id="Drops.tooltip.import"><FormattedMessage id="drops.controlbar.button.tooltip.import"/></Tooltip>;
+        let completeTitle = <Tooltip id="Drops.tooltip.complete"><FormattedMessage id="drops.controlbar.button.tooltip.complete"/></Tooltip>;
         let cancelTitle = <Tooltip id="Drops.tooltip.cancel"><FormattedMessage id="drops.controlbar.button.tooltip.cancel"/></Tooltip>;
 
         let importOverlay = "";
@@ -327,6 +337,15 @@ let Drops = React.createClass({
             importOverlay = (<OverlayTrigger placement="top" overlay={importTitle}>
                 <Button bsStyle="default" onClick={this.onClickImport.bind(this, dropId, repoId)}>
                     <span className="glyphicon glyphicon-import" aria-label={importTitle}/>
+                </Button>
+            </OverlayTrigger>);
+        }
+
+        let completeOverlay = "";
+        if (drop.completable()) {
+            completeOverlay = (<OverlayTrigger placement="top" overlay={completeTitle}>
+                <Button bsStyle="default" onClick={this.onClickComplete.bind(this, dropId)}>
+                    <span className="glyphicon glyphicon-check" aria-label={completeTitle}/>
                 </Button>
             </OverlayTrigger>);
         }
@@ -344,6 +363,7 @@ let Drops = React.createClass({
             <ButtonToolbar>
                 <ButtonGroup>
                     {importOverlay}
+                    {completeOverlay}
                     {cancelOverlay}
                 </ButtonGroup>
             </ButtonToolbar>

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -224,6 +224,9 @@ let Drops = React.createClass({
         let status = "";
 
         switch (drop.status) {
+            case Drop.STATUS_TYPE.PARTIALLY_IMPORTED:
+                status = this.props.intl.formatMessage({id: "drops.status.partiallyImported"});
+                break;
             case Drop.STATUS_TYPE.IMPORTED:
                 status = this.props.intl.formatMessage({id: "drops.status.imported"});
                 break;

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -178,7 +178,6 @@ let Drops = React.createClass({
      */
     onClickComplete(dropId) {
         DropActions.completeRequest(dropId);
-
         this.delayGetNewRequests(500);
     },
 

--- a/webapp/src/main/resources/public/js/sdk/DropClient.js
+++ b/webapp/src/main/resources/public/js/sdk/DropClient.js
@@ -54,6 +54,15 @@ class DropClient extends BaseClient {
     }
 
     /**
+     * @param {number} dropId
+     * @return {Promise}
+     */
+    completeDrop(dropId) {
+        let promise = this.post(this.getUrl() + "/complete/" + dropId);
+        return promise.then((result) => result);
+    }
+
+    /**
      * @param {CancelDropConfig} cancelDropConfig
      * @return {Promise}
      */

--- a/webapp/src/main/resources/public/js/sdk/drop/Drop.js
+++ b/webapp/src/main/resources/public/js/sdk/drop/Drop.js
@@ -55,6 +55,9 @@ export default class Drop {
 
         /** @type {Boolean|null} */
         this.importFailed = false;
+
+        /** @type {Boolean|null} */
+        this.partiallyImported = false;
     }
 
     getId() {
@@ -147,12 +150,7 @@ export default class Drop {
         } else if (this.isBeingImported()) {
             status = Drop.STATUS_TYPE.IMPORTING;
         } else if (this.lastImportedDate !== null) {
-            status = Drop.STATUS_TYPE.IMPORTED;
-            for (let translationKit of this.translationKits) {
-                if (translationKit.imported === false) {
-                    status = Drop.STATUS_TYPE.PARTIALLY_IMPORTED;
-                }
-            }
+            status = this.partiallyImported ? Drop.STATUS_TYPE.PARTIALLY_IMPORTED : Drop.STATUS_TYPE.IMPORTED;
         } else if (this.translationKits.length > 0) {
             if (this.translationKits[0].type.equals(StatusFilter.Type.Translation)) {
                 status = Drop.STATUS_TYPE.IN_TRANSLATION;
@@ -187,6 +185,7 @@ export default class Drop {
         return !this.isBeingExported() &&
                !this.isBeingImported() &&
                this.status !== Drop.STATUS_TYPE.IMPORTED &&
+               this.status !== Drop.STATUS_TYPE.PARTIALLY_IMPORTED &&
                this.status !== Drop.STATUS_TYPE.CANCELED;
     }
 
@@ -196,6 +195,15 @@ export default class Drop {
     importable() {
         return this.status !== Drop.STATUS_TYPE.EXPORT_FAILED &&
                this.status !== Drop.STATUS_TYPE.CANCELED;
+    }
+
+    /**
+     * @return {boolean}
+     */
+    completable() {
+        return this.status !== Drop.STATUS_TYPE.EXPORT_FAILED &&
+               this.status !== Drop.STATUS_TYPE.CANCELED &&
+               this.status === Drop.STATUS_TYPE.PARTIALLY_IMPORTED;
     }
 
     /**
@@ -235,6 +243,10 @@ export default class Drop {
 
         if (json.importFailed) {
             result.importFailed = json.importFailed;
+        }
+
+        if (json.partiallyImported) {
+            result.partiallyImported = json.partiallyImported;
         }
 
         result.translationKits = TranslationKit.toTranslationKits(json.translationKits);

--- a/webapp/src/main/resources/public/js/sdk/drop/Drop.js
+++ b/webapp/src/main/resources/public/js/sdk/drop/Drop.js
@@ -148,6 +148,11 @@ export default class Drop {
             status = Drop.STATUS_TYPE.IMPORTING;
         } else if (this.lastImportedDate !== null) {
             status = Drop.STATUS_TYPE.IMPORTED;
+            for (let translationKit of this.translationKits) {
+                if (translationKit.imported === false) {
+                    status = Drop.STATUS_TYPE.PARTIALLY_IMPORTED;
+                }
+            }
         } else if (this.translationKits.length > 0) {
             if (this.translationKits[0].type.equals(StatusFilter.Type.Translation)) {
                 status = Drop.STATUS_TYPE.IN_TRANSLATION;
@@ -264,6 +269,7 @@ Drop.STATUS_TYPE = {
     SENDING: Symbol(),
     IN_TRANSLATION: Symbol(),
     IN_REVIEW: Symbol(),
+    PARTIALLY_IMPORTED: Symbol(),
     IMPORTED: Symbol(),
     IMPORTING: Symbol(),
     CANCELED: Symbol(),

--- a/webapp/src/main/resources/public/js/sdk/entity/TranslationKit.js
+++ b/webapp/src/main/resources/public/js/sdk/entity/TranslationKit.js
@@ -40,6 +40,9 @@ export default class TranslationKit {
 
         /** @type {Number} */
         this.wordCount =  0;
+
+        /** @type {Boolean} */
+        this.imported = false;
     }
 
     /**
@@ -61,6 +64,7 @@ export default class TranslationKit {
         result.numTranslationKitUnits = json.numTranslationKitUnits;
         result.type = new StatusFilter(json.type);
         result.wordCount = json.wordCount;
+        result.imported = json.imported;
 
         return result;
     }

--- a/webapp/src/main/resources/public/js/stores/drop/DropDataSource.js
+++ b/webapp/src/main/resources/public/js/stores/drop/DropDataSource.js
@@ -43,6 +43,14 @@ const DropDataSource = {
         error: DropActions.importRequestError
     },
 
+    completeRequest: {
+        remote(dropStoreState, dropId) {
+            return DropClient.completeDrop(dropId);
+        },
+        success: DropActions.completeRequestSuccess,
+        error: DropActions.completeRequestError
+    },
+
     cancelRequest: {
         remote(dropStoreState, cancelDropConfig) {
             return DropClient.cancelDrop(cancelDropConfig);

--- a/webapp/src/main/resources/public/js/stores/drop/DropStore.js
+++ b/webapp/src/main/resources/public/js/stores/drop/DropStore.js
@@ -84,6 +84,13 @@ class DropStore {
     }
 
     /**
+     * @param {number} dropId
+     */
+    onCompleteRequest(dropId) {
+        this.getInstance().completeRequest(dropId);
+    }
+
+    /**
      * @param {CancelDropConfig} cancelDropConfig
      */
     onCancelRequest(cancelDropConfig) {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -148,6 +149,21 @@ public class DropServiceTest extends ServiceTestBase {
 
         logger.debug("Check everything is still untranslated");
         checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 4);
+        checkTranslationKitImported(drop.getId(), false);
+    }
+
+    @Transactional
+    public void checkTranslationKitImported(Long dropId, boolean expected) {
+        Drop drop = dropRepository.findOne(dropId);
+        if (expected) {
+            assertFalse(drop.getPartiallyImported());
+        } else {
+            assertTrue(drop.getPartiallyImported());
+        }
+        List<TranslationKit> translationKits = translationKitRepository.findByDropId(dropId);
+        for (TranslationKit translationKit : translationKits) {
+            assertEquals(expected, translationKit.getImported());
+        }
     }
 
     @Test
@@ -662,6 +678,7 @@ public class DropServiceTest extends ServiceTestBase {
 
             assertEquals("For locale: " + tk.getLocale().getBcp47Tag(), tk.getNumTranslationKitUnits(), tk.getNumTranslatedTranslationKitUnits());
             assertNotNull(tk.getWordCount());
+            assertTrue(tk.getImported());
 
             if (tk.getLocale().getBcp47Tag().equals("ko-KR")) {
                 assertEquals("For locale: " + tk.getLocale().getBcp47Tag(), 1, tk.getNotFoundTextUnitIds().size());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -150,6 +150,17 @@ public class DropServiceTest extends ServiceTestBase {
         logger.debug("Check everything is still untranslated");
         checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 4);
         checkTranslationKitImported(drop.getId(), false);
+
+        logger.debug("Force complete");
+        forceCompleteDrop(drop.getId());
+    }
+
+    @Transactional
+    public void forceCompleteDrop(Long dropId) {
+        Drop drop = dropRepository.findOne(dropId);
+        assertTrue(drop.getPartiallyImported());
+        dropService.completeDrop(drop);
+        assertFalse(drop.getPartiallyImported());
     }
 
     @Transactional


### PR DESCRIPTION
Sometimes some languages are delayed and the drop is partially imported. Current behavior is that the drop is considered to have `Imported` status as long as there is at least one xliff that was imported successfully. It's hard to distinguish between the fully completed drop and the partially completed drop. 

Partially completed drop should appear under `In Progress` filter with `Partially Imported` status. Also the detail should show which language was imported.

<img width="1360" alt="Screen Shot 2019-04-16 at 10 52 10 AM" src="https://user-images.githubusercontent.com/17402500/56234260-c1a92180-6039-11e9-83cd-e4769ce74299.png">
