### PR TITLE
Add Chrome extension JSON file type

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
@@ -18,6 +18,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.HashBiMap;
 import com.google.common.io.Files;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -26,8 +27,10 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -175,8 +178,8 @@ public class CommandHelper {
     /**
      * Writes the content into a file using same format as source file
      *
-     * @param content content to be written
-     * @param path path to the file
+     * @param content         content to be written
+     * @param path            path to the file
      * @param sourceFileMatch
      * @throws CommandException
      */
@@ -199,7 +202,7 @@ public class CommandHelper {
      * Writes the content into a file in UTF8
      *
      * @param content content to be written
-     * @param path path to the file
+     * @param path    path to the file
      * @throws CommandException
      */
     public void writeFileContent(String content, Path path) throws CommandException {
@@ -309,6 +312,18 @@ public class CommandHelper {
         }
 
         return locales;
+    }
+
+    /**
+     * Returns the filter options provided or defaults to the file type filter options.
+     * (that can be null too)
+     *
+     * @param fileType
+     * @param filterOptions
+     * @return the filter options provided or the default options for the file type (can be null)
+     */
+    public List<String> getFilterOptionsOrDefaults(FileType fileType, List<String> filterOptions) {
+        return filterOptions == null ? fileType.getDefaultFilterOptions() : filterOptions;
     }
 
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommand.java
@@ -63,7 +63,7 @@ public class ImportLocalizedAssetCommand extends Command {
     FileType fileType;
 
     @Parameter(names = {Param.FILTER_OPTIONS_LONG, Param.FILTER_OPTIONS_SHORT}, variableArity = true, required = false, description = Param.FILTER_OPTIONS_DESCRIPTION)
-    List<String> filterOptions;
+    List<String> filterOptionsParam;
 
     @Parameter(names = {Param.SOURCE_LOCALE_LONG, Param.SOURCE_LOCALE_SHORT}, arity = 1, required = false, description = Param.SOURCE_LOCALE_DESCRIPTION)
     String sourceLocale;
@@ -130,7 +130,7 @@ public class ImportLocalizedAssetCommand extends Command {
                     commandHelper.getFileContent(targetPath),
                     statusForEqualTarget,
                     fileMatch.getFileType().getFilterConfigIdOverride(),
-                    filterOptions
+                    commandHelper.getFilterOptionsOrDefaults(fileMatch.getFileType(), filterOptionsParam)
             );
 
             try {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PseudoLocCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PseudoLocCommand.java
@@ -50,7 +50,7 @@ public class PseudoLocCommand extends Command {
     FileType fileType;
 
     @Parameter(names = {Param.FILTER_OPTIONS_LONG, Param.FILTER_OPTIONS_SHORT}, variableArity = true, required = false, description = Param.FILTER_OPTIONS_DESCRIPTION)
-    List<String> filterOptions;
+    List<String> filterOptionsParam;
 
     @Parameter(names = {Param.SOURCE_LOCALE_LONG, Param.SOURCE_LOCALE_SHORT}, arity = 1, required = false, description = Param.SOURCE_LOCALE_DESCRIPTION)
     String sourceLocale;
@@ -86,7 +86,7 @@ public class PseudoLocCommand extends Command {
 
         for (FileMatch sourceFileMatch : commandHelper.getSourceFileMatches(commandDirectories, fileType, sourceLocale, sourcePathFilterRegex)) {
             consoleWriter.a("Localizing: ").fg(Color.CYAN).a(sourceFileMatch.getSourcePath()).println();
-            generatePseudoLocalizedFile(repository, sourceFileMatch, filterOptions);
+            generatePseudoLocalizedFile(repository, sourceFileMatch, commandHelper.getFilterOptionsOrDefaults(sourceFileMatch.getFileType(), filterOptionsParam));
         }
         consoleWriter.fg(Color.GREEN).newLine().a("Finished").println(2);
     }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
@@ -61,7 +61,7 @@ public class PullCommand extends Command {
     FileType fileType;
 
     @Parameter(names = {Param.FILTER_OPTIONS_LONG, Param.FILTER_OPTIONS_SHORT}, variableArity = true, required = false, description = Param.FILTER_OPTIONS_DESCRIPTION)
-    List<String> filterOptions;
+    List<String> filterOptionsParam;
 
     @Parameter(names = {Param.SOURCE_LOCALE_LONG, Param.SOURCE_LOCALE_SHORT}, arity = 1, required = false, description = Param.SOURCE_LOCALE_DESCRIPTION)
     String sourceLocale;
@@ -128,6 +128,8 @@ public class PullCommand extends Command {
         for (FileMatch sourceFileMatch : commandHelper.getSourceFileMatches(commandDirectories, fileType, sourceLocale, sourcePathFilterRegex)) {
 
             consoleWriter.a("Localizing: ").fg(Color.CYAN).a(sourceFileMatch.getSourcePath()).println();
+
+            List<String> filterOptions = commandHelper.getFilterOptionsOrDefaults(sourceFileMatch.getFileType(), filterOptionsParam);
 
             if (localeMappingParam != null) {
                 generateLocalizedFilesWithLocaleMaping(repository, sourceFileMatch, filterOptions);

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -60,7 +60,7 @@ public class PushCommand extends Command {
     FileType fileType;
 
     @Parameter(names = {Param.FILTER_OPTIONS_LONG, Param.FILTER_OPTIONS_SHORT}, variableArity = true, required = false, description = Param.FILTER_OPTIONS_DESCRIPTION)
-    List<String> filterOptions;
+    List<String> filterOptionsParam;
 
     @Parameter(names = {Param.SOURCE_LOCALE_LONG, Param.SOURCE_LOCALE_SHORT}, arity = 1, required = false, description = Param.SOURCE_LOCALE_DESCRIPTION)
     String sourceLocale;
@@ -133,7 +133,7 @@ public class PushCommand extends Command {
             sourceAsset.setContent(assetContent);
             sourceAsset.setRepositoryId(repository.getId());
             sourceAsset.setFilterConfigIdOverride(sourceFileMatch.getFileType().getFilterConfigIdOverride());
-            sourceAsset.setFilterOptions(filterOptions);
+            sourceAsset.setFilterOptions(commandHelper.getFilterOptionsOrDefaults(sourceFileMatch.getFileType(), filterOptionsParam));
 
             consoleWriter.a(" - Uploading: ").fg(Ansi.Color.CYAN).a(sourcePath).println();
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/ChromeExtensionJSONFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/ChromeExtensionJSONFileType.java
@@ -1,0 +1,29 @@
+package com.box.l10n.mojito.cli.filefinder.file;
+
+import com.box.l10n.mojito.cli.filefinder.locale.ChromeExtJsonLocaleType;
+
+import java.util.Arrays;
+
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.BASE_NAME;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.DOT;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PATH_SEPERATOR;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.SUB_PATH;
+
+/**
+ * @author jeanaurambault
+ */
+public class ChromeExtensionJSONFileType extends FileType {
+
+    public ChromeExtensionJSONFileType() {
+        this.sourceFileExtension = "json";
+        this.baseNamePattern = "messages";
+        this.subPath = "_locales";
+        this.sourceFilePatternTemplate = "{" + PARENT_PATH + "}{" + SUB_PATH + "}" + PATH_SEPERATOR + "{" + LOCALE + "}" + PATH_SEPERATOR + "{" + BASE_NAME + "}" + DOT + "{" + FILE_EXTENSION + "}";
+        this.targetFilePatternTemplate = sourceFilePatternTemplate;
+        this.localeType = new ChromeExtJsonLocaleType();
+        this.defaultFilterOptions = Arrays.asList("noteKeyPattern=description", "extractAllPairs=false", "exceptions=message");
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileType.java
@@ -4,6 +4,8 @@ import com.box.l10n.mojito.cli.filefinder.FilePattern;
 import com.box.l10n.mojito.cli.filefinder.locale.LocaleType;
 import com.box.l10n.mojito.rest.entity.FilterConfigIdOverride;
 
+import java.util.List;
+
 /**
  * Provides information about a file type: extension, directory layout, source
  * and target file pattern, etc.
@@ -22,6 +24,7 @@ public abstract class FileType {
     String subPath = "(?:.+/)?";
     FilterConfigIdOverride filterConfigIdOverride;
     GitBlameType gitBlameType = GitBlameType.SOURCE_FILE;
+    List<String> defaultFilterOptions;
 
     public String getSourceFileExtension() {
         return sourceFileExtension;
@@ -33,7 +36,7 @@ public abstract class FileType {
 
     /**
      * Returns the target file extension.
-     *
+     * <p>
      * This is used with format (like PO files) that have different source and
      * target file extension (eg. pot and po)
      *
@@ -118,5 +121,13 @@ public abstract class FileType {
 
     public void setGitBlameType(GitBlameType gitBlameType) {
         this.gitBlameType = gitBlameType;
+    }
+
+    public List<String> getDefaultFilterOptions() {
+        return defaultFilterOptions;
+    }
+
+    public void setDefaultFilterOptions(List<String> defaultFilterOptions) {
+        this.defaultFilterOptions = defaultFilterOptions;
     }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileTypes.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileTypes.java
@@ -22,6 +22,7 @@ public enum FileTypes {
     CSV(CSVFileType.class),
     JS(JSFileType.class),
     JSON(JSONFileType.class),
+    CHROME_EXT_JSON(ChromeExtensionJSONFileType.class),
     TS(TSFileType.class);
 
     Class<? extends FileType> clazz;

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/locale/ChromeExtJsonLocaleType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/locale/ChromeExtJsonLocaleType.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.cli.filefinder.locale;
+
+/**
+ * {@link LocaleType} implementation for Chrome extension. Use "_" in locale names.
+ *
+ * @author jaurambault
+ */
+public class ChromeExtJsonLocaleType extends AnyLocaleTargetNotSourceType {
+    public String getTargetLocaleRepresentation(String targetLocale) {
+        return targetLocale.replace("-", "_");
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
@@ -696,6 +696,32 @@ public class PullCommandTest extends CLITestBase {
     }
 
     @Test
+    public void pullJsonFromChromeExtension() throws Exception {
+
+        Repository repository = createTestRepoUsingRepoService();
+
+        getL10nJCommander().run("push", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source").getAbsolutePath(),
+                "-ft", "CHROME_EXT_JSON");
+
+        Asset asset = assetClient.getAssetByPathAndRepositoryId("_locales/en/messages.json", repository.getId());
+        importTranslations(asset.getId(), "source-xliff_", "fr-FR");
+        importTranslations(asset.getId(), "source-xliff_", "ja-JP");
+
+        getL10nJCommander().run("pull", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source").getAbsolutePath(),
+                "-t", getTargetTestDir("target").getAbsolutePath(),
+                "-ft", "CHROME_EXT_JSON");
+
+        getL10nJCommander().run("pull", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source_modified").getAbsolutePath(),
+                "-t", getTargetTestDir("target_modified").getAbsolutePath(),
+                "-ft", "CHROME_EXT_JSON");
+
+        checkExpectedGeneratedResources();
+    }
+
+    @Test
     public void pullFullyTranslated() throws Exception {
 
         Repository repository = createTestRepoUsingRepoService();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
@@ -18,6 +18,7 @@ import com.google.common.io.CharSink;
 import com.google.common.io.FileWriteMode;
 import com.google.common.io.Files;
 import org.eclipse.jgit.api.Git;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -392,6 +393,7 @@ public class PushCommandTest extends CLITestBase {
         assertEquals(0, l10nJCommander.getExitCode());
     }
 
+    @Ignore("this remove all uncommited changes when running the test!!")
     @Test
     public void testProcessDiffAsset() throws Exception {
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/TMImportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/TMImportCommandTest.java
@@ -97,7 +97,7 @@ public class TMImportCommandTest extends CLITestBase {
         Iterator<TMTextUnitVariant> iterator = tmTextUnitsVariantsJapanese.iterator();
 
         tmTextUnitVariant = iterator.next();
-        assertEquals("Description de 100 caractères :", tmTextUnitVariant.getContent());
+        assertEquals("100文字の説明:", tmTextUnitVariant.getContent());
 
         tmTextUnitVariant = iterator.next();
         assertEquals("15分", tmTextUnitVariant.getContent());
@@ -137,7 +137,7 @@ public class TMImportCommandTest extends CLITestBase {
         Iterator<TMTextUnitVariant> iterator = tmTextUnitsVariantsJapanese.iterator();
 
         tmTextUnitVariant = iterator.next();
-        assertEquals("Description de 100 caractères :", tmTextUnitVariant.getContent());
+        assertEquals("100文字の説明:", tmTextUnitVariant.getContent());
 
         tmTextUnitVariant = iterator.next();
         assertEquals("1時間", tmTextUnitVariant.getContent());

--- a/cli/src/test/java/com/box/l10n/mojito/cli/filefinder/file/ChromeExtensionJSONFileTypeTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/filefinder/file/ChromeExtensionJSONFileTypeTest.java
@@ -1,0 +1,53 @@
+package com.box.l10n.mojito.cli.filefinder.file;
+
+import com.box.l10n.mojito.cli.filefinder.FilePattern;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.BASE_NAME;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.SUB_PATH;
+import static org.junit.Assert.*;
+
+public class ChromeExtensionJSONFileTypeTest {
+
+    @Test
+    public void testSourcePattern() {
+        ChromeExtensionJSONFileType chromeExtensionJSONFileType = new ChromeExtensionJSONFileType();
+        FilePattern sourceFilePattern = chromeExtensionJSONFileType.getSourceFilePattern();
+        Matcher matcher = sourceFilePattern.getPattern().matcher("_locales/en/messages.json");
+        Assert.assertTrue(matcher.matches());
+        Assert.assertEquals("", matcher.group(PARENT_PATH));
+        Assert.assertEquals("_locales", matcher.group(SUB_PATH));
+        Assert.assertEquals("messages", matcher.group(BASE_NAME));
+        Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+    }
+
+    @Test
+    public void testTargetPattern() {
+        ChromeExtensionJSONFileType chromeExtensionJSONFileType = new ChromeExtensionJSONFileType();
+        Matcher matcher = chromeExtensionJSONFileType.getTargetFilePattern().getPattern().matcher("_locales/fr/messages.json");
+        Assert.assertTrue(matcher.matches());
+        Assert.assertEquals("fr", matcher.group(LOCALE));
+        Assert.assertEquals("", matcher.group(PARENT_PATH));
+        Assert.assertEquals("_locales", matcher.group(SUB_PATH));
+        Assert.assertEquals("messages", matcher.group(BASE_NAME));
+        Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+    }
+
+    @Test
+    public void testTargetPatternBcp47() {
+        ChromeExtensionJSONFileType chromeExtensionJSONFileType = new ChromeExtensionJSONFileType();
+        Matcher matcher = chromeExtensionJSONFileType.getTargetFilePattern().getPattern().matcher("_locales/fr-FR/messages.json");
+        Assert.assertTrue(matcher.matches());
+        Assert.assertEquals("fr-FR", matcher.group(LOCALE));
+        Assert.assertEquals("", matcher.group(PARENT_PATH));
+        Assert.assertEquals("_locales", matcher.group(SUB_PATH));
+        Assert.assertEquals("messages", matcher.group(BASE_NAME));
+        Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+    }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropExportCommandTest/export/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropExportCommandTest/export/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropExportCommandTest/exportReviewWithInheritance/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropExportCommandTest/exportReviewWithInheritance/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/dropImport/expected/fortest-1_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/dropImport/expected/fortest-1_ja-JP.xliff
@@ -4,7 +4,7 @@
 <body>
 <trans-unit id="" resname="100_character_description_" xml:space="preserve">
 <source xml:lang="en">100 character description:</source>
-<target xml:lang="ja-JP">Description de 100 caractères :</target>
+<target xml:lang="ja-JP">100文字の説明:</target>
 <note>{"sourceComment":null,"targetComment":null,"includedInLocalizedFile":true,"status":"APPROVED","variantComments":[],"pluralForm":null,"pluralFormOther":null}</note>
 </trans-unit>
 <trans-unit id="" resname="15_min_duration" xml:space="preserve">

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/dropImport/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/dropImport/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/importFetched/expected/fortest-1_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/importFetched/expected/fortest-1_ja-JP.xliff
@@ -4,7 +4,7 @@
 <body>
 <trans-unit id="" resname="100_character_description_" xml:space="preserve">
 <source xml:lang="en">100 character description:</source>
-<target xml:lang="ja-JP">Description de 100 caractères :</target>
+<target xml:lang="ja-JP">100文字の説明:</target>
 <note>{"sourceComment":null,"targetComment":null,"includedInLocalizedFile":true,"status":"APPROVED","variantComments":[],"pluralForm":null,"pluralFormOther":null}</note>
 </trans-unit>
 <trans-unit id="" resname="15_min_duration" xml:space="preserve">

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/importFetched/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropImportCommandTest/importFetched/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropXliffImportCommandTest/dropXliffImport/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropXliffImportCommandTest/dropXliffImport/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importCsv/expected/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importCsv/expected/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+﻿100_character_description_,100 character description:,100文字の説明:,
 15_min_duration,15 min,15分,File lock dialog duration
 1_day_duration,1 day,1日,File lock dialog duration
 1_hour_duration,1 hour,1時間,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importCsv/input/translations/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importCsv/input/translations/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+﻿﻿100_character_description_,100 character description:,100文字の説明:,
 15_min_duration,15 min,15分,File lock dialog duration
 1_day_duration,1 day,1日,File lock dialog duration
 1_hour_duration,1 hour,1時間,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJson/expected/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJson/expected/demo_ja-JP.json
@@ -1,5 +1,5 @@
 ﻿{
-  "100_character_description_": "Description de 100 caractères :",
+  "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",
   // File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJson/input/translations/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJson/input/translations/demo_ja-JP.json
@@ -1,5 +1,5 @@
-﻿{
-  "100_character_description_": "Description de 100 caractères :",
+﻿﻿{
+  "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",
   // File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJsonWithNote/expected/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJsonWithNote/expected/demo_ja-JP.json
@@ -1,6 +1,6 @@
 ﻿{
   "100_character_description_": {
-    "string": "Description de 100 caractères :"
+    "string": "100文字の説明:"
   },
   "15_min_duration": {
     "string": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJsonWithNote/input/translations/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importJsonWithNote/input/translations/demo_ja-JP.json
@@ -1,6 +1,6 @@
-﻿{
+﻿﻿{
   "100_character_description_": {
-    "string": "Description de 100 caractères :"
+    "string": "100文字の説明:"
   },
   "15_min_duration": {
     "string": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPo/expected/ja/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPo/expected/ja/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 #: file.js:2
 msgctxt "100_character_description_"
 msgid "100 character description:"
-msgstr "Description de 100 caractères :"
+msgstr "100文字の説明:"
 
 #. File lock dialog duration
 #: file.js:4

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPo/input/translations/ja/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPo/input/translations/ja/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 #: file.js:2
 msgctxt "100_character_description_"
 msgid "100 character description:"
-msgstr "Description de 100 caractères :"
+msgstr "100文字の説明:"
 
 #. File lock dialog duration
 #: file.js:4

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importProperties/expected/demo_ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importProperties/expected/demo_ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importProperties/input/translations/demo_ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importProperties/input/translations/demo_ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesJava/expected/demo_ja_JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesJava/expected/demo_ja_JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caract\u00e8res\u00a0:
+100_character_description_ = 100\u6587\u5b57\u306e\u8aac\u660e:
 #File lock dialog duration
 15_min_duration = 15\u5206
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesJava/input/translations/demo_ja_JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesJava/input/translations/demo_ja_JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caract\u00e8res\u00a0:
+100_character_description_ = 100\u6587\u5b57\u306e\u8aac\u660e:
 #File lock dialog duration
 15_min_duration = 15\u5206
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBaseName/expected/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBaseName/expected/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBaseName/input/translations/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBaseName/input/translations/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBasenameMultiDirectory/expected/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBasenameMultiDirectory/expected/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBasenameMultiDirectory/input/translations/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importPropertiesNoBasenameMultiDirectory/input/translations/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importXcodeXliff/expected/ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importXcodeXliff/expected/ja.xliff
@@ -6,7 +6,7 @@
     <body>
       <trans-unit id="100_character_description_" xml:space="preserve">
         <source>100 character description:</source>
-      <target xml:lang="ja">Description de 100 caractères :</target>
+      <target xml:lang="ja">100文字の説明:</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importXcodeXliff/input/translations/ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest/importXcodeXliff/input/translations/ja.xliff
@@ -5,7 +5,7 @@
     <body>
       <trans-unit id="100_character_description_" xml:space="preserve">
         <source>100 character description:</source>
-      <target xml:lang="ja">Description de 100 caractères :</target>
+      <target xml:lang="ja">100文字の説明:</target>
 </trans-unit>
       <trans-unit id="15_min_duration" xml:space="preserve">
         <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/assetMapping/expected/target/mapping-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/assetMapping/expected/target/mapping-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja-JP">Description de 100 caractères :</target>
+   <target xml:lang="ja-JP">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/assetMapping/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/assetMapping/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/leveraging/expected/target/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/leveraging/expected/target/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/leveraging/expected/target_modified/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/leveraging/expected/target_modified/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration update
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/leveraging/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/leveraging/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/localeMapping/expected/target/source-xliff_ja.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/localeMapping/expected/target/source-xliff_ja.xliff
@@ -4,7 +4,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja">Description de 100 caractères :</target>
+   <target xml:lang="ja">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/localeMapping/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/localeMapping/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pull/expected/target/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pull/expected/target/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja-JP">Description de 100 caractères :</target>
+   <target xml:lang="ja-JP">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pull/expected/target_modified/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pull/expected/target_modified/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja-JP">Description de 100 caractères :</target>
+   <target xml:lang="ja-JP">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pull/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pull/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullCsv/expected/target/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullCsv/expected/target/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+﻿100_character_description_,100 character description:,100文字の説明:,
 15_min_duration,15 min,15分,File lock dialog duration
 1_day_duration,1 day,1日,File lock dialog duration
 1_hour_duration,1 hour,1時間,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullCsv/expected/target_modified/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullCsv/expected/target_modified/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,,
+﻿100_character_description_,100 character description:,100文字の説明:,,
 15_min_duration,15 min,15分,File lock dialog duration,
 1_hour_duration,1 hour,1時間,File lock dialog duration,
 1_month_duration,1 month,1か月,File lock dialog duration,

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullCsv/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullCsv/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJS/expected/target/ja.js
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJS/expected/target/ja.js
@@ -1,5 +1,5 @@
 export default {
-  "100_character_description_": "Description de 100 caractères :",
+  "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",
   // File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJS/expected/target_modified/ja.js
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJS/expected/target_modified/ja.js
@@ -1,5 +1,5 @@
 export default {
-  "100_character_description_": "Description de 100 caractères :",
+  "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",
   // File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJS/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJS/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJson/expected/target/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJson/expected/target/demo_ja-JP.json
@@ -1,5 +1,5 @@
 ﻿{
-  "100_character_description_": "Description de 100 caractères :",
+  "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",
   // File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJson/expected/target_modified/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJson/expected/target_modified/demo_ja-JP.json
@@ -1,5 +1,5 @@
 ﻿{
-  "100_character_description_": "Description de 100 caractères :",
+  "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",
   // File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJson/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJson/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/fr_CA/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/fr_CA/messages.json
@@ -1,0 +1,21 @@
+﻿{
+  "100_character_description_": {
+    "message": "Description de 100 caractères :"
+  },
+  "15_min_duration": {
+    "message": "15 min",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1 jour",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1 heure",
+    "description": "File lock dialog duration"
+  },
+  "1_month_duration": {
+    "message": "1 mois",
+    "description": "File lock dialog duration"
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/fr_FR/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/fr_FR/messages.json
@@ -1,0 +1,21 @@
+﻿{
+  "100_character_description_": {
+    "message": "Description de 100 caractères :"
+  },
+  "15_min_duration": {
+    "message": "15 min",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1 jour",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1 heure",
+    "description": "File lock dialog duration"
+  },
+  "1_month_duration": {
+    "message": "1 mois",
+    "description": "File lock dialog duration"
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/ja_JP/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/ja_JP/messages.json
@@ -1,6 +1,6 @@
 ﻿{
   "100_character_description_": {
-    "message": "Description de 100 caractères :"
+    "message": "100文字の説明:"
   },
   "15_min_duration": {
     "message": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/ja_JP/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target/_locales/ja_JP/messages.json
@@ -1,0 +1,21 @@
+﻿{
+  "100_character_description_": {
+    "message": "Description de 100 caractères :"
+  },
+  "15_min_duration": {
+    "message": "15分",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1日",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1時間",
+    "description": "File lock dialog duration"
+  },
+  "1_month_duration": {
+    "message": "1か月",
+    "description": "File lock dialog duration"
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_CA/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_CA/messages.json
@@ -1,0 +1,21 @@
+﻿{
+  "100_character_description_": {
+    "message": "Description de 100 caractères :"
+  },
+  "15_min_duration": {
+    "message": "15 min",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1 jour",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1 heure",
+    "description": "File lock dialog duration"
+  },
+  "something_new": {
+    "message": "Something new",
+    "description": ""
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_FR/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_FR/messages.json
@@ -1,0 +1,21 @@
+﻿{
+  "100_character_description_": {
+    "message": "Description de 100 caractères :"
+  },
+  "15_min_duration": {
+    "message": "15 min",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1 jour",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1 heure",
+    "description": "File lock dialog duration"
+  },
+  "something_new": {
+    "message": "Something new",
+    "description": ""
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/ja_JP/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/ja_JP/messages.json
@@ -1,6 +1,6 @@
 ﻿{
   "100_character_description_": {
-    "message": "Description de 100 caractères :"
+    "message": "100文字の説明:"
   },
   "15_min_duration": {
     "message": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/ja_JP/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/expected/target_modified/_locales/ja_JP/messages.json
@@ -1,0 +1,21 @@
+﻿{
+  "100_character_description_": {
+    "message": "Description de 100 caractères :"
+  },
+  "15_min_duration": {
+    "message": "15分",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1日",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1時間",
+    "description": "File lock dialog duration"
+  },
+  "something_new": {
+    "message": "Something new",
+    "description": ""
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/source/_locales/en/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/source/_locales/en/messages.json
@@ -1,0 +1,21 @@
+{
+  "100_character_description_": {
+    "message": "100 character description:"
+  },
+  "15_min_duration": {
+    "message": "15 min",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1 day",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1 hour",
+    "description": "File lock dialog duration"
+  },
+  "1_month_duration": {
+    "message": "1 month",
+    "description": "File lock dialog duration"
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/source_modified/_locales/en/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/source_modified/_locales/en/messages.json
@@ -1,0 +1,21 @@
+{
+  "100_character_description_": {
+    "message": "100 character description:"
+  },
+  "15_min_duration": {
+    "message": "15 min",
+    "description": "File lock dialog duration"
+  },
+  "1_day_duration": {
+    "message": "1 day",
+    "description": "File lock dialog duration"
+  },
+  "1_hour_duration": {
+    "message": "1 hour",
+    "description": "File lock dialog duration"
+  },
+  "something_new": {
+    "message": "Something new",
+    "description": ""
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/translations/source-xliff_fr-FR.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/translations/source-xliff_fr-FR.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+    <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_/message" datatype="php">
+                <source>100 character description:</source>
+                <target>Description de 100 caractères :</target>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration/message" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15 min</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_day_duration/message" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1 jour</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration/message" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1 heure</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration/message" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1 mois</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/translations/source-xliff_ja-JP.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+    <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_/message" datatype="php">
+                <source>100 character description:</source>
+                <target>Description de 100 caractères :</target>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration/message" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15分</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_day_duration/message" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1日</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration/message" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1時間</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration/message" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1か月</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonFromChromeExtension/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_/message" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration/message" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonWithNote/expected/target/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonWithNote/expected/target/demo_ja-JP.json
@@ -1,6 +1,6 @@
 ﻿{
   "100_character_description_": {
-    "string": "Description de 100 caractères :"
+    "string": "100文字の説明:"
   },
   "15_min_duration": {
     "string": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonWithNote/expected/target_modified/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonWithNote/expected/target_modified/demo_ja-JP.json
@@ -1,6 +1,6 @@
 ﻿{
   "100_character_description_": {
-    "string": "Description de 100 caractères :"
+    "string": "100文字の説明:"
   },
   "15_min_duration": {
     "string": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonWithNote/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullJsonWithNote/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_/string" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration/string" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPo/expected/target/ja/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPo/expected/target/ja/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 #: file.js:2
 msgctxt "100_character_description_"
 msgid "100 character description:"
-msgstr "Description de 100 caractères :"
+msgstr "100文字の説明:"
 
 #. File lock dialog duration
 #: file.js:4

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPo/expected/target_modified/ja/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPo/expected/target_modified/ja/LC_MESSAGES/messages.po
@@ -21,7 +21,7 @@ msgstr ""
 #: file.js:2
 msgctxt "100_character_description_"
 msgid "100 character description:"
-msgstr "Description de 100 caractères :"
+msgstr "100文字の説明:"
 
 #. File lock dialog duration
 #: file.js:4

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPo/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPo/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100 character description: --- 100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15 min --- 15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullProperties/expected/target/demo_ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullProperties/expected/target/demo_ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullProperties/expected/target_modified/demo_ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullProperties/expected/target_modified/demo_ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullProperties/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullProperties/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesJava/expected/target/demo_ja_JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesJava/expected/target/demo_ja_JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caract\u00e8res\u00a0:
+100_character_description_ = 100\u6587\u5b57\u306e\u8aac\u660e:
 #File lock dialog duration
 15_min_duration = 15\u5206
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesJava/expected/target_modified/demo_ja_JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesJava/expected/target_modified/demo_ja_JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caract\u00e8res\u00a0:
+100_character_description_ = 100\u6587\u5b57\u306e\u8aac\u660e:
 #File lock dialog duration
 15_min_duration = 15\u5206
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesJava/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesJava/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasename/expected/target/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasename/expected/target/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasename/expected/target_modified/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasename/expected/target_modified/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasename/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasename/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasenameEnUs/expected/target/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasenameEnUs/expected/target/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasenameEnUs/expected/target_modified/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasenameEnUs/expected/target_modified/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasenameEnUs/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullPropertiesNoBasenameEnUs/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullWithDuplicatedTextUnits/expected/target/ja-JP.properties
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullWithDuplicatedTextUnits/expected/target/ja-JP.properties
@@ -1,4 +1,4 @@
-100_character_description_ = Description de 100 caractères :
+100_character_description_ = 100文字の説明:
 #File lock dialog duration
 15_min_duration = 15分
 #File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullWithDuplicatedTextUnits/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest/pullWithDuplicatedTextUnits/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMExportCommandTest/export/expected/fortest-1_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMExportCommandTest/export/expected/fortest-1_ja-JP.xliff
@@ -4,7 +4,7 @@
 <body>
 <trans-unit id="" resname="100_character_description_" xml:space="preserve">
 <source xml:lang="en">100 character description:</source>
-<target xml:lang="ja-JP">Description de 100 caractères :</target>
+<target xml:lang="ja-JP">100文字の説明:</target>
 <note>{"sourceComment":null,"targetComment":null,"includedInLocalizedFile":true,"status":"APPROVED","variantComments":[],"pluralForm":null,"pluralFormOther":null}</note>
 </trans-unit>
 <trans-unit id="" resname="15_min_duration" xml:space="preserve">

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMExportCommandTest/export/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMExportCommandTest/export/input/translations/source-xliff_ja-JP.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="" resname="100_character_description_" datatype="php">
                 <source>100 character description:</source>
-                <target>Description de 100 caractères :</target>
+                <target>100文字の説明:</target>
             </trans-unit>
             <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
                 <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testImport/input/import/test-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testImport/input/import/test-xliff_ja-JP.xliff
@@ -3,7 +3,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja-jp">Description de 100 caractères :</target>
+   <target xml:lang="ja-jp">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testImportShouldFailIfImportingJustTargetFiles/input/import/import/test-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testImportShouldFailIfImportingJustTargetFiles/input/import/import/test-xliff_ja-JP.xliff
@@ -3,7 +3,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja-jp">Description de 100 caractères :</target>
+   <target xml:lang="ja-jp">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testImportWithImportExportNote/input/import/fortest-1_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testImportWithImportExportNote/input/import/fortest-1_ja-JP.xliff
@@ -4,7 +4,7 @@
 <body>
 <trans-unit id="" resname="100_character_description_">
 <source xml:lang="en">100 character description:</source>
-<target xml:lang="ja-jp">Description de 100 caractères :</target>
+<target xml:lang="ja-jp">100文字の説明:</target>
 <note>{"sourceComment":null,"targetComment":null,"status":"APPROVED"}</note>
 </trans-unit>
 <trans-unit id="" resname="15_min_duration">

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testReimportShouldFail/input/import/import/test-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/TMImportCommandTest/testReimportShouldFail/input/import/import/test-xliff_ja-JP.xliff
@@ -3,7 +3,7 @@
   <body>
    <trans-unit id="" resname="100_character_description_" datatype="php">
     <source>100 character description:</source>
-   <target xml:lang="ja-jp">Description de 100 caractères :</target>
+   <target xml:lang="ja-jp">100文字の説明:</target>
 </trans-unit>
    <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
     <source>15 min</source>

--- a/test-common/src/main/java/com/box/l10n/mojito/test/IOTestBase.java
+++ b/test-common/src/main/java/com/box/l10n/mojito/test/IOTestBase.java
@@ -98,6 +98,18 @@ public class IOTestBase {
     }
 
     /**
+     * Options to override expected test files.
+     *
+     * Test can be run that way: mvn test -DoverrideExpectedTestFiles=true
+     *
+     * @return
+     */
+    protected boolean shouldOverrideExpectedTestFiles() {
+        String overrideExpectedTestFiles = System.getProperty("overrideExpectedTestFiles");
+        return overrideExpectedTestFiles == null ? false : Boolean.valueOf(overrideExpectedTestFiles);
+    }
+
+    /**
      * Gets the directory that contains expected resources.
      *
      * @return
@@ -176,9 +188,19 @@ public class IOTestBase {
      */
     public void checkExpectedGeneratedResources() {
         try {
+            if (shouldOverrideExpectedTestFiles()) {
+                logger.info("Override expected test files (instead of checking)");
+                try {
+                    FileUtils.copyDirectory(targetTestDir, getExpectedResourcesTestDir());
+                } catch (IOException io) {
+                    throw new RuntimeException(io);
+                }
+            }
+
             checkDirectoriesContainSameContent(getExpectedResourcesTestDir(), targetTestDir);
         } catch (DifferentDirectoryContentException e) {
-            String msg = "Generated resources do not match the expected resources";
+            String msg = "Generated resources do not match the expected resource (Use -DoverrideExpectedTestFiles=true " +
+                    "to run test and override expected test files instead of doing this check)";
             logger.debug(msg, e);
             Assert.fail(msg + "\n" + e.getMessage());
         }


### PR DESCRIPTION
- Reuse the base JSON filter but directory layout is different from JSON file type
- Added logic to define default filter options for a file type
- If no filter option is provided in push/pull/import/pseudoloc/gitblame commands then the default filter options from the type are used