### PR TITLE
Implemented backquote integrity checker

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoCommand.java
@@ -21,7 +21,7 @@ public abstract class RepoCommand extends Command {
     protected static final String INTEGRITY_CHECK_SHORT_PARAM = "-it";
     protected static final String INTEGRITY_CHECK_DESCRIPTION
             = "Integrity Checker by File Extension, comma seperated format: \"FILE_EXTENSION_1:CHECKER_TYPE_1,FILE_EXTENSION_2:CHECKER_TYPE_2\"\n       "
-            + "Available Checker types: MESSAGE_FORMAT, PRINTF_LIKE, SIMPLE_PRINTF_LIKE, COMPOSITE_FORMAT, WHITESPACE, TRAILING_WHITESPACE, HTML_TAG, ELLIPSIS\n       "
+            + "Available Checker types: MESSAGE_FORMAT, PRINTF_LIKE, SIMPLE_PRINTF_LIKE, COMPOSITE_FORMAT, WHITESPACE, TRAILING_WHITESPACE, HTML_TAG, ELLIPSIS, BACKQUOTE\n       "
             + "For examples: \"properties:MESSAGE_FORMAT,xliff:PRINTF_LIKE\"";
 
     @Autowired

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
@@ -14,5 +14,6 @@ public enum IntegrityCheckerType {
     WHITESPACE,
     TRAILING_WHITESPACE,
     HTML_TAG,
-    ELLIPSIS;
+    ELLIPSIS,
+    BACKQUOTE;
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/BackquoteIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/BackquoteIntegrityChecker.java
@@ -1,0 +1,33 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks that there are the same backquoted strings in the source and target
+ * content.
+ *
+ * @author jyi
+ */
+public class BackquoteIntegrityChecker extends RegexIntegrityChecker {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(BackquoteIntegrityChecker.class);
+
+    @Override
+    public String getRegex() {
+        return "`.*?`";
+    }
+
+    @Override
+    public void check(String sourceContent, String targetContent) throws BackquoteIntegrityCheckerException {
+
+        try {
+            super.check(sourceContent, targetContent);
+        } catch (RegexCheckerException rce) {
+            throw new BackquoteIntegrityCheckerException((rce.getMessage()));
+        }
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/BackquoteIntegrityCheckerException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/BackquoteIntegrityCheckerException.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+/**
+ *
+ * @author jyi
+ */
+public class BackquoteIntegrityCheckerException extends IntegrityCheckException {
+
+    public BackquoteIntegrityCheckerException(String message) {
+        super(message);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerType.java
@@ -14,7 +14,8 @@ public enum IntegrityCheckerType {
     WHITESPACE(WhitespaceIntegrityChecker.class.getName()),
     TRAILING_WHITESPACE(TrailingWhitespaceIntegrityChecker.class.getName()),
     HTML_TAG(HtmlTagIntegrityChecker.class.getName()),
-    ELLIPSIS(EllipsisIntegrityChecker.class.getName());
+    ELLIPSIS(EllipsisIntegrityChecker.class.getName()),
+    BACKQUOTE(BackquoteIntegrityChecker.class.getName());
 
     String className;
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/BackquoteIntegrityCheckerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/BackquoteIntegrityCheckerTest.java
@@ -1,0 +1,68 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author jyi
+ */
+public class BackquoteIntegrityCheckerTest {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(BackquoteIntegrityCheckerTest.class);
+
+    BackquoteIntegrityChecker checker = new BackquoteIntegrityChecker();
+
+    @Test
+    public void testBackquoteCheckWorks() {
+        String source = "Check `shared_item` and `collaborators`.";
+        String target = "Vink `shared_item` en `collaborators` aan.";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testBackquoteWorksWithDifferentOrders() {
+        String source = "Check `shared_item` and `collaborators`.";
+        String target = "Vink `collaborators` en `shared_item` aan.";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = BackquoteIntegrityCheckerException.class)
+    public void testBackquoteCheckWorksWhenMissingAClosingQuote() {
+        String source = "Check `shared_item` and `collaborators`.";
+        String target = "Vink `collaborators` en `shared_item aan.";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = BackquoteIntegrityCheckerException.class)
+    public void testBackquoteCheckWorksWhenMissingQuotes() {
+        String source = "Check `shared_item` and `collaborators`.";
+        String target = "Vink shared_item en collaborators aan.";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = BackquoteIntegrityCheckerException.class)
+    public void testBackquoteCheckWorksWhenTagIsModified() {
+        String source = "Check `shared_item` and `collaborators`.";
+        String target = "Vink `medewerkers` en `shared_item` aan.";
+
+        checker.check(source, target);
+    }
+
+    @Test(expected = BackquoteIntegrityCheckerException.class)
+    public void testBackquoteCheckWorksWhenCountDoesNotMatch() {
+        String source = "Check `shared_item` and `collaborators`.";
+        String target = "Check `shared_item`, `permissions` and `collaborators`.";
+
+        checker.check(source, target);
+    }
+
+}


### PR DESCRIPTION
 to preserve strings in backquote, because they should not be localized. For example:
*Please make sure `user` is not `null`.*