### PR TITLE
Make delete command asynchrous

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/BranchDeleteCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/BranchDeleteCommand.java
@@ -8,6 +8,7 @@ import com.box.l10n.mojito.cli.command.param.Param;
 import com.box.l10n.mojito.rest.client.AssetClient;
 import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.entity.Branch;
+import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
 import org.fusesource.jansi.Ansi;
 import org.slf4j.Logger;
@@ -48,14 +49,16 @@ public class BranchDeleteCommand extends Command {
     @Override
     public void execute() throws CommandException {
         consoleWriter.newLine().a("Delete branch: ").fg(Ansi.Color.CYAN).a(branchName).reset()
-                .a(" from repository: ").fg(Ansi.Color.CYAN).a(repositoryParam).println(2);
+                .a(" from repository: ").fg(Ansi.Color.CYAN).a(repositoryParam).println(1);
         Repository repository = commandHelper.findRepositoryByName(repositoryParam);
         Branch branchToRemove = repositoryClient.getBranch(repository.getId(), branchName);
 
         if (branchToRemove == null) {
             throw new CommandException(String.format("Cannot find branch in %s by branchName %s.", repositoryParam, branchName));
         }
-        repositoryClient.deleteBranch(branchToRemove.getId(), repository.getId());
+        PollableTask pollableTask = repositoryClient.deleteBranch(branchToRemove.getId(), repository.getId());
+        commandHelper.waitForPollableTask(pollableTask.getId());
+
         consoleWriter.newLine().a("deleted --> branch name: ").fg(Ansi.Color.MAGENTA).a(branchName).println();
     }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
@@ -61,9 +61,6 @@ public class CommandHelper {
     PollableTaskClient pollableTaskClient;
 
     @Autowired
-    CommandWaitForPollableTaskListener commandWaitForPollableTaskListener;
-
-    @Autowired
     ConsoleWriter consoleWriter;
 
     /**
@@ -225,7 +222,7 @@ public class CommandHelper {
         consoleWriter.newLine().a("Running, task id: ").fg(Ansi.Color.MAGENTA).a(pollableId).a(" ").println();
 
         try {
-            pollableTaskClient.waitForPollableTask(pollableId, PollableTaskClient.NO_TIMEOUT, commandWaitForPollableTaskListener);
+            pollableTaskClient.waitForPollableTask(pollableId, PollableTaskClient.NO_TIMEOUT, new CommandWaitForPollableTaskListener());
         } catch (PollableTaskException e) {
             throw new CommandException(e.getMessage(), e.getCause());
         }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandWaitForPollableTaskListener.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandWaitForPollableTaskListener.java
@@ -8,6 +8,7 @@ import org.fusesource.jansi.Ansi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -15,7 +16,7 @@ import org.springframework.stereotype.Component;
  *
  * @author jaurambault
  */
-@Component
+@Configurable
 public class CommandWaitForPollableTaskListener implements WaitForPollableTaskListener {
 
     /**

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -140,7 +140,8 @@ public class PushCommand extends Command {
             SourceAsset assetAfterSend = assetClient.sendSourceAsset(sourceAsset);
             pollableTasks.add(assetAfterSend.getPollableTask());
 
-            consoleWriter.a(" --> asset id: ").fg(Ansi.Color.MAGENTA).a(assetAfterSend.getAddedAssetId()).println();
+            consoleWriter.a(" --> asset id: ").fg(Ansi.Color.MAGENTA).a(assetAfterSend.getAddedAssetId()).reset().
+                    a(", task: ").fg(Ansi.Color.MAGENTA).a(assetAfterSend.getPollableTask().getId()).println();
             usedAssetIds.add(assetAfterSend.getAddedAssetId());
         }
 
@@ -163,8 +164,10 @@ public class PushCommand extends Command {
 
             assetIds.removeAll(usedAssetIds);
             if (!assetIds.isEmpty()) {
-                assetClient.deleteAssetsInBranch(assetIds, branch.getId());
-                consoleWriter.newLine().a("Delete assets from repository, ids: ").fg(Ansi.Color.CYAN).a(assetIds.toString()).println(2);
+                consoleWriter.newLine().a("Delete assets from repository, ids: ").fg(Ansi.Color.CYAN).a(assetIds.toString()).println();
+                PollableTask pollableTask = assetClient.deleteAssetsInBranch(assetIds, branch.getId());
+                consoleWriter.a(" --> task id: ").fg(Ansi.Color.MAGENTA).a(pollableTask.getId()).println();
+                commandHelper.waitForPollableTask(pollableTask.getId());
             }
         }
 
@@ -173,6 +176,7 @@ public class PushCommand extends Command {
 
     /**
      * Get fileMatch list contains git changes against git tree HEAD
+     *
      * @param sourceFileMatches
      * @return
      * @throws CommandException

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
@@ -6,6 +6,7 @@ import com.box.l10n.mojito.rest.entity.FilterConfigIdOverride;
 import com.box.l10n.mojito.rest.entity.ImportLocalizedAssetBody;
 import com.box.l10n.mojito.rest.entity.Locale;
 import com.box.l10n.mojito.rest.entity.LocalizedAssetBody;
+import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
 import com.box.l10n.mojito.rest.entity.SourceAsset;
 import com.box.l10n.mojito.rest.entity.XliffExportBody;
@@ -16,6 +17,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -301,11 +303,10 @@ public class AssetClient extends BaseClient {
 
     /**
      * Deletes multiple {@link Asset} by the list of {@link Asset#id} of a given branch
-     *
-     * @param assetIds
+     *  @param assetIds
      * @param branchId
      */
-    public void deleteAssetsInBranch(Set<Long> assetIds, Long branchId) {
+    public PollableTask deleteAssetsInBranch(Set<Long> assetIds, Long branchId) {
         logger.debug("Deleting assets by asset ids = {} or branch id: {}", assetIds.toString(), branchId);
 
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromPath(getBasePath() + "/assets");
@@ -316,7 +317,7 @@ public class AssetClient extends BaseClient {
 
         HttpEntity<Set<Long>> httpEntity = new HttpEntity<>(assetIds);
         String uriString = uriComponentsBuilder.toUriString();
-        authenticatedRestTemplate.delete(uriString, httpEntity);
+        return authenticatedRestTemplate.deleteForObject(uriString, httpEntity, PollableTask.class);
     }
 
     /**

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
@@ -7,11 +7,13 @@ import com.box.l10n.mojito.rest.entity.Branch;
 import com.box.l10n.mojito.rest.entity.ImportRepositoryBody;
 import com.box.l10n.mojito.rest.entity.IntegrityChecker;
 import com.box.l10n.mojito.rest.entity.Locale;
+import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
 import com.box.l10n.mojito.rest.entity.RepositoryLocale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -231,11 +233,12 @@ public class RepositoryClient extends BaseClient {
         return branch;
     }
 
-    public void deleteBranch(Long branchId, Long repositoryId) {
+    public PollableTask deleteBranch(Long branchId, Long repositoryId) {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.
                 fromPath(getBasePathForResource(repositoryId, "branches")).
                 queryParam("branchId", branchId);
-        authenticatedRestTemplate.delete(uriComponentsBuilder.build().toUriString());
+
+        return authenticatedRestTemplate.deleteForObject(uriComponentsBuilder.build().toUriString(), null, PollableTask.class);
     }
 
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
@@ -265,8 +265,12 @@ public class AuthenticatedRestTemplate {
         return restTemplate.postForEntity(getURIForResource(resourcePath), request, responseType);
     }
 
+    public <T> T deleteForObject(String resourcePath, HttpEntity request, Class<T> responseType) throws RestClientException {
+        return restTemplate.exchange(getURIForResource(resourcePath), HttpMethod.DELETE, request, responseType).getBody();
+    }
+
     public void delete(String resourcePath, HttpEntity request) throws RestClientException {
-        restTemplate.exchange(getURIForResource(resourcePath), HttpMethod.DELETE, request,  Void.class);
+        deleteForObject(resourcePath, request, Void.class);
     }
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -35,11 +35,9 @@ public class QuartzPollableTaskScheduler {
     @Autowired
     ObjectMapper objectMapper;
 
-
     public <T> PollableFuture<T> scheduleJob(Class<? extends QuartzPollableJob> clazz, Object input) {
         return scheduleJob(clazz, input, null, null, 0);
     }
-
 
     public <T> PollableFuture<T> scheduleJob(Class<? extends QuartzPollableJob> clazz,
                                              Object input,

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -11,6 +11,8 @@ import com.box.l10n.mojito.rest.View;
 import com.box.l10n.mojito.service.NormalizationUtils;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.asset.VirtualAssetRequiredException;
+import com.box.l10n.mojito.service.asset.VirtualAssetTextUnit;
 import com.box.l10n.mojito.service.assetExtraction.extractor.UnsupportedAssetFilterTypeException;
 import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.pollableTask.PollableFuture;
@@ -298,12 +300,12 @@ public class AssetWS {
      * @return
      */
     @RequestMapping(value = "/api/assets", method = RequestMethod.DELETE)
-    public void deleteAssetsOfBranches(@RequestParam(value = "branchId", required = false) Long branchId,
-                                       @RequestBody Set<Long> ids) {
+    public PollableTask deleteAssetsOfBranches(@RequestParam(value = "branchId", required = false) Long branchId,
+                                               @RequestBody Set<Long> ids) {
         logger.debug("Deleting assets: {} for branch id: {}", ids.toString(), branchId);
-        assetService.deleteAssetsOfBranch(ids, branchId);
+        PollableFuture pollableFuture = assetService.asyncDeleteAssetsOfBranch(ids, branchId);
+        return pollableFuture.getPollableTask();
     }
-
 
     /**
      * Returns list of {@link Asset#id} for a given {@link Repository}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
@@ -1,12 +1,14 @@
 package com.box.l10n.mojito.rest.repository;
 
 import com.box.l10n.mojito.entity.Branch;
+import com.box.l10n.mojito.entity.PollableTask;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.rest.View;
 import com.box.l10n.mojito.service.NormalizationUtils;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.branch.BranchRepository;
 import com.box.l10n.mojito.service.branch.BranchService;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.repository.RepositoryLocaleCreationException;
 import com.box.l10n.mojito.service.repository.RepositoryNameAlreadyUsedException;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
@@ -247,11 +249,12 @@ public class RepositoryWS {
     }
 
     @RequestMapping(value ="/api/repositories/{repositoryId}/branches", method = RequestMethod.DELETE)
-    public void deleteBranch(@PathVariable(value = "repositoryId") Long repositoryId,
-                             @RequestParam(value = "branchId") Long branchId) {
+    public PollableTask deleteBranch(@PathVariable(value = "repositoryId") Long repositoryId,
+                                     @RequestParam(value = "branchId") Long branchId) {
 
         logger.debug("Deleting branch {} in repository {}", repositoryId, branchId);
-        branchService.deleteBranch(repositoryId, branchId);
+        PollableFuture pollableFuture = branchService.asyncDeleteBranch(repositoryId, branchId);
+        return pollableFuture.getPollableTask();
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/DeleteAssetsOfBranchJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/DeleteAssetsOfBranchJob.java
@@ -1,0 +1,30 @@
+package com.box.l10n.mojito.service.asset;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author jaurambault
+ */
+@Component
+public class DeleteAssetsOfBranchJob extends QuartzPollableJob<DeleteAssetsOfBranchJobInput, Void> {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(DeleteAssetsOfBranchJob.class);
+
+    @Autowired
+    AssetService assetService;
+
+    @Override
+    public Void call(DeleteAssetsOfBranchJobInput input) throws Exception {
+        logger.debug("DeleteAssetsOfBranchJob");
+        assetService.deleteAssetsOfBranch(input.getAssetIds(), input.getBranchId());
+        return null;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/DeleteAssetsOfBranchJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/DeleteAssetsOfBranchJobInput.java
@@ -1,0 +1,27 @@
+package com.box.l10n.mojito.service.asset;
+
+import java.util.Set;
+
+/**
+ * @author jaurambault
+ */
+public class DeleteAssetsOfBranchJobInput {
+    Set<Long> assetIds;
+    long branchId;
+
+    public Set<Long> getAssetIds() {
+        return assetIds;
+    }
+
+    public void setAssetIds(Set<Long> assetIds) {
+        this.assetIds = assetIds;
+    }
+
+    public long getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(long branchId) {
+        this.branchId = branchId;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/DeleteBranchJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/DeleteBranchJob.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.service.branch;
+
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.asset.VirtualTextUnitBatchUpdaterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author jaurambault
+ */
+@Component
+public class DeleteBranchJob extends QuartzPollableJob<DeleteBranchJobInput, Void> {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(DeleteBranchJob.class);
+
+    @Autowired
+    BranchService branchService;
+
+    @Override
+    public Void call(DeleteBranchJobInput input) throws Exception {
+        logger.debug("DeleteAssetsOfBranchJob");
+        branchService.deleteBranch(input.getRepositoryId(), input.getBranchId());
+        return null;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/DeleteBranchJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/DeleteBranchJobInput.java
@@ -1,0 +1,27 @@
+package com.box.l10n.mojito.service.branch;
+
+import java.util.Set;
+
+/**
+ * @author jaurambault
+ */
+public class DeleteBranchJobInput {
+    long repositoryId;
+    long branchId;
+
+    public long getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(long repositoryId) {
+        this.repositoryId = repositoryId;
+    }
+
+    public long getBranchId() {
+        return branchId;
+    }
+
+    public void setBranchId(long branchId) {
+        this.branchId = branchId;
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/asset/AssetWSTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/asset/AssetWSTest.java
@@ -9,6 +9,7 @@ import com.box.l10n.mojito.rest.WSTestDataFactory;
 import com.box.l10n.mojito.rest.client.AssetClient;
 import com.box.l10n.mojito.rest.client.PollableTaskClient;
 import com.box.l10n.mojito.rest.client.exception.RepositoryNotFoundException;
+import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
 import com.box.l10n.mojito.service.branch.BranchRepository;
@@ -154,7 +155,8 @@ public class AssetWSTest extends WSTestBase {
 
         Branch branch = branchRepository.findByNameAndRepository(null, repository);
 
-        assetClient.deleteAssetsInBranch(Sets.newHashSet(sourceAssetAfterPost2.getAddedAssetId(), sourceAssetAfterPost3.getAddedAssetId()), branch.getId());
+        PollableTask pollableTask = assetClient.deleteAssetsInBranch(Sets.newHashSet(sourceAssetAfterPost2.getAddedAssetId(), sourceAssetAfterPost3.getAddedAssetId()), branch.getId());
+        pollableTaskClient.waitForPollableTask(pollableTask.getId());
         assets = assetClient.getAssetsByRepositoryId(repository.getId());
         assertEquals("There should be three assets for this repository", 3, assets.size());
         assets = assetClient.getAssetsByRepositoryId(repository.getId(), false);


### PR DESCRIPTION
Since when deleting asset and when supporting branch current asset extraction needs to be recomputed, that operation can take some time.
It should be asychronous.

Also fix some small things when waiting for pollable and improve the output of the push command that got a little bit weird when parallel asset processing was added