### PR TITLE
Specify user importing translations

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
@@ -209,7 +209,7 @@ public class DropWS {
         UpdateTMWithXLIFFResult updateTMWithLocalizedXLIFF;
 
         if (importXliffBody.isTranslationKit()) {
-            updateTMWithLocalizedXLIFF = tmService.updateTMWithTranslationKitXLIFF(normalizedContent, importXliffBody.getImportStatus());
+            updateTMWithLocalizedXLIFF = tmService.updateTMWithTranslationKitXLIFF(normalizedContent, importXliffBody.getImportStatus(), null);
         } else {
             updateTMWithLocalizedXLIFF = tmService.updateTMWithXLIFFByMd5(normalizedContent, importXliffBody.getImportStatus(), repository);
         }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -302,7 +302,7 @@ public class DropService {
             @ParentTask PollableTask parentTask) throws ImportDropException {
 
         try {
-            return tmService.updateTMWithTranslationKitXLIFF(dropFile.getContent(), importStatus);
+            return tmService.updateTMWithTranslationKitXLIFF(dropFile.getContent(), importStatus, dropServiceConfig.getDropImporterUsername());
         } catch (OkapiBadFilterInputException | OkapiIOException okapiException) {
             throw new ImportDropException(okapiException.getMessage(), okapiException);
         }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropServiceConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropServiceConfig.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * To configure the service that import/export drops.
- * 
+ *
  * @author jaurambault
  */
 @Component
@@ -17,12 +17,27 @@ public class DropServiceConfig {
      */
     int dropNameWeekOffset = 0;
 
+    /**
+     * User for imported translations
+     * If this is not set, then the authenticated user in context 
+     * who is importing the drop is used for all imported translations
+     */
+    String dropImporterUsername;
+
     public int getDropNameWeekOffset() {
         return dropNameWeekOffset;
     }
 
     public void setDropNameWeekOffset(int dropNameWeekOffset) {
         this.dropNameWeekOffset = dropNameWeekOffset;
+    }
+
+    public String getDropImporterUsername() {
+        return dropImporterUsername;
+    }
+
+    public void setDropImporterUsername(String dropImporterUsername) {
+        this.dropImporterUsername = dropImporterUsername;
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
@@ -44,6 +44,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.box.l10n.mojito.entity.TMTextUnitVariant.Status.APPROVED;
+import com.box.l10n.mojito.entity.security.user.User;
+import com.box.l10n.mojito.security.AuditorAwareImpl;
 import static com.box.l10n.mojito.utils.Predicates.logIfFalse;
 
 
@@ -84,6 +86,9 @@ public class TextUnitBatchImporterService {
 
     @Autowired
     TextUnitBatchMatcher textUnitBatchMatcher;
+
+    @Autowired
+    AuditorAwareImpl auditorAwareImpl;
 
     /**
      * Imports a batch of text units.
@@ -176,6 +181,7 @@ public class TextUnitBatchImporterService {
                         tmTextUnitCurrentVariant = tmTextUnitCurrentVariantRepository.findByLocale_IdAndTmTextUnit_Id(currentTextUnit.getLocaleId(), currentTextUnit.getTmTextUnitId());
                     }
 
+                    User importedBy = auditorAwareImpl.getCurrentAuditor();
                     tmService.addTMTextUnitCurrentVariantWithResult(
                             tmTextUnitCurrentVariant,
                             asset.getRepository().getTm().getId(),
@@ -185,7 +191,8 @@ public class TextUnitBatchImporterService {
                             textUnitForBatchImport.getComment(),
                             textUnitForBatchImport.getStatus(),
                             textUnitForBatchImport.isIncludedInLocalizedFile(),
-                            importTime);
+                            importTime,
+                            importedBy);
                 });
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
@@ -292,7 +292,7 @@ public class TranslationKitService {
         List<TranslationKit> translationKits = translationKitRepository.findByDropId(drop.getId());
         boolean partiallyImported = false;
         for (TranslationKit translationKit : translationKits) {
-            if (!translationKit.getImported()) {
+            if (translationKit.getNumTranslationKitUnits() > 0 && !translationKit.getImported()) {
                 partiallyImported = true;
                 break;
             }


### PR DESCRIPTION
Now that we have translation history, we'd like to be able to distinguish changes done through the workbench and drops. 

Current implementation sets the user who pressed the import button as the one responsible for all translations in the drop. This changes provide a way to specify user for translations imported by the drop.

```
l10n.dropService.dropImporterUsername=vendor
```