### PR TITLE
Escaping of GT and LineBreak in text unit id for xcode xliff

### DIFF
--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr-CA.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr-CA.xliff
@@ -4,9 +4,13 @@
     <header>
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
-      <trans-unit id="100_character_description_" xml:space="preserve">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
-      <target xml:lang="fr-CA">&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</target>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
+      <target xml:lang="fr-CA">&lt;link>100 character description&lt;/link>:
+
+</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr.xliff
@@ -4,9 +4,13 @@
     <header>
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
-      <trans-unit id="100_character_description_" xml:space="preserve">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
-      <target xml:lang="fr">&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</target>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
+      <target xml:lang="fr">&lt;link>100 character description&lt;/link>:
+
+</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/ja.xliff
@@ -4,9 +4,13 @@
     <header>
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
-      <trans-unit id="100_character_description_" xml:space="preserve">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
-      <target xml:lang="ja">&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</target>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
+      <target xml:lang="ja">&lt;link>100 character description&lt;/link>:
+
+</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr-CA.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr-CA.xliff
@@ -4,9 +4,13 @@
     <header>
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
-      <trans-unit id="100_character_description_" xml:space="preserve">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
-      <target xml:lang="fr-CA">&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</target>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
+      <target xml:lang="fr-CA">&lt;link>100 character description&lt;/link>:
+
+</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr.xliff
@@ -4,9 +4,13 @@
     <header>
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
-      <trans-unit id="100_character_description_" xml:space="preserve">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
-      <target xml:lang="fr">&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</target>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
+      <target xml:lang="fr">&lt;link>100 character description&lt;/link>:
+
+</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/ja.xliff
@@ -4,9 +4,13 @@
     <header>
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
-      <trans-unit id="100_character_description_" xml:space="preserve">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
-      <target xml:lang="ja">&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</target>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
+      <target xml:lang="ja">&lt;link>100 character description&lt;/link>:
+
+</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source/en.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source/en.xliff
@@ -5,8 +5,10 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2" build-num="7C68"/>
     </header>
     <body>
-      <trans-unit id="100_character_description_">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
       </trans-unit>
       <trans-unit id="15_min_duration">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source_modified/en.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source_modified/en.xliff
@@ -5,8 +5,10 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2" build-num="7C68"/>
     </header>
     <body>
-      <trans-unit id="100_character_description_">
-        <source>&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;</source>
+      <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;">
+        <source>&lt;link>100 character description&lt;/link>:
+
+</source>
       </trans-unit>
       <trans-unit id="15_min_duration">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_fr-FR.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_fr-FR.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
     <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined">
         <body>
-            <trans-unit id="" resname="100_character_description_" datatype="php">
+            <trans-unit id="" resname="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" datatype="php">
                 <source xml:lang="en">&lt;link>100 character description&lt;/link>:
 
                 </source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_ja-JP.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
     <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined">
         <body>
-            <trans-unit id="" resname="100_character_description_" datatype="php">
+            <trans-unit id="" resname="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" datatype="php">
                 <source xml:lang="en">&lt;link>100 character description&lt;/link>:
 
                 </source>

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/XcodeXliffSkeletonWriter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/XcodeXliffSkeletonWriter.java
@@ -1,0 +1,48 @@
+package com.box.l10n.mojito.okapi;
+
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.encoder.EncoderContext;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.filters.xliff.Parameters;
+import net.sf.okapi.filters.xliff.XLIFFSkeletonWriter;
+
+/**
+ *
+ * @author jyi
+ */
+public class XcodeXliffSkeletonWriter extends XLIFFSkeletonWriter {
+
+    public XcodeXliffSkeletonWriter(Parameters params) {
+        super(params);
+    }
+
+    @Override
+    protected String getString(ITextUnit tu,
+            LocaleId locToUse,
+            EncoderContext context) {
+        String tuString = super.getString(tu, locToUse, context);
+        return encodeTransUnitId(tuString);
+    }
+
+    private String encodeTransUnitId(String tuString) {
+        String tuIdStart = "<trans-unit id=\"";
+        int start = tuString.indexOf(tuIdStart);
+        if (start < 0) {
+            return tuString;
+        } else {
+            start += tuIdStart.length();
+            int end = tuString.indexOf("\"", start);
+
+            String tuIdString = tuString.substring(start, end);
+            tuIdString = tuIdString.replaceAll(">", "&gt;");
+            tuIdString = tuIdString.replaceAll("\n", "&#10;");
+
+            StringBuilder encoded = new StringBuilder();
+            encoded.append(tuString.substring(0, start));
+            encoded.append(tuIdString);
+            encoded.append(tuString.substring(end, tuString.length()));
+
+            return encoded.toString();
+        }
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XcodeXliffFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XcodeXliffFilter.java
@@ -1,14 +1,16 @@
 package com.box.l10n.mojito.okapi.filters;
 
+import com.box.l10n.mojito.okapi.XcodeXliffSkeletonWriter;
 import java.util.List;
 import net.sf.okapi.common.Event;
-import net.sf.okapi.common.IParameters;
 import net.sf.okapi.common.MimeTypeMapper;
-import net.sf.okapi.common.encoder.EncoderManager;
-import static net.sf.okapi.common.encoder.XMLEncoder.ESCAPEGT;
-import static net.sf.okapi.common.encoder.XMLEncoder.ESCAPELINEBREAK;
 import net.sf.okapi.common.filters.FilterConfiguration;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.skeleton.GenericSkeleton;
+import net.sf.okapi.common.skeleton.GenericSkeletonPart;
+import net.sf.okapi.common.skeleton.ISkeletonWriter;
 import net.sf.okapi.filters.xliff.XLIFFFilter;
+import net.sf.okapi.filters.xliff.XLIFFSkeletonWriter;
 import org.springframework.beans.factory.annotation.Configurable;
 
 /**
@@ -33,14 +35,15 @@ public class XcodeXliffFilter extends XLIFFFilter {
                 getClass().getName(),
                 "XCODEXLIFF",
                 "Configuration for XCODE XLIFF documents. Supports XCODE specific metadata",
-                "xcode_mojito.fprm",
+                null,
                 ".xliff"));
         return list;
     }
-    
-	@Override
-	public Event next () {
-            return super.next();
-        }
+
+    @Override
+    public ISkeletonWriter createSkeletonWriter() {
+        XLIFFSkeletonWriter writer = new XcodeXliffSkeletonWriter(getParameters());
+        return writer;
+    }
 
 }

--- a/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/xcode_mojito.fprm
+++ b/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/xcode_mojito.fprm
@@ -1,3 +1,0 @@
-#v1
-escapeGT.b=true
-escapeLineBreak.b=true


### PR DESCRIPTION
The escaping of GT and LineBreak is required in the text unit id. They do not need escaping in the source and target.