### PR TITLE
Avoid empty xliffs

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -24,6 +24,7 @@ import com.box.l10n.mojito.service.pollableTask.PollableTaskService;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.UpdateTMWithXLIFFResult;
+import com.box.l10n.mojito.service.translationkit.TranslationKitAsXliff;
 import com.box.l10n.mojito.service.translationkit.TranslationKitService;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -180,14 +181,16 @@ public class DropService {
 
         logger.trace("Generate and export translation kits for locale: {}", bcp47Tag);
 
-        String translationKitAsXLIFF = translationKitService.generateTranslationKitAsXLIFF(
+        TranslationKitAsXliff translationKitAsXLIFF = translationKitService.generateTranslationKitAsXLIFF(
                 drop.getId(),
                 drop.getRepository().getTm().getId(),
                 localeService.findByBcp47Tag(bcp47Tag).getId(),
                 type,
-                useInheritance).getContent();
+                useInheritance);
 
-        dropExporter.exportSourceFile(bcp47Tag, translationKitAsXLIFF);
+        if (translationKitAsXLIFF != null) {
+            dropExporter.exportSourceFile(bcp47Tag, translationKitAsXLIFF.getContent());
+        }
     }
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -188,7 +188,7 @@ public class DropService {
                 type,
                 useInheritance);
 
-        if (translationKitAsXLIFF != null) {
+        if (!translationKitAsXLIFF.isEmpty()) {
             dropExporter.exportSourceFile(bcp47Tag, translationKitAsXLIFF.getContent());
         }
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitAsXliff.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitAsXliff.java
@@ -7,13 +7,13 @@ import com.box.l10n.mojito.service.NormalizationUtils;
  * Contains a translation kit in XLIFF format along with the corresponding
  * {@link TranslationKit#id}.
  *
-s * @author jaurambault
+ * @author jaurambault
  */
 public class TranslationKitAsXliff {
 
     Long translationKitId;
     String content;
-    boolean empty;
+    boolean empty = false;
 
     public Long getTranslationKitId() {
         return translationKitId;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitAsXliff.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitAsXliff.java
@@ -13,6 +13,7 @@ public class TranslationKitAsXliff {
 
     Long translationKitId;
     String content;
+    boolean empty;
 
     public Long getTranslationKitId() {
         return translationKitId;
@@ -30,4 +31,11 @@ public class TranslationKitAsXliff {
         this.content = NormalizationUtils.normalize(content);
     }
 
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    public void setEmpty(boolean empty) {
+        this.empty = empty;
+    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
@@ -298,7 +298,7 @@ public class TranslationKitService {
         List<TranslationKit> translationKits = translationKitRepository.findByDropId(drop.getId());
         boolean partiallyImported = false;
         for (TranslationKit translationKit : translationKits) {
-            if (!translationKit.getImported()) {
+            if (translationKit.getNumTranslationKitUnits() > 0 && !translationKit.getImported()) {
                 partiallyImported = true;
                 break;
             }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceBoxTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceBoxTest.java
@@ -72,8 +72,8 @@ public class DropServiceBoxTest extends DropServiceTest {
     @Test
     @Category({BoxSDKTest.class, SlowTest.class})
     @Override
-    public void allWithSeverError() throws Exception {
-        super.allWithSeverError();
+    public void allWithSevereError() throws Exception {
+        super.allWithSevereError();
     }
 
     @Override

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -361,7 +361,7 @@ public class DropServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void allWithSeverError() throws Exception {
+    public void allWithSevereError() throws Exception {
 
         TMTestData tmTestData = new TMTestData(testIdWatcher);
 
@@ -412,7 +412,7 @@ public class DropServiceTest extends ServiceTestBase {
         // make French be fully translated and Japanese not
         tmTestData.addCurrentTMTextUnitVariant1FrFR.setStatus(Status.APPROVED);
         tmService.addCurrentTMTextUnitVariant(tmTestData.addTMTextUnit2.getId(), localeService.findByBcp47Tag("fr-FR").getId(), "French stuff here.");
-        
+
         List<String> bcp47Tags = new ArrayList<>();
         bcp47Tags.add("fr-FR");
         bcp47Tags.add("ja-JP");
@@ -547,9 +547,9 @@ public class DropServiceTest extends ServiceTestBase {
 
     public void checkImportedFilesContent(String filename, String importedContent, int round) {
         if (filename.startsWith("fr-FR")) {
-            
+
             logger.debug(importedContent);
-            
+
             String xliffWithoutIds = XliffUtils.replaceXliffVariableContent(importedContent);
             logger.error(xliffWithoutIds);
             

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -439,9 +439,9 @@ public class DropServiceTest extends ServiceTestBase {
         FileSystemDropExporter fileSystemDropExporter = (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
         FileSystemDropExporterConfig fileSystemDropExporterConfig = fileSystemDropExporter.getFileSystemDropExporterConfig();
 
-        File koKR = new File(Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), DROP_FOLDER_SOURCE_FILES_NAME, "fr-FR.xliff").toString());
+        File frFR = new File(Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), DROP_FOLDER_SOURCE_FILES_NAME, "fr-FR.xliff").toString());
 
-        assertFalse(koKR.exists());
+        assertFalse(frFR.exists());
     }
 
     public void checkNumberOfUntranslatedTextUnit(Repository repository, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {


### PR DESCRIPTION
Modify the BE code to not generate an xliff file for a locale in a drop if there are no translation units with translations needed for that particular locale. Also, changed the import so that if there are no translations needed for a locale, it does not mark the imported drop as partially imported. It only checks the locales where translations were needed.