### PR TITLE
Implement translation history UI

### DIFF
--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -707,16 +707,13 @@ textUnit.gitBlameModal.screenshotModalOpen=View
 workbench.translationHistoryModal.info=Text unit history
 
 # Title of the translation history modal dialog
-workbench.translationHistoryModal.title=Text Unit Translation History
+workbench.translationHistoryModal.title=Translation History for Locale {locale}
 
 # Label for the button to close the translation history modal dialog
 textUnit.translationHistoryModal.close=Close
 
 # Text in the section in the translation history dialog where info about the translation unit is given
-textUnit.translationHistoryModal.locale=Translation history for locale: {locale}
-
-# Text in the section in the translation history dialog where info about the translation unit is given
-textUnit.translationHistoryModal.source=Source string: "{source}"
+textUnit.translationHistoryModal.source=Source: "{source}"
 
 # Label for the column that contains the username of the user that made the translation
 textUnit.translationHistoryModal.User=User Name

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -712,8 +712,11 @@ workbench.translationHistoryModal.title=Text Unit Translation History
 # Label for the button to close the translation history modal dialog
 textUnit.translationHistoryModal.close=Close
 
-# Label for the section in the translation history dialog where the table of historical translations appear
-textUnit.translationHistoryModal.header=Translation history for locale: {locale}\nSource string: "{source}"
+# Text in the section in the translation history dialog where info about the translation unit is given
+textUnit.translationHistoryModal.locale=Translation history for locale: {locale}
+
+# Text in the section in the translation history dialog where info about the translation unit is given
+textUnit.translationHistoryModal.source=Source string: "{source}"
 
 # Label for the column that contains the username of the user that made the translation
 textUnit.translationHistoryModal.User=User Name
@@ -729,3 +732,6 @@ textUnit.translationHistoryModal.Status=Status
 
 # Body of the translation history modal dialog if there are no translations on this text unit yet
 textUnit.translationHistoryModal.NoTranslations=No translation history yet.
+
+# String shown in the translation field when the text unit is first submitted to mojito and there is no translation yet
+textUnit.translationHistoryModal.InitialPush=<no translation yet>

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -702,3 +702,6 @@ textUnit.gitBlameModal.screenshots=Screenshots
 
 # Text for link to open screenshot modal in git-blame modal
 textUnit.gitBlameModal.screenshotModalOpen=View
+
+# Label for button to open the translation history modal
+workbench.translationHistoryModal.info=Text unit history

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -703,5 +703,29 @@ textUnit.gitBlameModal.screenshots=Screenshots
 # Text for link to open screenshot modal in git-blame modal
 textUnit.gitBlameModal.screenshotModalOpen=View
 
-# Label for button to open the translation history modal
+# Tooltip for button to open the translation history modal
 workbench.translationHistoryModal.info=Text unit history
+
+# Title of the translation history modal dialog
+workbench.translationHistoryModal.title=Text Unit Translation History
+
+# Label for the button to close the translation history modal dialog
+textUnit.translationHistoryModal.close=Close
+
+# Label for the section in the translation history dialog where the table of historical translations appear
+textUnit.translationHistoryModal.header=Translation history for locale: {locale}\nSource string: "{source}"
+
+# Label for the column that contains the username of the user that made the translation
+textUnit.translationHistoryModal.User=User Name
+
+# Label for the column that contains the translation
+textUnit.translationHistoryModal.Translation=Translation
+
+# Label for the column that contains the date that the translation was submitted
+textUnit.translationHistoryModal.Date=Date
+
+# Label for the column that contains the status of the translation
+textUnit.translationHistoryModal.Status=Status
+
+# Body of the translation history modal dialog if there are no translations on this text unit yet
+textUnit.translationHistoryModal.NoTranslations=No translation history yet.

--- a/webapp/src/main/resources/public/js/actions/workbench/TextUnitDataSource.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/TextUnitDataSource.js
@@ -3,6 +3,7 @@ import TextUnitError from "../../utils/TextUnitError";
 import TextUnitClient from "../../sdk/TextUnitClient";
 import WorkbenchActions from "./WorkbenchActions";
 import GitBlameActions from "./GitBlameActions";
+import TranslationHistoryActions from "./TranslationHistoryActions";
 
 const TextUnitDataSource = {
     performSaveTextUnit: {
@@ -60,6 +61,14 @@ const TextUnitDataSource = {
         },
         success: GitBlameActions.getGitBlameInfoSuccess,
         error: GitBlameActions.getGitBlameInfoError
+    },
+
+    getTranslationHistory: {
+        remote(translationHistoryStoreState, textUnit) {
+            return TextUnitClient.getTranslationHistory(textUnit);
+        },
+        success: TranslationHistoryActions.getTranslationHistorySuccess,
+        error: TranslationHistoryActions.getTranslationHistoryError
     }
 };
 

--- a/webapp/src/main/resources/public/js/actions/workbench/TranslationHistoryActions.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/TranslationHistoryActions.js
@@ -1,0 +1,15 @@
+import alt from "../../alt";
+
+class TranslationHistoryActions {
+
+    constructor() {
+        this.generateActions(
+            "openWithTextUnit",
+            "getTranslationHistorySuccess",
+            "getTranslationHistoryError",
+            "close"
+        );
+    }
+}
+
+export default alt.createActions(TranslationHistoryActions);

--- a/webapp/src/main/resources/public/js/components/widgets/StatusGlyph.js
+++ b/webapp/src/main/resources/public/js/components/widgets/StatusGlyph.js
@@ -1,0 +1,43 @@
+/**
+ * Render the icon for the statuses that the backend returns.
+ */
+
+import PropTypes from 'prop-types';
+import React from "react";
+import {FormattedMessage, injectIntl} from 'react-intl';
+import {Glyphicon} from "react-bootstrap";
+import TextUnitSDK from "../../sdk/TextUnit";
+
+const glyphMap = {
+    [TextUnitSDK.STATUS.APPROVED]: 'ok',
+    [TextUnitSDK.STATUS.REVIEW_NEEDED]: 'eye-open',
+    [TextUnitSDK.STATUS.TRANSLATION_NEEDED]: 'edit'
+};
+
+class StatusGlyph extends React.Component {
+    static propTypes = {
+        "status": PropTypes.oneOf([
+            TextUnitSDK.STATUS.APPROVED,
+            TextUnitSDK.STATUS.REVIEW_NEEDED,
+            TextUnitSDK.STATUS.TRANSLATION_NEEDED]).isRequired,
+        "onClick": PropTypes.func.isRequired
+    };
+
+    getGlyph = (type) => {
+        return glyphMap[type] || glyphMap.TRANSLATION_NEEDED;
+    };
+
+    /**
+     * @return {JSX}
+     */
+    render() {
+        return (<Glyphicon 
+                    glyph={this.getGlyph(this.props.status)} 
+                    title={this.props.status} 
+                    onClick={this.props.onClick}
+                    className="btn"
+               />);
+    }
+}
+
+export default injectIntl(StatusGlyph);

--- a/webapp/src/main/resources/public/js/components/widgets/StatusGlyph.js
+++ b/webapp/src/main/resources/public/js/components/widgets/StatusGlyph.js
@@ -31,9 +31,9 @@ class StatusGlyph extends React.Component {
      * @return {JSX}
      */
     render() {
-        return (<Glyphicon 
-                    glyph={this.getGlyph(this.props.status)} 
-                    title={this.props.status} 
+        return (<Glyphicon
+                    glyph={this.getGlyph(this.props.status)}
+                    title={this.props.status}
                     onClick={this.props.onClick}
                     className="btn"
                />);

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -830,14 +830,11 @@ let TextUnit = createReactClass({
                         <span className="textunit-gitInfo glyphicon glyphicon-info-sign mls"
                               onClick={this.onTextUnitInfoClick} />
                     </OverlayTrigger>
-                    {
-                        (this.props.textUnit.getTmTextUnitVariantId()) ?
-                            <OverlayTrigger placement="top" overlay={assetPathTranslationHistoryTooltip}>
-                                <span className="textunit-translation-history glyphicon glyphicon-time mls"
-                                      onClick={this.onTranslationHistoryClick} />
-                            </OverlayTrigger> :
-                            ""
-                    }
+
+                    <OverlayTrigger placement="top" overlay={assetPathTranslationHistoryTooltip}>
+                        <span className="textunit-translation-history glyphicon glyphicon-time mls"
+                              onClick={this.onTranslationHistoryClick} />
+                    </OverlayTrigger>
                 </span>
         );
     },

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -16,6 +16,7 @@ import TextUnitsReviewModal from "./TextUnitsReviewModal";
 import TextUnitSDK from "../../sdk/TextUnit";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 import GitBlameActions from "../../actions/workbench/GitBlameActions";
+import TranslationHistoryActions from "../../actions/workbench/TranslationHistoryActions";
 import Locales from "../../utils/Locales";
 import {
     Grid,
@@ -641,6 +642,13 @@ let TextUnit = createReactClass({
         GitBlameActions.openWithTextUnit(this.props.textUnit);
     },
 
+    onTranslationHistoryClick(e){
+
+        e.stopPropagation();
+
+        TranslationHistoryActions.openWithTextUnit(this.props.textUnit);
+    },
+
     /**
      * Handle click on the asset path icon: stop event propagation (no need to bubble
      * up as we're reloading the workbench with new data) and update the search
@@ -805,6 +813,9 @@ let TextUnit = createReactClass({
         let assetPathWithGitInfoTooltip =
             <Tooltip id="{this.props.textUnit.getId()}-gitInfo">{this.props.intl.formatMessage( {id: 'workbench.gitBlameModal.info'} )}</Tooltip>;
 
+        let assetPathTranslationHistoryTooltip =
+            <Tooltip id="{this.props.textUnit.getId()}-translation-history">{this.props.intl.formatMessage( {id: 'workbench.translationHistoryModal.info'} )}</Tooltip>;
+
         return (<span className="clickable textunit-name"
                       onClick={this.onStringIdClick}>
                     <span>{this.props.textUnit.getName()}</span>
@@ -816,6 +827,11 @@ let TextUnit = createReactClass({
                     <OverlayTrigger placement="top" overlay={assetPathWithGitInfoTooltip}>
                         <span className="textunit-gitInfo glyphicon glyphicon-info-sign mls"
                               onClick={this.onTextUnitInfoClick} />
+                    </OverlayTrigger>
+
+                    <OverlayTrigger placement="top" overlay={assetPathTranslationHistoryTooltip}>
+                        <span className="textunit-translation-history glyphicon glyphicon-calendar mls"
+                              onClick={this.onTranslationHistoryClick} />
                     </OverlayTrigger>
                 </span>
         );

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -816,11 +816,13 @@ let TextUnit = createReactClass({
         let assetPathTranslationHistoryTooltip =
             <Tooltip id="{this.props.textUnit.getId()}-translation-history">{this.props.intl.formatMessage( {id: 'workbench.translationHistoryModal.info'} )}</Tooltip>;
 
+        // Only show the overlay trigger for the translation history if there is a current text unit variant (ie. there is
+        // at least one translation) If not, we have no history to show anyways!
         return (<span className="clickable textunit-name"
                       onClick={this.onStringIdClick}>
                     <span>{this.props.textUnit.getName()}</span>
                     <OverlayTrigger placement="top" overlay={assetPathTooltip}>
-                        <span className="textunit-assetpath glyphicon glyphicon-level-up mls" 
+                        <span className="textunit-assetpath glyphicon glyphicon-level-up mls"
                                onClick={this.onAssetPathClick} />
                     </OverlayTrigger>
 
@@ -828,11 +830,14 @@ let TextUnit = createReactClass({
                         <span className="textunit-gitInfo glyphicon glyphicon-info-sign mls"
                               onClick={this.onTextUnitInfoClick} />
                     </OverlayTrigger>
-
-                    <OverlayTrigger placement="top" overlay={assetPathTranslationHistoryTooltip}>
-                        <span className="textunit-translation-history glyphicon glyphicon-calendar mls"
-                              onClick={this.onTranslationHistoryClick} />
-                    </OverlayTrigger>
+                    {
+                        (this.props.textUnit.getTmTextUnitVariantId()) ?
+                            <OverlayTrigger placement="top" overlay={assetPathTranslationHistoryTooltip}>
+                                <span className="textunit-translation-history glyphicon glyphicon-time mls"
+                                      onClick={this.onTranslationHistoryClick} />
+                            </OverlayTrigger> :
+                            ""
+                    }
                 </span>
         );
     },

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -808,13 +808,15 @@ let TextUnit = createReactClass({
     },
 
     renderName() {
+        const id = this.props.textUnit.getTmTextUnitId();
+        const locale = this.props.textUnit.getTargetLocale();
         let assetPathWithZeroWidthSpace = this.addZeroWidthSpace(this.props.textUnit.getAssetPath()); // to make the tooltip text to wrap
-        let assetPathTooltip = <Tooltip id="{this.props.textUnit.getId()}-assetPath">{assetPathWithZeroWidthSpace}</Tooltip>;
+        let assetPathTooltip = <Tooltip id={`${id}-${locale}-assetPath`}>{assetPathWithZeroWidthSpace}</Tooltip>;
         let assetPathWithGitInfoTooltip =
-            <Tooltip id="{this.props.textUnit.getId()}-gitInfo">{this.props.intl.formatMessage( {id: 'workbench.gitBlameModal.info'} )}</Tooltip>;
+            <Tooltip id={`${id}-${locale}-gitInfo`}>{this.props.intl.formatMessage( {id: 'workbench.gitBlameModal.info'} )}</Tooltip>;
 
         let assetPathTranslationHistoryTooltip =
-            <Tooltip id="{this.props.textUnit.getId()}-translation-history">{this.props.intl.formatMessage( {id: 'workbench.translationHistoryModal.info'} )}</Tooltip>;
+            <Tooltip id={`${id}-${locale}-translation-history`}>{this.props.intl.formatMessage( {id: 'workbench.translationHistoryModal.info'} )}</Tooltip>;
 
         // Only show the overlay trigger for the translation history if there is a current text unit variant (ie. there is
         // at least one translation) If not, we have no history to show anyways!

--- a/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
@@ -1,0 +1,571 @@
+import PropTypes from 'prop-types';
+import React from "react";
+import {FormattedMessage, injectIntl} from "react-intl";
+import {Button, Modal} from "react-bootstrap";
+import {withAppConfig} from "../../utils/AppConfig";
+import LinkHelper from "../../utils/LinkHelper";
+import {Link} from "react-router";
+
+class translationHistoryModal extends React.Component {
+    static propTypes() {
+        return {
+            "show": PropTypes.bool.isRequired,
+            "textUnit": PropTypes.object.isRequired,
+            "translationHistoryWithUsage": PropTypes.object.isRequired
+        };
+    }
+
+    /**
+     * @returns {string} The title of the modal is the name of the text unit
+     */
+    getTitle = () => {
+        return this.props.intl.formatMessage({id: "workbench.translationHistoryModal.info"});
+    };
+
+    /**
+     * @param label  The label for the data to display
+     * @param data   The data to display
+     * @returns {*}  The row of label:data to display in the modal
+     */
+    displayInfo = (label, data) => {
+        let translationHistoryClass = "";
+        if (data == null) {
+            translationHistoryClass = " git-blame-unused";
+            data = "-";
+        }
+
+        return (
+            <div className={"row git-blame"}>
+                <label className={"col-sm-3 git-blame-label"}>{label}</label>
+                <div className={"col-sm-9 git-blame-info" + translationHistoryClass}>{data}</div>
+            </div>
+        );
+    };
+
+    /**
+     * @returns {*} The row of label:link to display in the modal
+     */
+    displayScreenshotLink = () => {
+        const label = this.props.intl.formatMessage({id: "textUnit.translationHistoryModal.screenshots"});
+        const branchScreenshots = this.getBranchScreenshots();
+        if (!branchScreenshots.length) {
+            return this.displayInfo(label, null);
+        }
+
+        return (
+            <div className={"row git-blame"}>
+                <label className={"col-sm-3 git-blame-label"}>{label}</label>
+                <Link
+                    onClick={() => this.props.onViewScreenshotClick(branchScreenshots)}
+                    className="col-sm-9 clickable">
+                    <FormattedMessage id="textUnit.translationHistoryModal.screenshotModalOpen"/>
+                </Link>
+            </div>
+        );
+    };
+
+    /**
+     * @param labelId  The labelId for the formatted message
+     * @param data     The data to display
+     * @returns {*}    The row of label:data to display in the modal
+     */
+    displayInfoWithId = (labelId, data) => {
+        return this.displayInfo(this.props.intl.formatMessage({id: labelId}), data);
+    };
+
+    /**
+     * @returns {*} Generated content for the text unit information section
+     */
+    renderTextUnitInfo = () => {
+        return this.props.textUnit === null ? "" :
+            (
+                <div>
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.repository", this.props.textUnit.getRepositoryName())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.assetPath", this.props.textUnit.getAssetPath())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.id", this.props.textUnit.getName())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.source", this.props.textUnit.getSource())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.target", this.props.textUnit.getTarget())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.locale", this.props.textUnit.getTargetLocale())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.created", this.convertDateTime(this.props.textUnit.getTmTextUnitCreatedDate()))}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.translated", this.getTranslatedDate())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.pluralForm", this.props.textUnit.getPluralForm())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.pluralFormOther", this.props.textUnit.getPluralFormOther())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.comment", this.props.textUnit.getComment())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.targetComment", this.props.textUnit.getTargetComment())}
+                    {this.displayInfoWithId("textUnit.translationHistoryModal.location", this.getLocationLinks())}
+                    {this.shouldShowThirdPartyTMS() && this.displayInfoWithId("textUnit.translationHistoryModal.thirdPartyTMS", this.getThirdPartyLink())}
+                </div>
+            );
+    };
+
+    /**
+     * @returns {*} Generated content for the git blame information section
+     */
+    rendertranslationHistory = () => {
+        return (
+            <div>
+                {this.displayInfoWithId("textUnit.translationHistoryModal.authorName", this.getAuthorName())}
+                {this.displayInfoWithId("textUnit.translationHistoryModal.authorEmail", this.getAuthorEmail())}
+                {this.displayInfoWithId("textUnit.translationHistoryModal.commit", this.getCommitLink())}
+                {this.displayInfoWithId("textUnit.translationHistoryModal.commitDate", this.convertDateTime(this.getCommitTime()))}
+            </div>
+        )
+    };
+
+    /**
+     * @returns {*} Generated content for the additional text unit information section
+     */
+    renderDebugInfo = () => {
+        return this.props.textUnit === null ? "" :
+            (
+                <div className="panel-body">
+                    {this.displayInfo("TmTextUnitId", this.props.textUnit.getTmTextUnitId())}
+                    {this.displayInfo("TmTextUnitVariantId", this.props.textUnit.getTmTextUnitVariantId())}
+                    {this.displayInfo("TmTextUnitCurrentVariantId", this.props.textUnit.getTmTextUnitCurrentVariantId())}
+                    {this.displayInfo("AssetTextUnitId", this.props.textUnit.getAssetTextUnitId())}
+                    {this.displayInfo("AssetId", this.props.textUnit.getAssetId())}
+                    {this.displayInfo("LastSuccessfulAsset\nExtractionId", this.props.textUnit.getLastSuccessfulAssetExtractionId())}
+                    {this.displayInfo("AssetExtractionId", this.props.textUnit.getAssetExtractionId())}
+                    {this.displayInfo("Branch", this.getBranch())}
+                    {this.displayScreenshotLink()}
+                </div>
+            );
+    };
+
+    /**
+     * @param property The property of the TranslationHistory object to retrieve
+     * @returns {*}    The value of the given property of the TranslationHistory object
+     */
+    getTranslationHistoryProperty = (property) => {
+        let value = null;
+        if (this.props.translationHistoryWithUsage != null && this.props.translationHistoryWithUsage["translationHistory"] != null)
+            value = this.props.translationHistoryWithUsage["translationHistory"][property];
+        return value;
+    };
+
+    /**
+     * @returns {str} The code author of the current text unit
+     */
+    getAuthorName = () => {
+        return this.getTranslationHistoryProperty("authorName");
+    };
+
+    /**
+     * @returns {str} The email of the code author of the current text unit
+     */
+    getAuthorEmail = () => {
+        return this.getTranslationHistoryProperty("authorEmail");
+    };
+
+    /**
+     * @returns {str} The commit name of the current text unit
+     */
+    getCommitName = () => {
+        return this.getTranslationHistoryProperty("commitName");
+    };
+
+    /**
+     * @returns {int} The commit time (in ms) of the current text unit
+     */
+    getCommitTime = () => {
+        return parseInt(this.getTranslationHistoryProperty("commitTime")) * 1000;
+    };
+
+    /**
+     * @returns {*} A list of usages of the current text unit, or null if there are none
+     */
+    getUsages = () => {
+        if (this.props.translationHistoryWithUsage == null || this.props.translationHistoryWithUsage["usages"] == null)
+            return null;
+        return this.props.translationHistoryWithUsage["usages"];
+    };
+
+    getBranch = () => {
+        try {
+            return this.props.translationHistoryWithUsage.branch.name;
+        } catch (e) {
+            return " - ";
+        }
+    };
+
+    getBranchScreenshots = () => {
+        try {
+            return this.props.translationHistoryWithUsage.screenshots;
+        } catch (e) {
+            return [];
+        }
+    };
+
+    getParamsForLinks = () => {
+        return {
+            textUnitName: this.props.textUnit.getName(),
+            textUnitNameInSource: this.getTextUnitNameInSource(),
+            assetPath: this.props.textUnit.getAssetPath()
+        };
+    };
+
+    getTextUnitNameInSource() {
+        const regex = this.getTextUnitNameToTextUnitNameInSourceRegex();
+        const match = this.props.textUnit.getName().match(regex);
+        return match[1];
+    }
+
+    getTextUnitNameToTextUnitNameInSourceRegex() {
+        return this.props.textUnit.getPluralForm() == null
+            ? this.getTextUnitNameToTextUnitNameInSourceSingular()
+            : this.getTextUnitNameToTextUnitNameInSourcePlural();
+    }
+
+    renderLink = (urlTemplate, urlComponentTemplate, labelTemplate, params) => {
+        let url = LinkHelper.renderUrl(urlTemplate, urlComponentTemplate, params);
+        let label = LinkHelper.renderTemplate(labelTemplate, params);
+        return <a href={url}>{label}</a>;
+    };
+
+    getThirdPartyLink = () => {
+        return this.renderLink(
+            this.getThirdPartyUrlTemplate(),
+            this.getThirdPartyUrlComponentTemplate(),
+            this.getThirdPartyLabelTemplate(),
+            this.getParamsForLinks());
+    };
+
+    /**
+     * @returns {*|Array} A list of Location links if configuration is set, or the string set in getLocationDefaultLabel
+     */
+    getLocationLinks = () => {
+        const urlTemplate = this.getLocationUrlTemplate();
+        const useUsage = this.getLocationUseUsage();
+        let links = [];
+
+        if (urlTemplate === "") {
+            links = this.getLocationDefaultLabel();
+        } else if (useUsage) {
+            links = this.getLocationLinksFromUsages();
+        } else {
+            links = this.getLocationLink();
+        }
+        return links;
+    };
+
+    /**
+     * @returns {*} Creates a link to a single location
+     */
+    getLocationLink = () => {
+        return this.renderLink(
+            this.getLocationUrlTemplate(),
+            this.getLocationUrlComponentTemplate(),
+            this.getLocationLabelTemplate(),
+            this.getParamsForLinks());
+    };
+
+    /**
+     * @returns {Array} Creates a list of links corresponding to the usages
+     */
+    getLocationLinksFromUsages = () => {
+        const extractorPrefix = this.getLocationExtractorPrefix();
+
+        let links = [];
+        let usages = this.getUsages();
+
+        if (usages == null) {
+            links = this.getLocationDefaultLabel();
+        } else {
+            for (let usage of usages) {
+                if (extractorPrefix !== undefined) {
+                    usage = usage.replace(extractorPrefix, "");
+                }
+                let params = {
+                    filePath: this.getFilePathFromUsage(usage),
+                    lineNumber: this.getLineNumberFromUsage(usage),
+                    textUnitName: this.props.textUnit.getName(),
+                    assetPath: this.props.textUnit.getAssetPath(),
+                    usage: usage
+                };
+                let link = this.renderLink(this.getLocationUrlTemplate(), this.getLocationUrlComponentTemplate(), this.getLocationLabelTemplate(), params);
+                links.push(<div>{link}</div>);
+            }
+        }
+        return links;
+
+    };
+
+    /**
+     * @returns {*} Returns the extractorPrefix, if in configuration, or an empty string otherwise
+     */
+    getLocationExtractorPrefix = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.extractorPrefix;
+        } catch (e) {
+            return "";
+        }
+    };
+
+    /**
+     * @param usage          Usage to use to extract file path
+     * @returns {string | *} File path from given usage
+     */
+    getFilePathFromUsage = (usage) => {
+        return usage.split(':')[0];
+    };
+
+    /**
+     * @param usage          Usage to use to extract line number
+     * @returns {string | *} Line number from given usage
+     */
+    getLineNumberFromUsage = (usage) => {
+        return usage.split(':')[1];
+    };
+
+    /**
+     * @returns {*} Template for location url, if in configuration, an empty string otherwise.
+     */
+    getLocationUrlTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.url;
+        } catch (e) {
+            return "";
+        }
+    };
+
+    /**
+     * @returns {*} Template for location url cmoponent, if in configuration, an empty string otherwise.
+     */
+    getLocationUrlComponentTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.urlComponent;
+        } catch (e) {
+            return "";
+        }
+    };
+
+    /**
+     * @returns {*} Template for location label, if in configuration, or the string set in getLocationDefaultLabel otherwise
+     */
+    getLocationLabelTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.label;
+        } catch (e) {
+            return this.getLocationDefaultLabel();
+        }
+    };
+
+    /**
+     * @returns {*} The value of useUsage, if in configuration, or false otherwise
+     */
+    getLocationUseUsage = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.useUsage;
+        } catch (e) {
+            return false;
+        }
+    };
+
+    /**
+     * @returns {*} The default string for location in case no link configuration is set
+     */
+    getLocationDefaultLabel = () => {
+        const usages = this.getUsages();
+        if (usages !== null && usages.length > 0) {
+            return usages.join("\n");
+        } else {
+            return '-';
+        }
+    };
+
+    /**
+     * @returns {*} Says if the Third party TMS info should be displayed or not
+     */
+    shouldShowThirdPartyTMS = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty !== null;
+        } catch (e) {
+            return false;
+        }
+    };
+
+    /**
+     * @returns {*} Template for thirdParty url, if in configuration, an empty string otherwise.
+     */
+    getThirdPartyUrlTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty.url;
+        } catch (e) {
+            return "";
+        }
+    };
+
+    /**
+     * @returns {*} Template for thirdParty url to be component encoded, if in configuration, an empty string otherwise.
+     */
+    getThirdPartyUrlComponentTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty.urlComponent;
+        } catch (e) {
+            return "";
+        }
+    };
+
+    /**
+     * @returns {*} Template for thirdParty label, if in configuration, or the string set in getThirdPartyDefaultLabel otherwise
+     */
+    getThirdPartyLabelTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty.label;
+        } catch (e) {
+            return null;
+        }
+    };
+
+    /**
+     * @returns {*} Regex to tranform the text unit name into the text unit name as it appear in source code,
+     * if in configuration, an empty string otherwise.
+     */
+    getTextUnitNameToTextUnitNameInSourceSingular = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].textUnitNameToTextUnitNameInSource.singular;
+        } catch (e) {
+            return "(.*)";
+        }
+    };
+
+    /**
+     * @returns {*} Regex to tranform text unit name into text unit string in code, if in configuration, default
+     * to exp to remove plural otherwise.
+     */
+    getTextUnitNameToTextUnitNameInSourcePlural = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].textUnitNameToTextUnitNameInSource.plural;
+        } catch (e) {
+            return "(.*) ?_(zero|one|two|few|many|other)$";
+        }
+    };
+
+    /**
+     * @returns {*} Creates a link to current commit if there is one, or value of getCommitDefaultLabel if there is none
+     */
+    getCommitLink = () => {
+        const urlTemplate = this.getCommitUrlTemplate();
+        const commit = this.getCommitName();
+        let link = this.getCommitDefaultLabel();
+
+        if (commit !== null && urlTemplate !== "") {
+            let params = {commit: commit};
+            link = this.renderLink(urlTemplate, this.getCommitUrlComponentTemplate(), this.getCommitLabelTemplate(), params);
+        }
+
+        return link;
+    };
+
+    /**
+     * @returns {*} Template for commit url, if in configuration, an empty string otherwise.
+     */
+    getCommitUrlTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].commit.url;
+        } catch (e) {
+            return ""
+        }
+    };
+
+    /**
+     * @returns {*} Template for commit url component, if in configuration, an empty string otherwise.
+     */
+    getCommitUrlComponentTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].commit.urlComponent;
+        } catch (e) {
+            return ""
+        }
+    };
+
+    /**
+     * @returns {*} Template for commit label, if in configuration, or the string set in getCommitDefaultLabel otherwise
+     */
+    getCommitLabelTemplate = () => {
+        try {
+            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].commit.label;
+        } catch (e) {
+            return this.getCommitDefaultLabel();
+        }
+    };
+
+    /**
+     * @returns {*} The default string for commit in case no link configuration is set
+     */
+    getCommitDefaultLabel = () => {
+        return this.getCommitName();
+    };
+
+    /**
+     * @returns {*} The translated date if the text unit has been translated
+     */
+    getTranslatedDate = () => {
+        if (this.props.textUnit.getTmTextUnitCurrentVariantId() != null) {
+            return this.convertDateTime(this.props.textUnit.getCreatedDate());
+        }
+    };
+
+    /**
+     * @param date   An integer representing a datetime
+     * @returns {*}  Human readable version of the given datetime
+     *
+     */
+    convertDateTime = (date) => {
+        if (date === null || isNaN(date)) {
+            return null;
+        }
+
+        let options = {
+            year: 'numeric', month: 'numeric', day: 'numeric',
+            hour: 'numeric', minute: 'numeric'
+        };
+        return (this.props.intl.formatDate(date, options));
+    };
+
+    /**
+     * Closes the modal and calls the parent action handler to mark the modal as closed
+     */
+    closeModal = () => {
+        this.props.onCloseModal();
+    };
+
+    render() {
+        return (
+            <Modal className={"git-blame-modal"} show={this.props.show} onHide={this.closeModal}>
+                <Modal.Header closeButton>
+                    <Modal.Title>{this.getTitle()}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className={"row"}>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.translationHistoryModal.textUnit"}/></h4>
+                        </div>
+                    </div>
+                    {this.renderTextUnitInfo()}
+                    <hr/>
+                    <div className={"row"}>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.translationHistoryModal.translationHistory"}/></h4>
+                        </div>
+                        <div className={"col-sm-8"}>
+                            {this.props.loading ? (<span className="glyphicon glyphicon-refresh spinning"/>) : ""}
+                        </div>
+                    </div>
+                    {this.rendertranslationHistory()}
+                    <hr/>
+                    <div className={"row"}>
+                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.translationHistoryModal.more"}/></h4>
+                        </div>
+                    </div>
+                    {this.renderDebugInfo()}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button bsStyle="primary" onClick={this.closeModal}>
+                        <FormattedMessage id={"textUnit.translationHistoryModal.close"}/>
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+export default withAppConfig(injectIntl(translationHistoryModal));

--- a/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
@@ -2,507 +2,54 @@ import PropTypes from 'prop-types';
 import React from "react";
 import {FormattedMessage, injectIntl} from "react-intl";
 import {Button, Modal} from "react-bootstrap";
-import {withAppConfig} from "../../utils/AppConfig";
-import LinkHelper from "../../utils/LinkHelper";
-import {Link} from "react-router";
+import {Table} from "react-bootstrap";
+import StatusGlyph from '../widgets/StatusGlyph';
 
 class translationHistoryModal extends React.Component {
     static propTypes() {
         return {
             "show": PropTypes.bool.isRequired,
             "textUnit": PropTypes.object.isRequired,
-            "translationHistoryWithUsage": PropTypes.object.isRequired
+            "translationHistory": PropTypes.object.isRequired
         };
     }
 
-    /**
-     * @returns {string} The title of the modal is the name of the text unit
-     */
-    getTitle = () => {
-        return this.props.intl.formatMessage({id: "workbench.translationHistoryModal.info"});
-    };
-
-    /**
-     * @param label  The label for the data to display
-     * @param data   The data to display
-     * @returns {*}  The row of label:data to display in the modal
-     */
-    displayInfo = (label, data) => {
-        let translationHistoryClass = "";
-        if (data == null) {
-            translationHistoryClass = " git-blame-unused";
-            data = "-";
-        }
-
-        return (
-            <div className={"row git-blame"}>
-                <label className={"col-sm-3 git-blame-label"}>{label}</label>
-                <div className={"col-sm-9 git-blame-info" + translationHistoryClass}>{data}</div>
-            </div>
-        );
-    };
-
-    /**
-     * @returns {*} The row of label:link to display in the modal
-     */
-    displayScreenshotLink = () => {
-        const label = this.props.intl.formatMessage({id: "textUnit.translationHistoryModal.screenshots"});
-        const branchScreenshots = this.getBranchScreenshots();
-        if (!branchScreenshots.length) {
-            return this.displayInfo(label, null);
-        }
-
-        return (
-            <div className={"row git-blame"}>
-                <label className={"col-sm-3 git-blame-label"}>{label}</label>
-                <Link
-                    onClick={() => this.props.onViewScreenshotClick(branchScreenshots)}
-                    className="col-sm-9 clickable">
-                    <FormattedMessage id="textUnit.translationHistoryModal.screenshotModalOpen"/>
-                </Link>
-            </div>
-        );
-    };
-
-    /**
-     * @param labelId  The labelId for the formatted message
-     * @param data     The data to display
-     * @returns {*}    The row of label:data to display in the modal
-     */
-    displayInfoWithId = (labelId, data) => {
-        return this.displayInfo(this.props.intl.formatMessage({id: labelId}), data);
-    };
-
-    /**
-     * @returns {*} Generated content for the text unit information section
-     */
-    renderTextUnitInfo = () => {
-        return this.props.textUnit === null ? "" :
+    renderHistoryItem = (item) => {
+        return item ?
             (
-                <div>
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.repository", this.props.textUnit.getRepositoryName())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.assetPath", this.props.textUnit.getAssetPath())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.id", this.props.textUnit.getName())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.source", this.props.textUnit.getSource())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.target", this.props.textUnit.getTarget())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.locale", this.props.textUnit.getTargetLocale())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.created", this.convertDateTime(this.props.textUnit.getTmTextUnitCreatedDate()))}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.translated", this.getTranslatedDate())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.pluralForm", this.props.textUnit.getPluralForm())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.pluralFormOther", this.props.textUnit.getPluralFormOther())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.comment", this.props.textUnit.getComment())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.targetComment", this.props.textUnit.getTargetComment())}
-                    {this.displayInfoWithId("textUnit.translationHistoryModal.location", this.getLocationLinks())}
-                    {this.shouldShowThirdPartyTMS() && this.displayInfoWithId("textUnit.translationHistoryModal.thirdPartyTMS", this.getThirdPartyLink())}
-                </div>
-            );
+                <tr>
+                    <td>{item.createdByUser.username}</td>
+                    <td>{item.content}</td>
+                    <td>{this.convertDateTime(item.createdDate)}</td>
+                    <td><StatusGlyph status={item.status} onClick={() => ""}/></td>
+                </tr>
+            ) :
+            "";
     };
 
     /**
      * @returns {*} Generated content for the git blame information section
      */
     rendertranslationHistory = () => {
-        return (
-            <div>
-                {this.displayInfoWithId("textUnit.translationHistoryModal.authorName", this.getAuthorName())}
-                {this.displayInfoWithId("textUnit.translationHistoryModal.authorEmail", this.getAuthorEmail())}
-                {this.displayInfoWithId("textUnit.translationHistoryModal.commit", this.getCommitLink())}
-                {this.displayInfoWithId("textUnit.translationHistoryModal.commitDate", this.convertDateTime(this.getCommitTime()))}
-            </div>
-        )
-    };
+        const { translationHistory } = this.props;
 
-    /**
-     * @returns {*} Generated content for the additional text unit information section
-     */
-    renderDebugInfo = () => {
-        return this.props.textUnit === null ? "" :
-            (
-                <div className="panel-body">
-                    {this.displayInfo("TmTextUnitId", this.props.textUnit.getTmTextUnitId())}
-                    {this.displayInfo("TmTextUnitVariantId", this.props.textUnit.getTmTextUnitVariantId())}
-                    {this.displayInfo("TmTextUnitCurrentVariantId", this.props.textUnit.getTmTextUnitCurrentVariantId())}
-                    {this.displayInfo("AssetTextUnitId", this.props.textUnit.getAssetTextUnitId())}
-                    {this.displayInfo("AssetId", this.props.textUnit.getAssetId())}
-                    {this.displayInfo("LastSuccessfulAsset\nExtractionId", this.props.textUnit.getLastSuccessfulAssetExtractionId())}
-                    {this.displayInfo("AssetExtractionId", this.props.textUnit.getAssetExtractionId())}
-                    {this.displayInfo("Branch", this.getBranch())}
-                    {this.displayScreenshotLink()}
-                </div>
+        if (translationHistory && translationHistory.length) {
+            return (
+                <Table striped bordered hover responsive="sm">
+                    <thead>
+                        <th><FormattedMessage id="textUnit.translationHistoryModal.User"/></th>
+                        <th><FormattedMessage id="textUnit.translationHistoryModal.Translation"/></th>
+                        <th><FormattedMessage id="textUnit.translationHistoryModal.Date"/></th>
+                        <th><FormattedMessage id="textUnit.translationHistoryModal.Status"/></th>
+                    </thead>
+                    <tbody>
+                    {translationHistory.map(this.renderHistoryItem)}
+                    </tbody>
+                </Table>
             );
-    };
-
-    /**
-     * @param property The property of the TranslationHistory object to retrieve
-     * @returns {*}    The value of the given property of the TranslationHistory object
-     */
-    getTranslationHistoryProperty = (property) => {
-        let value = null;
-        if (this.props.translationHistoryWithUsage != null && this.props.translationHistoryWithUsage["translationHistory"] != null)
-            value = this.props.translationHistoryWithUsage["translationHistory"][property];
-        return value;
-    };
-
-    /**
-     * @returns {str} The code author of the current text unit
-     */
-    getAuthorName = () => {
-        return this.getTranslationHistoryProperty("authorName");
-    };
-
-    /**
-     * @returns {str} The email of the code author of the current text unit
-     */
-    getAuthorEmail = () => {
-        return this.getTranslationHistoryProperty("authorEmail");
-    };
-
-    /**
-     * @returns {str} The commit name of the current text unit
-     */
-    getCommitName = () => {
-        return this.getTranslationHistoryProperty("commitName");
-    };
-
-    /**
-     * @returns {int} The commit time (in ms) of the current text unit
-     */
-    getCommitTime = () => {
-        return parseInt(this.getTranslationHistoryProperty("commitTime")) * 1000;
-    };
-
-    /**
-     * @returns {*} A list of usages of the current text unit, or null if there are none
-     */
-    getUsages = () => {
-        if (this.props.translationHistoryWithUsage == null || this.props.translationHistoryWithUsage["usages"] == null)
-            return null;
-        return this.props.translationHistoryWithUsage["usages"];
-    };
-
-    getBranch = () => {
-        try {
-            return this.props.translationHistoryWithUsage.branch.name;
-        } catch (e) {
-            return " - ";
-        }
-    };
-
-    getBranchScreenshots = () => {
-        try {
-            return this.props.translationHistoryWithUsage.screenshots;
-        } catch (e) {
-            return [];
-        }
-    };
-
-    getParamsForLinks = () => {
-        return {
-            textUnitName: this.props.textUnit.getName(),
-            textUnitNameInSource: this.getTextUnitNameInSource(),
-            assetPath: this.props.textUnit.getAssetPath()
-        };
-    };
-
-    getTextUnitNameInSource() {
-        const regex = this.getTextUnitNameToTextUnitNameInSourceRegex();
-        const match = this.props.textUnit.getName().match(regex);
-        return match[1];
-    }
-
-    getTextUnitNameToTextUnitNameInSourceRegex() {
-        return this.props.textUnit.getPluralForm() == null
-            ? this.getTextUnitNameToTextUnitNameInSourceSingular()
-            : this.getTextUnitNameToTextUnitNameInSourcePlural();
-    }
-
-    renderLink = (urlTemplate, urlComponentTemplate, labelTemplate, params) => {
-        let url = LinkHelper.renderUrl(urlTemplate, urlComponentTemplate, params);
-        let label = LinkHelper.renderTemplate(labelTemplate, params);
-        return <a href={url}>{label}</a>;
-    };
-
-    getThirdPartyLink = () => {
-        return this.renderLink(
-            this.getThirdPartyUrlTemplate(),
-            this.getThirdPartyUrlComponentTemplate(),
-            this.getThirdPartyLabelTemplate(),
-            this.getParamsForLinks());
-    };
-
-    /**
-     * @returns {*|Array} A list of Location links if configuration is set, or the string set in getLocationDefaultLabel
-     */
-    getLocationLinks = () => {
-        const urlTemplate = this.getLocationUrlTemplate();
-        const useUsage = this.getLocationUseUsage();
-        let links = [];
-
-        if (urlTemplate === "") {
-            links = this.getLocationDefaultLabel();
-        } else if (useUsage) {
-            links = this.getLocationLinksFromUsages();
         } else {
-            links = this.getLocationLink();
-        }
-        return links;
-    };
-
-    /**
-     * @returns {*} Creates a link to a single location
-     */
-    getLocationLink = () => {
-        return this.renderLink(
-            this.getLocationUrlTemplate(),
-            this.getLocationUrlComponentTemplate(),
-            this.getLocationLabelTemplate(),
-            this.getParamsForLinks());
-    };
-
-    /**
-     * @returns {Array} Creates a list of links corresponding to the usages
-     */
-    getLocationLinksFromUsages = () => {
-        const extractorPrefix = this.getLocationExtractorPrefix();
-
-        let links = [];
-        let usages = this.getUsages();
-
-        if (usages == null) {
-            links = this.getLocationDefaultLabel();
-        } else {
-            for (let usage of usages) {
-                if (extractorPrefix !== undefined) {
-                    usage = usage.replace(extractorPrefix, "");
-                }
-                let params = {
-                    filePath: this.getFilePathFromUsage(usage),
-                    lineNumber: this.getLineNumberFromUsage(usage),
-                    textUnitName: this.props.textUnit.getName(),
-                    assetPath: this.props.textUnit.getAssetPath(),
-                    usage: usage
-                };
-                let link = this.renderLink(this.getLocationUrlTemplate(), this.getLocationUrlComponentTemplate(), this.getLocationLabelTemplate(), params);
-                links.push(<div>{link}</div>);
-            }
-        }
-        return links;
-
-    };
-
-    /**
-     * @returns {*} Returns the extractorPrefix, if in configuration, or an empty string otherwise
-     */
-    getLocationExtractorPrefix = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.extractorPrefix;
-        } catch (e) {
-            return "";
-        }
-    };
-
-    /**
-     * @param usage          Usage to use to extract file path
-     * @returns {string | *} File path from given usage
-     */
-    getFilePathFromUsage = (usage) => {
-        return usage.split(':')[0];
-    };
-
-    /**
-     * @param usage          Usage to use to extract line number
-     * @returns {string | *} Line number from given usage
-     */
-    getLineNumberFromUsage = (usage) => {
-        return usage.split(':')[1];
-    };
-
-    /**
-     * @returns {*} Template for location url, if in configuration, an empty string otherwise.
-     */
-    getLocationUrlTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.url;
-        } catch (e) {
-            return "";
-        }
-    };
-
-    /**
-     * @returns {*} Template for location url cmoponent, if in configuration, an empty string otherwise.
-     */
-    getLocationUrlComponentTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.urlComponent;
-        } catch (e) {
-            return "";
-        }
-    };
-
-    /**
-     * @returns {*} Template for location label, if in configuration, or the string set in getLocationDefaultLabel otherwise
-     */
-    getLocationLabelTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.label;
-        } catch (e) {
-            return this.getLocationDefaultLabel();
-        }
-    };
-
-    /**
-     * @returns {*} The value of useUsage, if in configuration, or false otherwise
-     */
-    getLocationUseUsage = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].location.useUsage;
-        } catch (e) {
-            return false;
-        }
-    };
-
-    /**
-     * @returns {*} The default string for location in case no link configuration is set
-     */
-    getLocationDefaultLabel = () => {
-        const usages = this.getUsages();
-        if (usages !== null && usages.length > 0) {
-            return usages.join("\n");
-        } else {
-            return '-';
-        }
-    };
-
-    /**
-     * @returns {*} Says if the Third party TMS info should be displayed or not
-     */
-    shouldShowThirdPartyTMS = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty !== null;
-        } catch (e) {
-            return false;
-        }
-    };
-
-    /**
-     * @returns {*} Template for thirdParty url, if in configuration, an empty string otherwise.
-     */
-    getThirdPartyUrlTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty.url;
-        } catch (e) {
-            return "";
-        }
-    };
-
-    /**
-     * @returns {*} Template for thirdParty url to be component encoded, if in configuration, an empty string otherwise.
-     */
-    getThirdPartyUrlComponentTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty.urlComponent;
-        } catch (e) {
-            return "";
-        }
-    };
-
-    /**
-     * @returns {*} Template for thirdParty label, if in configuration, or the string set in getThirdPartyDefaultLabel otherwise
-     */
-    getThirdPartyLabelTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].thirdParty.label;
-        } catch (e) {
-            return null;
-        }
-    };
-
-    /**
-     * @returns {*} Regex to tranform the text unit name into the text unit name as it appear in source code,
-     * if in configuration, an empty string otherwise.
-     */
-    getTextUnitNameToTextUnitNameInSourceSingular = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].textUnitNameToTextUnitNameInSource.singular;
-        } catch (e) {
-            return "(.*)";
-        }
-    };
-
-    /**
-     * @returns {*} Regex to tranform text unit name into text unit string in code, if in configuration, default
-     * to exp to remove plural otherwise.
-     */
-    getTextUnitNameToTextUnitNameInSourcePlural = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].textUnitNameToTextUnitNameInSource.plural;
-        } catch (e) {
-            return "(.*) ?_(zero|one|two|few|many|other)$";
-        }
-    };
-
-    /**
-     * @returns {*} Creates a link to current commit if there is one, or value of getCommitDefaultLabel if there is none
-     */
-    getCommitLink = () => {
-        const urlTemplate = this.getCommitUrlTemplate();
-        const commit = this.getCommitName();
-        let link = this.getCommitDefaultLabel();
-
-        if (commit !== null && urlTemplate !== "") {
-            let params = {commit: commit};
-            link = this.renderLink(urlTemplate, this.getCommitUrlComponentTemplate(), this.getCommitLabelTemplate(), params);
-        }
-
-        return link;
-    };
-
-    /**
-     * @returns {*} Template for commit url, if in configuration, an empty string otherwise.
-     */
-    getCommitUrlTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].commit.url;
-        } catch (e) {
-            return ""
-        }
-    };
-
-    /**
-     * @returns {*} Template for commit url component, if in configuration, an empty string otherwise.
-     */
-    getCommitUrlComponentTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].commit.urlComponent;
-        } catch (e) {
-            return ""
-        }
-    };
-
-    /**
-     * @returns {*} Template for commit label, if in configuration, or the string set in getCommitDefaultLabel otherwise
-     */
-    getCommitLabelTemplate = () => {
-        try {
-            return this.props.appConfig.link[this.props.textUnit.getRepositoryName()].commit.label;
-        } catch (e) {
-            return this.getCommitDefaultLabel();
-        }
-    };
-
-    /**
-     * @returns {*} The default string for commit in case no link configuration is set
-     */
-    getCommitDefaultLabel = () => {
-        return this.getCommitName();
-    };
-
-    /**
-     * @returns {*} The translated date if the text unit has been translated
-     */
-    getTranslatedDate = () => {
-        if (this.props.textUnit.getTmTextUnitCurrentVariantId() != null) {
-            return this.convertDateTime(this.props.textUnit.getCreatedDate());
+            // for safety
+            return <div><FormattedMessage id="textUnit.translationHistoryModal.NoTranslations"/></div>;
         }
     };
 
@@ -531,32 +78,27 @@ class translationHistoryModal extends React.Component {
     };
 
     render() {
-        return (
-            <Modal className={"git-blame-modal"} show={this.props.show} onHide={this.closeModal}>
+        const { textUnit, show } = this.props;
+
+        return textUnit ? (
+            <Modal className={"git-blame-modal"} show={show} onHide={this.closeModal}>
                 <Modal.Header closeButton>
-                    <Modal.Title>{this.getTitle()}</Modal.Title>
+                    <Modal.Title><FormattedMessage id="workbench.translationHistoryModal.title"/></Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
                     <div className={"row"}>
-                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.translationHistoryModal.textUnit"}/></h4>
+                        <div className={"col-sm-4"}>
+                            <h4>
+                                <FormattedMessage id={"textUnit.translationHistoryModal.header"} values={{
+                                    locale: textUnit.getTargetLocale(),
+                                    source: textUnit.getSource()
+                                }}/>
+                            </h4>
                         </div>
                     </div>
-                    {this.renderTextUnitInfo()}
-                    <hr/>
-                    <div className={"row"}>
-                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.translationHistoryModal.translationHistory"}/></h4>
-                        </div>
-                        <div className={"col-sm-8"}>
-                            {this.props.loading ? (<span className="glyphicon glyphicon-refresh spinning"/>) : ""}
-                        </div>
+                    <div>
+                        {this.rendertranslationHistory()}
                     </div>
-                    {this.rendertranslationHistory()}
-                    <hr/>
-                    <div className={"row"}>
-                        <div className={"col-sm-4"}><h4><FormattedMessage id={"textUnit.translationHistoryModal.more"}/></h4>
-                        </div>
-                    </div>
-                    {this.renderDebugInfo()}
                 </Modal.Body>
                 <Modal.Footer>
                     <Button bsStyle="primary" onClick={this.closeModal}>
@@ -564,8 +106,8 @@ class translationHistoryModal extends React.Component {
                     </Button>
                 </Modal.Footer>
             </Modal>
-        );
+        ) : "";
     }
 }
 
-export default withAppConfig(injectIntl(translationHistoryModal));
+export default injectIntl(translationHistoryModal);

--- a/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
@@ -4,6 +4,7 @@ import {FormattedMessage, injectIntl} from "react-intl";
 import {Button, Modal} from "react-bootstrap";
 import {Table} from "react-bootstrap";
 import StatusGlyph from '../widgets/StatusGlyph';
+import TextUnitSDK from "../../sdk/TextUnit";
 
 class translationHistoryModal extends React.Component {
     static propTypes() {
@@ -31,26 +32,29 @@ class translationHistoryModal extends React.Component {
      * @returns {*} Generated content for the git blame information section
      */
     rendertranslationHistory = () => {
-        const { translationHistory } = this.props;
+        const { translationHistory, textUnit, intl } = this.props;
 
-        if (translationHistory && translationHistory.length) {
-            return (
-                <Table striped bordered hover responsive="sm">
-                    <thead>
-                        <th><FormattedMessage id="textUnit.translationHistoryModal.User"/></th>
-                        <th><FormattedMessage id="textUnit.translationHistoryModal.Translation"/></th>
-                        <th><FormattedMessage id="textUnit.translationHistoryModal.Date"/></th>
-                        <th><FormattedMessage id="textUnit.translationHistoryModal.Status"/></th>
-                    </thead>
-                    <tbody>
-                    {translationHistory.map(this.renderHistoryItem)}
-                    </tbody>
-                </Table>
-            );
-        } else {
-            // for safety
-            return <div><FormattedMessage id="textUnit.translationHistoryModal.NoTranslations"/></div>;
-        }
+        return (
+            <Table striped bordered hover responsive="sm">
+                <thead>
+                    <th><FormattedMessage id="textUnit.translationHistoryModal.User"/></th>
+                    <th><FormattedMessage id="textUnit.translationHistoryModal.Translation"/></th>
+                    <th><FormattedMessage id="textUnit.translationHistoryModal.Date"/></th>
+                    <th><FormattedMessage id="textUnit.translationHistoryModal.Status"/></th>
+                </thead>
+                <tbody>
+                {(translationHistory && translationHistory.length) ? translationHistory.map(this.renderHistoryItem) : ""}
+                {this.renderHistoryItem({
+                    createdByUser: {
+                        username: "mojito"
+                    },
+                    content: (<span class="history-initial"><FormattedMessage id="textUnit.translationHistoryModal.InitialPush"/></span>),
+                    createdDate: textUnit.getTmTextUnitCreatedDate(),
+                    status: TextUnitSDK.STATUS.TRANSLATION_NEEDED
+                })}
+                </tbody>
+            </Table>
+        );
     };
 
     /**
@@ -88,14 +92,19 @@ class translationHistoryModal extends React.Component {
                 <Modal.Body>
                     <div className={"row"}>
                         <div className={"col-sm-4"}>
-                            <h4>
-                                <FormattedMessage id={"textUnit.translationHistoryModal.header"} values={{
-                                    locale: textUnit.getTargetLocale(),
+                            <div>
+                                <FormattedMessage id={"textUnit.translationHistoryModal.locale"} values={{
+                                    locale: textUnit.getTargetLocale()
+                                }}/>
+                            </div>
+                            <div>
+                                <FormattedMessage id={"textUnit.translationHistoryModal.source"} values={{
                                     source: textUnit.getSource()
                                 }}/>
-                            </h4>
+                            </div>
                         </div>
                     </div>
+                    <p/>
                     <div>
                         {this.rendertranslationHistory()}
                     </div>

--- a/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TranslationHistoryModal.js
@@ -35,12 +35,14 @@ class translationHistoryModal extends React.Component {
         const { translationHistory, textUnit, intl } = this.props;
 
         return (
-            <Table striped bordered hover responsive="sm">
+            <Table className="repo-table table-padded-sides">
                 <thead>
-                    <th><FormattedMessage id="textUnit.translationHistoryModal.User"/></th>
-                    <th><FormattedMessage id="textUnit.translationHistoryModal.Translation"/></th>
-                    <th><FormattedMessage id="textUnit.translationHistoryModal.Date"/></th>
-                    <th><FormattedMessage id="textUnit.translationHistoryModal.Status"/></th>
+                    <tr>
+                        <th className="col-md-4"><FormattedMessage id="textUnit.translationHistoryModal.User"/></th>
+                        <th className="col-md-4"><FormattedMessage id="textUnit.translationHistoryModal.Translation"/></th>
+                        <th className="col-md-4"><FormattedMessage id="textUnit.translationHistoryModal.Date"/></th>
+                        <th className="col-md-4"><FormattedMessage id="textUnit.translationHistoryModal.Status"/></th>
+                    </tr>
                 </thead>
                 <tbody>
                 {(translationHistory && translationHistory.length) ? translationHistory.map(this.renderHistoryItem) : ""}
@@ -87,16 +89,15 @@ class translationHistoryModal extends React.Component {
         return textUnit ? (
             <Modal className={"git-blame-modal"} show={show} onHide={this.closeModal}>
                 <Modal.Header closeButton>
-                    <Modal.Title><FormattedMessage id="workbench.translationHistoryModal.title"/></Modal.Title>
+                    <Modal.Title>
+                        <FormattedMessage id="workbench.translationHistoryModal.title" values={{
+                            locale: textUnit.getTargetLocale()
+                        }}/>
+                    </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
                     <div className={"row"}>
                         <div className={"col-sm-4"}>
-                            <div>
-                                <FormattedMessage id={"textUnit.translationHistoryModal.locale"} values={{
-                                    locale: textUnit.getTargetLocale()
-                                }}/>
-                            </div>
                             <div>
                                 <FormattedMessage id={"textUnit.translationHistoryModal.source"} values={{
                                     source: textUnit.getSource()

--- a/webapp/src/main/resources/public/js/components/workbench/Workbench.js
+++ b/webapp/src/main/resources/public/js/components/workbench/Workbench.js
@@ -18,6 +18,9 @@ import BranchesScreenshotViewerModal from "../branches/BranchesScreenshotViewerM
 import GitBlameScreenshotViewerActions from "../../actions/workbench/GitBlameScreenshotViewerActions";
 import GitBlameScreenshotViewerStore from "../../stores/workbench/GitBlameScreenshotViewerStore";
 import UrlHelper from "../../utils/UrlHelper";
+import TranslationHistoryStore from "../../stores/workbench/TranslationHistoryStore";
+import TranslationHistoryModal from "./TranslationHistoryModal";
+import TranslationHistoryActions from "../../actions/workbench/TranslationHistoryActions";
 
 let Workbench = createReactClass({
     displayName: 'Workbench',
@@ -26,7 +29,8 @@ let Workbench = createReactClass({
     statics: {
         storeListeners: {
             "onSearchParamsStoreChanged": SearchParamsStore,
-            "onGitBlameStoreUpdated": GitBlameStore
+            "onGitBlameStoreUpdated": GitBlameStore,
+            "onTranslationHistoryStoreUpdated": TranslationHistoryStore
         }
     },
 
@@ -41,6 +45,10 @@ let Workbench = createReactClass({
 
     onGitBlameStoreUpdated(store) {
         this.setState({"isShowGitBlameModal": store.show});
+    },
+
+    onTranslationHistoryStoreUpdated(store) {
+        this.setState({"isShowTranslationHistoryModal": store.show});
     },
 
     /**
@@ -109,7 +117,9 @@ let Workbench = createReactClass({
                         }}
                     />
                 </AltContainer>
-
+                <AltContainer store={TranslationHistoryStore}>
+                    <TranslationHistoryModal onCloseModal={TranslationHistoryActions.close}/>
+                </AltContainer>
             </div>
         );
     },

--- a/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
+++ b/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
@@ -105,7 +105,7 @@ class TextUnitClient extends BaseClient {
 
     getTranslationHistory(textUnit) {
         return this.get(this.getUrl() + "/history/" + textUnit.getTmTextUnitId(), {
-            "bcp47Tag": textUnit.targetLocale
+            "bcp47Tag": textUnit.getTargetLocale()
         });
     }
 

--- a/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
+++ b/webapp/src/main/resources/public/js/sdk/TextUnitClient.js
@@ -103,6 +103,11 @@ class TextUnitClient extends BaseClient {
         return this.get(this.getUrl() + "/gitBlameWithUsages", {"tmTextUnitId": textUnit.getTmTextUnitId()});
     }
 
+    getTranslationHistory(textUnit) {
+        return this.get(this.getUrl() + "/history/" + textUnit.getTmTextUnitId(), {
+            "bcp47Tag": textUnit.targetLocale
+        });
+    }
 
     getEntityName() {
         return 'textunits';

--- a/webapp/src/main/resources/public/js/stores/workbench/TranslationHistoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/TranslationHistoryStore.js
@@ -18,7 +18,7 @@ class TranslationHistoryStore {
     setDefaultState() {
         this.show = false;
         this.textUnit = null;
-        this.translationHistoryWithUsage = null;
+        this.translationHistory = null;
         this.loading = false;
     }
 
@@ -31,14 +31,14 @@ class TranslationHistoryStore {
 
         this.show = true;
         this.textUnit = textUnit;
-        this.translationHistoryWithUsage = null;
+        this.translationHistory = null;
         this.loading = true;
         this.getInstance().getTranslationHistory(textUnit);
     }
 
-    onGetTranslationHistorySuccess(translationHistoryWithUsage) {
+    onGetTranslationHistorySuccess(translationHistory) {
         console.log("TranslationHistoryStore::onGetTranslationHistorySuccess");
-        this.translationHistoryWithUsage = translationHistoryWithUsage[0];
+        this.translationHistory = translationHistory;
         this.loading = false;
     }
 

--- a/webapp/src/main/resources/public/js/stores/workbench/TranslationHistoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/TranslationHistoryStore.js
@@ -1,0 +1,51 @@
+import alt from "../../alt";
+import Error from "../../utils/Error";
+import TextUnit from "../../sdk/TextUnit";
+import TextUnitDataSource from "../../actions/workbench/TextUnitDataSource";
+import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
+import SearchParamsStore from "./SearchParamsStore";
+import {StatusCommonTypes} from "../../components/screenshots/StatusCommon";
+import TranslationHistoryActions from "../../actions/workbench/TranslationHistoryActions";
+
+class TranslationHistoryStore {
+
+    constructor() {
+        this.setDefaultState();
+        this.bindActions(TranslationHistoryActions);
+        this.registerAsync(TextUnitDataSource);
+    }
+
+    setDefaultState() {
+        this.show = false;
+        this.textUnit = null;
+        this.translationHistoryWithUsage = null;
+        this.loading = false;
+    }
+
+    close() {
+        this.show = false;
+    }
+
+    openWithTextUnit(textUnit) {
+        console.log("TranslationHistoryStore::openWithTextUnit");
+
+        this.show = true;
+        this.textUnit = textUnit;
+        this.translationHistoryWithUsage = null;
+        this.loading = true;
+        this.getInstance().getTranslationHistory(textUnit);
+    }
+
+    onGetTranslationHistorySuccess(translationHistoryWithUsage) {
+        console.log("TranslationHistoryStore::onGetTranslationHistorySuccess");
+        this.translationHistoryWithUsage = translationHistoryWithUsage[0];
+        this.loading = false;
+    }
+
+    onGetTranslationHistoryError(errorResponse) {
+        console.log("TranslationHistoryStore::onGetTranslationHistoryError");
+        this.loading = false;
+    }
+}
+
+export default alt.createStore(TranslationHistoryStore, 'TranslationHistoryStore');

--- a/webapp/src/main/resources/public/js/stores/workbench/TranslationHistoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/TranslationHistoryStore.js
@@ -27,8 +27,6 @@ class TranslationHistoryStore {
     }
 
     openWithTextUnit(textUnit) {
-        console.log("TranslationHistoryStore::openWithTextUnit");
-
         this.show = true;
         this.textUnit = textUnit;
         this.translationHistory = null;
@@ -37,13 +35,11 @@ class TranslationHistoryStore {
     }
 
     onGetTranslationHistorySuccess(translationHistory) {
-        console.log("TranslationHistoryStore::onGetTranslationHistorySuccess");
         this.translationHistory = translationHistory;
         this.loading = false;
     }
 
     onGetTranslationHistoryError(errorResponse) {
-        console.log("TranslationHistoryStore::onGetTranslationHistoryError");
         this.loading = false;
     }
 }

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -489,7 +489,13 @@ div.targetstring-container textarea {
 }
 
 .history-initial {
-    color: $brand-primary;
+    color: $gray-light;
+    font-style: italic;
+}
+
+.history-header {
+    font-weight: 400;
+    padding: 8px;
 }
 
 /**

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -488,6 +488,10 @@ div.targetstring-container textarea {
     width: 60%;
 }
 
+.history-initial {
+    color: $brand-primary;
+}
+
 /**
  * LOGIN
  */

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -428,6 +428,15 @@ div.textunit label {
     color: $brand-success;
 }
 
+.textunit:hover .textunit-assetpath, .textunit:hover .textunit-translation-history {
+    visibility: visible;
+}
+
+.textunit-name .textunit-assetpath, .textunit-name .textunit-translation-history {
+    visibility: hidden;
+    color: $brand-success;
+}
+
 .textunit-returnline {
     color: $brand-primary;
     font-size: 10px;


### PR DESCRIPTION
Now that the BE exposes the translation history of a text unit, this PR introduces the UI on the front end so that you can see it easily. The history is exposed as a clock button on each text unit:

<img width="407" alt="Screen Shot 2019-10-14 at 14 00 19" src="https://user-images.githubusercontent.com/3444053/66782667-144d8400-ee8b-11e9-8c1c-f66003d2708a.png">

When you click it, a dialog comes up with the translation history in it:

<img width="953" alt="Screen Shot 2019-10-17 at 13 30 59" src="https://user-images.githubusercontent.com/3444053/67045090-7522c980-f0e2-11e9-862a-7ec69ba2bee5.png">

You can only view the history for the locale of the unit that you click on. You cannot (yet?) see the history of all translations for a source string.

The table is ordered in reverse chronological order. (ie. the latest is on the top of the table). The first/oldest entry in the list (ie. the bottom of the table) is information about when the text unit was initially created and it has no translation yet. 

In the screen shot, the 2nd & 3rd row have no translation because I deleted the text to make sure it still works. When there are many items in the list, the dialog grows dynamically and you can scroll the page to see them all.

Imports show up with the username of the person who performed the import.

Currently, you cannot do anything with this UI other than view the history. Later in a separate PR, we can implement some sort of "revert" functionality where you can go back to an old translation, or any other behaviours we would like to do.