### PR TITLE
Refactor Smartling client to use standard OAuth2RestTemplate

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
@@ -1,0 +1,106 @@
+package com.box.l10n.mojito.smartling;
+
+import com.box.l10n.mojito.smartling.request.AuthenticationData;
+import com.box.l10n.mojito.smartling.response.AuthenticationResponse;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.resource.UserApprovalRequiredException;
+import org.springframework.security.oauth2.client.resource.UserRedirectRequiredException;
+import org.springframework.security.oauth2.client.token.AccessTokenProvider;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.common.DefaultExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author jaurambault
+ */
+public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessTokenProvider {
+
+    static Logger logger = LoggerFactory.getLogger(SmartlingAuthorizationCodeAccessTokenProvider.class);
+
+    RestTemplate restTemplate = new RestTemplate();
+
+    public boolean supportsResource(OAuth2ProtectedResourceDetails resource) {
+        return resource instanceof SmartlingOAuth2ProtectedResourceDetails && "smartling".equals(resource.getGrantType());
+    }
+
+    @Override
+    public OAuth2AccessToken obtainAccessToken(OAuth2ProtectedResourceDetails details, AccessTokenRequest accessTokenRequest) throws UserRedirectRequiredException, UserApprovalRequiredException, AccessDeniedException {
+
+        logger.debug("Get access token");
+        Map<String, String> request = new HashMap<>();
+        request.put("userIdentifier", details.getClientId());
+        request.put("userSecret", details.getClientSecret());
+
+        DefaultOAuth2AccessToken defaultOAuth2AccessToken = null;
+        try {
+            DateTime now = getNowForToken();
+            AuthenticationResponse authenticationResponse = restTemplate.postForObject(details.getAccessTokenUri(), request, AuthenticationResponse.class);
+            defaultOAuth2AccessToken = getDefaultOAuth2AccessToken(now, authenticationResponse);
+        } catch (Exception e) {
+            String msg = "Can't get Smartling token";
+            logger.debug(msg, e);
+            throw new OAuth2AccessDeniedException(msg, details, e);
+        }
+
+        return defaultOAuth2AccessToken;
+    }
+
+    @Override
+    public OAuth2AccessToken refreshAccessToken(OAuth2ProtectedResourceDetails resource, OAuth2RefreshToken refreshToken, AccessTokenRequest accessTokenRequest) throws UserRedirectRequiredException {
+
+        logger.debug("Get refresh token");
+
+        SmartlingOAuth2ProtectedResourceDetails smartlingOAuth2ProtectedResourceDetails = (SmartlingOAuth2ProtectedResourceDetails) resource;
+        Map<String, String> request = new HashMap<>();
+        request.put("refreshToken", refreshToken.getValue());
+
+        DefaultOAuth2AccessToken defaultOAuth2AccessToken = null;
+        try {
+            DateTime now = getNowForToken();
+            AuthenticationResponse authenticationResponse = restTemplate.postForObject(smartlingOAuth2ProtectedResourceDetails.getRefreshUri(), request, AuthenticationResponse.class);
+            defaultOAuth2AccessToken = getDefaultOAuth2AccessToken(now, authenticationResponse);
+        } catch (Exception e) {
+            String msg = "Can't get Smartling refresh token";
+            logger.debug(msg, e);
+            throw new OAuth2AccessDeniedException(msg, resource, e);
+        }
+
+        return defaultOAuth2AccessToken;
+    }
+
+    @Override
+    public boolean supportsRefresh(OAuth2ProtectedResourceDetails resource) {
+        return true;
+    }
+
+    DefaultOAuth2AccessToken getDefaultOAuth2AccessToken(DateTime now, AuthenticationResponse authenticationResponse) {
+        AuthenticationData data = authenticationResponse.getResponse().getData();
+        DefaultOAuth2AccessToken defaultOAuth2AccessToken = new DefaultOAuth2AccessToken(data.getAccessToken());
+        defaultOAuth2AccessToken.setExpiration(now.plusSeconds(data.getExpiresIn()).toDate());
+        defaultOAuth2AccessToken.setRefreshToken(new DefaultExpiringOAuth2RefreshToken(
+                data.getRefreshToken(),
+                now.plusSeconds(data.getRefreshExpiresIn()).toDate()));
+        return defaultOAuth2AccessToken;
+    }
+
+    /**
+     * Since Smartling gives the TTL of the token but not the emission time, play safe taking now() minus 1 seconds as
+     * "now" time.
+     *
+     * @return
+     */
+    DateTime getNowForToken() {
+        return DateTime.now().minusSeconds(1);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
@@ -4,10 +4,15 @@ import com.box.l10n.mojito.smartling.response.AuthenticationResponse;
 import com.box.l10n.mojito.smartling.response.SourceStringsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.*;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplate;
 
+import javax.xml.transform.Source;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -16,6 +21,7 @@ import java.util.Map;
 /**
  * Smartling client based on the Web API: https://github.com/Smartling/api-sdk-java
  */
+@Component
 public class SmartlingClient {
 
     /**
@@ -23,137 +29,13 @@ public class SmartlingClient {
      */
     static Logger logger = LoggerFactory.getLogger(SmartlingClient.class);
 
-    private static final String DEFAULT_BASE_HOST = "https://api.smartling.com/";
-    private static final String AUTH_API_V2_AUTHENTICATE = DEFAULT_BASE_HOST + "auth-api/v2/authenticate";
-    private static final String AUTH_API_V2_REFRESH = DEFAULT_BASE_HOST + "auth-api/v2/authenticate/refresh";
-    private static final String API_PULL_SOURCE_STRINGS = DEFAULT_BASE_HOST + "strings-api/v2/projects/{projectId}/source-strings?fileUri={fileUri}&offset={offset}";
-    private static final String API_PUSH_NEW_CONTEXT = DEFAULT_BASE_HOST + "context-api/v2/projects/{projectId}/contexts";
-    private static final String API_BIND_CONTEXT_TO_HASHCODE = DEFAULT_BASE_HOST + "context-api/v2/projects/{projecId}/bindings";
+    static final String API_PULL_SOURCE_STRINGS = "strings-api/v2/projects/{projectId}/source-strings?fileUri={fileUri}&offset={offset}";
 
-    private RestTemplate restTemplate = new RestTemplate();
-
-    private String userIdentifier;
-    private String userSecret;
-    private String authToken = null;
-    private String refreshToken = null;
-    private Instant nextAuthentication = Instant.now();
-    private Instant nextRefresh = Instant.now();
-    // Refresh tokens are valid for up to 1 hour
-    private static final Integer refreshDurationMinutes = 50;
-    // Authentication tokens can be refreshed for up to 24 hours
-    private static final Integer authenticationDurationHours = 23;
-
-    public SmartlingClient(String userIdentifier, String userSecret) {
-        this.userIdentifier = userIdentifier;
-        this.userSecret = userSecret;
-    }
-
-    private Map<String, Object> getPayloadMapAuthentication() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("userIdentifier", userIdentifier);
-        map.put("userSecret", userSecret);
-        return map;
-    }
-
-    private Map<String, Object> getPayloadMapRefresh() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("refreshToken", refreshToken);
-        return map;
-    }
-
-    private Map<String, Object> getPayloadMapPullSourceString() {
-        return new HashMap<>();
-    }
-
-    private HttpHeaders getHttpHeadersForJson() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        return headers;
-    }
-
-    private HttpHeaders getHttpHeadersForJsonWithAuthorization() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("Authorization", "Bearer " + authToken);
-        return headers;
-    }
-
-    private <T> HttpEntity<T> getHttpEntityForPayload(T payload) {
-        return new HttpEntity<>(payload, getHttpHeadersForJson());
-    }
-
-    private <T> HttpEntity<T> getHttpEntityForPayloadWithAuthorization(T payload) {
-        return new HttpEntity<>(payload, getHttpHeadersForJsonWithAuthorization());
-    }
-
-    public void authenticate() throws SmartlingClientException {
-        Map<String, Object> payload = getPayloadMapAuthentication();
-        AuthenticationResponse authenticationResponse = postForAuthentication(payload, AUTH_API_V2_AUTHENTICATE);
-
-        if (authenticationResponse.isAuthenticationErrorResponse()) {
-            throw new SmartlingClientException("Error authenticating with Smartling API, please check your credentials.");
-        } else if (!authenticationResponse.isSuccessResponse()) {
-            throw new SmartlingClientException(authenticationResponse.getErrorMessage());
-        } else {
-            logger.debug("Successful authentication.");
-            Instant now = Instant.now();
-            nextAuthentication = now.plus(Duration.ofHours(authenticationDurationHours));
-            nextRefresh = now.plus(Duration.ofMinutes(refreshDurationMinutes));
-            authToken = authenticationResponse.getResponse().getData().getAccessToken();
-            refreshToken = authenticationResponse.getResponse().getData().getRefreshToken();
-        }
-    }
-
-    AuthenticationResponse postForAuthentication(Map<String, Object> payload, String authApiV2) throws SmartlingClientException {
-        HttpEntity<Map<String, Object>> httpEntity = getHttpEntityForPayload(payload);
-        AuthenticationResponse postForObject = restTemplate.postForObject(
-                authApiV2, httpEntity, AuthenticationResponse.class);
-        return postForObject;
-    }
-
-    public void refresh() throws SmartlingClientException {
-        Instant now = Instant.now();
-        Instant nextCalculatedRefresh = now.plus(Duration.ofMinutes(refreshDurationMinutes));
-        if (now.isAfter(nextAuthentication) || nextCalculatedRefresh.isAfter(nextAuthentication)) {
-            authenticate();
-        } else if (!(nextRefresh.isAfter(now) && nextAuthentication.isAfter(now))) {
-            Map<String, Object> payload = getPayloadMapRefresh();
-            AuthenticationResponse authenticationResponse = postForAuthentication(payload, AUTH_API_V2_REFRESH);
-
-            if (authenticationResponse.isAuthenticationErrorResponse()) {
-                authenticate();
-            } else if (!authenticationResponse.isSuccessResponse()) {
-                nextRefresh = now;
-                throw new SmartlingClientException(authenticationResponse.getErrorMessage());
-            } else {
-                logger.debug("Successful refresh of authentication.");
-                nextRefresh = nextCalculatedRefresh;
-                refreshToken = authenticationResponse.getResponse().getData().getRefreshToken();
-            }
-        }
-    }
+    @Autowired
+    @Qualifier("smartling")
+    OAuth2RestTemplate restTemplate;
 
     public SourceStringsResponse getSourceStrings(String projectId, String file, Integer offset) throws SmartlingClientException {
-        refresh();
-        Map<String, Object> payload = getPayloadMapPullSourceString();
-
-        HttpEntity<Map<String, Object>> httpEntity = getHttpEntityForPayloadWithAuthorization(payload);
-
-        Map<String, String> pathVariables = new HashMap<>();
-        pathVariables.put("projectId", projectId);
-        pathVariables.put("fileUri", file);
-        pathVariables.put("offset", offset.toString());
-        UriTemplate template = new UriTemplate(API_PULL_SOURCE_STRINGS);
-        ResponseEntity<SourceStringsResponse> exchange = restTemplate.exchange(
-                template.toString(), HttpMethod.GET, httpEntity, SourceStringsResponse.class, pathVariables);
-        SourceStringsResponse sourceStringsResponse = exchange.getBody();
-        if (sourceStringsResponse != null && sourceStringsResponse.isAuthenticationErrorResponse()) {
-            logger.debug("Authentication error occurred when attempting to pull the source strings.");
-            authenticate();
-        } else if (sourceStringsResponse != null && !sourceStringsResponse.isSuccessResponse()) {
-            throw new SmartlingClientException(sourceStringsResponse.getErrorMessage());
-        }
-        return sourceStringsResponse;
+        return restTemplate.getForObject(API_PULL_SOURCE_STRINGS, SourceStringsResponse.class, projectId, file, offset);
     }
-
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClientConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClientConfiguration.java
@@ -1,36 +1,92 @@
 package com.box.l10n.mojito.smartling;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.AccessTokenProvider;
+import org.springframework.security.oauth2.client.token.AccessTokenProviderChain;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
+import org.springframework.web.util.DefaultUriTemplateHandler;
 
+import java.util.Arrays;
+
+/**
+ * @author jaurambault
+ */
 @Configuration
+@EnableOAuth2Client
 @ConfigurationProperties("l10n.smartling")
 public class SmartlingClientConfiguration {
 
-    String userIdentifier;
-    String userSecret;
+    String baseUri = "https://api.smartling.com/";
+    String accessTokenUri = "https://api.smartling.com/auth-api/v2/authenticate";
+    String refreshTokenUri = "https://api.smartling.com/auth-api/v2/authenticate/refresh";
 
-    @ConditionalOnProperty(prefix="l10n.smartling", value = { "userIdentifier", "userSecret" })
+    String clientID;
+    String clientSecret;
+
     @Bean
-    public SmartlingClient getSmartlingClient() {
-        return new SmartlingClient(userIdentifier, userSecret);
+    public OAuth2ProtectedResourceDetails smartling() {
+        SmartlingOAuth2ProtectedResourceDetails details = new SmartlingOAuth2ProtectedResourceDetails();
+        details.setId("smarlting");
+        details.setGrantType("smartling");
+        details.setClientId(clientID);
+        details.setClientSecret(clientSecret);
+        details.setAccessTokenUri(accessTokenUri);
+        details.setRefreshUri(refreshTokenUri);
+        return details;
     }
 
-    public String getUserIdentifier() {
-        return userIdentifier;
+    @Bean
+    @Qualifier("smartling")
+    public OAuth2RestTemplate smarltingRestTemplate() {
+        OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(smartling(), new DefaultOAuth2ClientContext());
+
+        AccessTokenProviderChain accessTokenProviderChain = new AccessTokenProviderChain(Arrays.asList(
+                new SmartlingAuthorizationCodeAccessTokenProvider())
+        );
+        oAuth2RestTemplate.setAccessTokenProvider(accessTokenProviderChain);
+
+        DefaultUriTemplateHandler defaultUriTemplateHandler = new DefaultUriTemplateHandler();
+        defaultUriTemplateHandler.setBaseUrl(baseUri);
+
+        oAuth2RestTemplate.setUriTemplateHandler(defaultUriTemplateHandler);
+        return oAuth2RestTemplate;
     }
 
-    public void setUserIdentifier(String userIdentifier) {
-        this.userIdentifier = userIdentifier;
+    public String getAccessTokenUri() {
+        return accessTokenUri;
     }
 
-    public String getUserSecret() {
-        return userSecret;
+    public void setAccessTokenUri(String accessTokenUri) {
+        this.accessTokenUri = accessTokenUri;
     }
 
-    public void setUserSecret(String userSecret) {
-        this.userSecret = userSecret;
+    public String getRefreshTokenUri() {
+        return refreshTokenUri;
+    }
+
+    public void setRefreshTokenUri(String refreshTokenUri) {
+        this.refreshTokenUri = refreshTokenUri;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public void setClientID(String clientID) {
+        this.clientID = clientID;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingOAuth2ProtectedResourceDetails.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingOAuth2ProtectedResourceDetails.java
@@ -1,0 +1,27 @@
+package com.box.l10n.mojito.smartling;
+
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+
+/**
+ * @author jaurambault
+ */
+public class SmartlingOAuth2ProtectedResourceDetails extends BaseOAuth2ProtectedResourceDetails {
+    String refreshUri;
+
+    SmartlingOAuth2ProtectedResourceDetails() {
+        setGrantType("smartling");
+    }
+
+    public String getRefreshUri() {
+        return refreshUri;
+    }
+
+    public void setRefreshUri(String refreshUri) {
+        this.refreshUri = refreshUri;
+    }
+
+    @Override
+    public boolean isClientOnly() {
+        return true;
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
@@ -1,41 +1,66 @@
 package com.box.l10n.mojito.smartling;
 
 import com.box.l10n.mojito.smartling.response.SourceStringsResponse;
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = {SmartlingClientTest.class})
+@SpringApplicationConfiguration(classes = {SmartlingClientTest.class, SmartlingClientConfiguration.class, SmartlingClient.class})
 @EnableAutoConfiguration
 @IntegrationTest("spring.datasource.initialize=false")
 public class SmartlingClientTest {
 
-    @Value("${l10n.smartling.userIdentifier:#{null}}")
-    String userIdentifier;
+    static Logger logger = LoggerFactory.getLogger(SmartlingClient.class);
 
-    @Value("${l10n.smartling.userSecret:#{null}}")
-    String userSecret;
+    @Autowired
+    SmartlingClient smartlingClient;
 
-    @Value("${test.l10n.smartling.projectId:abc123}")
-    String projectId;
+    @Value("${l10n.smartling.clientID:#{null}}")
+    String clientID;
 
-    @Value("${test.l10n.smartling.file:demo.properties}")
-    String file;
+    @Value("${l10n.smartling.clientSecret:#{null}")
+    String clientSecret;
 
-    @Value("${test.l10n.smartling.offset:0}")
-    Integer offset;
+    @Value("${test.l10n.smartling.projectId:#{null}}")
+    String projectId = null;
 
-    @Test
-    public void testClient() throws SmartlingClientException {
-        Assume.assumeNotNull(userIdentifier, userSecret);
-        SmartlingClient smartlingClient = new SmartlingClient(userIdentifier, userSecret);
-        SourceStringsResponse sourceStringsResponse = smartlingClient.getSourceStrings(projectId, file, offset);
+    @Value("${test.l10n.smartling.fileUri:#{null}}")
+    String fileUri = null;
+
+    @Before
+    public void init() {
+        Assume.assumeNotNull(clientID);
+        Assume.assumeNotNull(clientSecret);
     }
 
+    @Test
+    public void testGetSourceStrings() throws Exception {
+        Assume.assumeNotNull(projectId);
+        Assume.assumeNotNull(fileUri);
+
+        for (int i = 0; i < 3; i++) {
+            logger.debug("Test getSourceStrings");
+            SourceStringsResponse sourceStrings = smartlingClient.getSourceStrings(
+                    projectId,
+                    fileUri,
+                    0);
+            sourceStrings.getResponse().getData().getItems().stream().map(item -> item.getHashcode())
+                    .forEach(logger::debug);
+            Thread.sleep(4000L);
+        }
+    }
 }


### PR DESCRIPTION
- implements a special SmartlingAuthorizationCodeAccessTokenProvider since smartling seems to be non standard
- Added simple integration test, needs props (client id & secrets, etc) to be set in config file