### PR TITLE
Only escaping GT in source/target for xcode xliff

### DIFF
--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr-CA.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr-CA.xliff
@@ -5,10 +5,10 @@
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
-      <target xml:lang="fr-CA">&lt;link>100 character description&lt;/link>:
+      <target xml:lang="fr-CA">&lt;link&gt;Description de 100 caractères&lt;/link&gt;:
 
 </target>
 </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/fr.xliff
@@ -5,10 +5,10 @@
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
-      <target xml:lang="fr">&lt;link>100 character description&lt;/link>:
+      <target xml:lang="fr">&lt;link&gt;Description de 100 caractères&lt;/link&gt;:
 
 </target>
 </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target/ja.xliff
@@ -5,10 +5,10 @@
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
-      <target xml:lang="ja">&lt;link>100 character description&lt;/link>:
+      <target xml:lang="ja">&lt;link&gt;100文字の説明&lt;/link&gt;:
 
 </target>
 </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr-CA.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr-CA.xliff
@@ -5,10 +5,10 @@
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
-      <target xml:lang="fr-CA">&lt;link>100 character description&lt;/link>:
+      <target xml:lang="fr-CA">&lt;link&gt;Description de 100 caractères&lt;/link&gt;:
 
 </target>
 </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/fr.xliff
@@ -5,10 +5,10 @@
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
-      <target xml:lang="fr">&lt;link>100 character description&lt;/link>:
+      <target xml:lang="fr">&lt;link&gt;Description de 100 caractères&lt;/link&gt;:
 
 </target>
 </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/expected/target_modified/ja.xliff
@@ -5,10 +5,10 @@
     <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="7.2"></tool></header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" xml:space="preserve">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
-      <target xml:lang="ja">&lt;link>100 character description&lt;/link>:
+      <target xml:lang="ja">&lt;link&gt;100文字の説明&lt;/link&gt;:
 
 </target>
 </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source/en.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source/en.xliff
@@ -6,7 +6,7 @@
     </header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
       </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source_modified/en.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/source_modified/en.xliff
@@ -6,7 +6,7 @@
     </header>
     <body>
       <trans-unit id="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;">
-        <source>&lt;link>100 character description&lt;/link>:
+        <source>&lt;link&gt;100 character description&lt;/link&gt;:
 
 </source>
       </trans-unit>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_fr-FR.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_fr-FR.xliff
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
-    <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined">
+    <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined" xml:space="preserve">
         <body>
             <trans-unit id="" resname="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" datatype="php">
                 <source xml:lang="en">&lt;link>100 character description&lt;/link>:
 
-                </source>
+</source>
                 <target xml:lang="en">&lt;link>Description de 100 caractères&lt;/link>:
 
-                </target>
+</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullXcodeXliff/input/translations/source-xliff_ja-JP.xliff
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
-    <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined">
+    <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined" xml:space="preserve">
         <body>
             <trans-unit id="" resname="&lt;link&gt;100 character description&lt;/link&gt;:&#10;&#10;" datatype="php">
                 <source xml:lang="en">&lt;link>100 character description&lt;/link>:
 
-                </source>
+</source>
                 <target xml:lang="en">&lt;link>100文字の説明&lt;/link>:
 
-                </target>
+</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XcodeXliffFilter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/filters/XcodeXliffFilter.java
@@ -35,7 +35,7 @@ public class XcodeXliffFilter extends XLIFFFilter {
                 getClass().getName(),
                 "XCODEXLIFF",
                 "Configuration for XCODE XLIFF documents. Supports XCODE specific metadata",
-                null,
+                "xcode_mojito.fprm",
                 ".xliff"));
         return list;
     }

--- a/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/xcode_mojito.fprm
+++ b/webapp/src/main/resources/com/box/l10n/mojito/okapi/filters/xcode_mojito.fprm
@@ -1,0 +1,2 @@
+#v1
+escapeGT.b=true


### PR DESCRIPTION
In addition to escaping GT and newline in the ID, escaping GT in source/target. Escaping newline in source/target is not required.