### PR TITLE
Improvement to the "Branches" page

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/react/PullRequest.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/PullRequest.java
@@ -1,0 +1,23 @@
+package com.box.l10n.mojito.react;
+
+public class PullRequest {
+
+    String url;
+    String urlComponent;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUrlComponent() {
+        return urlComponent;
+    }
+
+    public void setUrlComponent(String urlComponent) {
+        this.urlComponent = urlComponent;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/react/RepositoryConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/RepositoryConfig.java
@@ -5,6 +5,7 @@ public class RepositoryConfig {
     Location location;
     Commit commit;
     ThirdParty thirdParty;
+    PullRequest pullRequest;
 
     public Location getLocation() {
         return location;
@@ -28,5 +29,13 @@ public class RepositoryConfig {
 
     public void setThirdParty(ThirdParty thirdParty) {
         this.thirdParty = thirdParty;
+    }
+
+    public PullRequest getPullRequest() {
+        return pullRequest;
+    }
+
+    public void setPullRequest(PullRequest pullRequest) {
+        this.pullRequest = pullRequest;
     }
 }

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -147,7 +147,9 @@ l10n.PluralFormUpdater=true
 #l10n.link.{repository}.location.extractedPrefix=/some/extractor/prefix/
 #l10n.link.{repository}.location.label=${openGrokRepository}
 #l10n.link.{repository}.location.useUsage=True
-#
+#l10n.link.{repository}.pullRequest.url=https://secure.phabricator.com/${branchName}
+
+
 #l10n.link.{repository}.commit.url=http://github.com/${gitHubRepository}
 #l10n.link.{repository}.commit.label=${gitHubRepository}
 
@@ -158,4 +160,6 @@ l10n.PluralFormUpdater=true
 #l10n.link.{repository2}.location.url=https://someotherplace.com/xref/${textUnitName}
 #l10n.link.{repository2}.location.label=${textUnitName}
 #l10n.link.{repository2}.location.useUsage=False
+
+
 

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -61,6 +61,12 @@ branches.screenshotUploadModal.title=Upload screenshot for selected textunits
 # Button label to upload an image/screenshot
 branches.screenshotUploadModal.upload=Upload
 
+# Tooltip shown on the button to open the screenshoot review modal when some screenshot are available
+branches.searchResults.tooltip.withscreenshots=See screenshots
+
+# Tooltip shown on the button to open the screenshoot review modal when no screenshot has been added
+branches.searchResults.tooltip.noscreenshots=No screenshots yet
+
 # upload reminder
 upload.screenshot.prompt=Please choose image and upload screenshot
 

--- a/webapp/src/main/resources/public/js/components/branches/BranchesAddScreenshotButton.js
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesAddScreenshotButton.js
@@ -12,6 +12,8 @@ class BranchesAddScreenshotButton extends React.Component {
     };
 
     render() {
+
+        // we use this construct instead of putting the button in the overlay because tooltips don't work on disabled buttons
         let button = (
             <div style={{display: "inline-block"}}>
                 <Button bsStyle="primary"

--- a/webapp/src/main/resources/public/js/components/branches/BranchesPage.js
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesPage.js
@@ -149,6 +149,22 @@ class BranchesPage extends React.Component {
                             WorkbenchActions.searchParamsChanged(params);
                             this.props.router.push("/workbench", null, null);
                         }}
+
+                        onTextUnitNameClick={(branchStatistic, tmTextUnitId) => {
+
+                            let repoIds = [branchStatistic.branch.repository.id];
+
+                            let params = {
+                                "changedParam": SearchConstants.UPDATE_ALL,
+                                "repoIds": repoIds,
+                                "tmTextUnitId": tmTextUnitId,
+                                "bcp47Tags": RepositoryStore.getAllBcp47TagsForRepositoryIds(repoIds, true),
+                                "status": SearchParamsStore.STATUS.ALL,
+                            }
+
+                            WorkbenchActions.searchParamsChanged(params);
+                            this.props.router.push("/workbench", null, null);
+                        }}
                     />
                 </AltContainer>
 

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -789,6 +789,10 @@ label.current-pageNumber {
     padding-left: 0px;
 }
 
+.branches-branchstatistic-col1-row {
+    min-height: 30px;
+}
+
 .branches-branchstatistic-textunit-open {
     border-left: 2px solid $brand-primary;
 }


### PR DESCRIPTION
- Add link from the branch name to an external system (eg. phabricator). It can be configured using following properties l10n.link.{repository}.pullRequest.url (and urlComponent)
- Add link on the text unit name to open it in the workbench regardless of the branch (when branch are removed other links won't work), this allow to access the strings easily under those conditions
- Redesign the button to open the screenshot viewer. The button will now show up when hovering on the branch (if no screenshots are available it will be disabled). In both that the button will have a tool tip to give more context