### PR TITLE
Remove @DisallowConcurrentExecution since it is making the job store …

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/job/BranchNotificationJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/job/BranchNotificationJob.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
  * Job that sends notifications for a branch.
  */
 @Component
-@DisallowConcurrentExecution
 public class BranchNotificationJob extends SchedulableJob {
 
     /**


### PR DESCRIPTION
…durably too and we don't care about concurrent execution anyway