### PR TITLE
Add a mode to copy translations between text units with the leveraging command

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/LeveragingCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/LeveragingCommand.java
@@ -18,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 /**
  * Command to create copy TM from a source repository into a target repository.
  *
@@ -36,10 +38,10 @@ public class LeveragingCommand extends Command {
     @Autowired
     ConsoleWriter consoleWriter;
 
-    @Parameter(names = {Param.SOURCE_REPOSITORY_LONG, Param.SOURCE_REPOSITORY_SHORT}, arity = 1, required = true, description = Param.SOURCE_REPOSITORY_DESCRIPTION)
+    @Parameter(names = {Param.SOURCE_REPOSITORY_LONG, Param.SOURCE_REPOSITORY_SHORT}, arity = 1, required = false, description = Param.SOURCE_REPOSITORY_DESCRIPTION)
     String sourceRepositoryParam;
 
-    @Parameter(names = {Param.TARGET_REPOSITORY_LONG, Param.TARGET_REPOSITORY_SHORT}, arity = 1, required = true, description = Param.TARGET_REPOSITORY_DESCRIPTION)
+    @Parameter(names = {Param.TARGET_REPOSITORY_LONG, Param.TARGET_REPOSITORY_SHORT}, arity = 1, required = false, description = Param.TARGET_REPOSITORY_DESCRIPTION)
     String targetRepositoryParam;
 
     @Parameter(names = {"--name-regex", "-nr"}, arity = 1, required = false, description = "Leveraging will be performed only for target text units whose name matches provided regex")
@@ -56,6 +58,11 @@ public class LeveragingCommand extends Command {
             + "EXACT match is only using the content.", converter = CopyTmConfigMode.class)
     CopyTmConfig.Mode mode = CopyTmConfig.Mode.MD5;
 
+    @Parameter(names = {"--tuids-mapping"}, required = false,
+            description = "Text unit mapping for TUIDS mode (source to target tmTextUnit id), format: \"1001:2001;1002:2002\"",
+            converter = TmTextUnitMappingConverter.class)
+    Map<Long, Long> sourceToTargetTmTextUnitMapping;
+
     @Autowired
     CommandHelper commandHelper;
 
@@ -67,6 +74,19 @@ public class LeveragingCommand extends Command {
 
     @Override
     public void execute() throws CommandException {
+
+        if (CopyTmConfig.Mode.TUIDS.equals(mode)) {
+            copyTranslationBetweenTextUnits();
+        } else {
+            copyTmBetweenRepositories();
+        }
+    }
+
+    void copyTmBetweenRepositories() throws CommandException {
+
+        if (sourceRepositoryParam == null || targetRepositoryParam == null) {
+            throw new CommandException("Both --source-repository and --target-repository options must be provided in mode: " + mode.toString());
+        }
 
         consoleWriter.newLine().a("Copy TM from repository: ").fg(Color.CYAN).a(sourceRepositoryParam).
                 reset().a(" into repository: ").fg(Color.CYAN).a(targetRepositoryParam).println(2);
@@ -83,25 +103,46 @@ public class LeveragingCommand extends Command {
             if (mode != null) {
                 copyTmConfig.setMode(mode);
             }
-            
+
             if (targetAssetPathParam != null) {
-                 Asset asset = assetClient.getAssetByPathAndRepositoryId(targetAssetPathParam, targetRepository.getId());
-                 copyTmConfig.setTargetAssetId(asset.getId());
+                Asset asset = assetClient.getAssetByPathAndRepositoryId(targetAssetPathParam, targetRepository.getId());
+                copyTmConfig.setTargetAssetId(asset.getId());
             }
-            
+
             if (sourceAssetPathParam != null) {
-                 Asset asset = assetClient.getAssetByPathAndRepositoryId(sourceAssetPathParam, sourceRepository.getId());
-                 copyTmConfig.setSourceAssetId(asset.getId());
+                Asset asset = assetClient.getAssetByPathAndRepositoryId(sourceAssetPathParam, sourceRepository.getId());
+                copyTmConfig.setSourceAssetId(asset.getId());
             }
-            
+
             copyTmConfig = leveragingClient.copyTM(copyTmConfig);
-           
+
             PollableTask pollableTask = copyTmConfig.getPollableTask();
             commandHelper.waitForPollableTask(pollableTask.getId());
 
         } catch (AssetNotFoundException assetNotFoundException) {
             throw new CommandException(assetNotFoundException);
         }
+    }
+
+    void copyTranslationBetweenTextUnits() throws CommandException {
+        consoleWriter.newLine().a("Copy TM with mapping: ").println();
+
+        for (Map.Entry<Long, Long> entry : sourceToTargetTmTextUnitMapping.entrySet()) {
+            consoleWriter.newLine()
+                    .fg(Color.MAGENTA).a(entry.getKey())
+                    .reset().a(" --> ")
+                    .fg(Color.MAGENTA).a(entry.getValue());
+        }
+
+        CopyTmConfig copyTmConfig = new CopyTmConfig();
+        copyTmConfig.setNameRegex(nameRegexParam);
+        copyTmConfig.setMode(CopyTmConfig.Mode.TUIDS);
+        copyTmConfig.setSourceToTargetTmTextUnitIds(sourceToTargetTmTextUnitMapping);
+
+        copyTmConfig = leveragingClient.copyTM(copyTmConfig);
+
+        PollableTask pollableTask = copyTmConfig.getPollableTask();
+        commandHelper.waitForPollableTask(pollableTask.getId());
     }
 
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/TmTextUnitMappingConverter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/TmTextUnitMappingConverter.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import com.google.common.base.Splitter;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author jaurambault
+ */
+public class TmTextUnitMappingConverter implements IStringConverter<Map<Long, Long>> {
+
+    @Override
+    public Map<Long, Long> convert(String value) {
+
+        Map<Long, Long> map = null;
+
+        if (value != null) {
+            try {
+                return Splitter.on(";").withKeyValueSeparator(":").split(value).entrySet().stream().
+                        collect(Collectors.toMap(
+                                e -> Long.valueOf(e.getKey()),
+                                e -> Long.valueOf(e.getValue())));
+            } catch (IllegalArgumentException iae) {
+                throw new ParameterException("Invalid source to target textunit id mapping [" + value + "]");
+            }
+        }
+
+        return map;
+    }
+
+}
+

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/LeveragingCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/LeveragingCommandTest.java
@@ -8,18 +8,19 @@ import com.box.l10n.mojito.rest.entity.Asset;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.service.tm.TMImportService;
 import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
 /**
- *
  * @author jaurambault
  */
 public class LeveragingCommandTest extends CLITestBase {
@@ -113,9 +114,9 @@ public class LeveragingCommandTest extends CLITestBase {
         getL10nJCommander().run("leveraging-copy-tm", "-s", sourceRepository.getName(), "-t", targetRepository.getName(), "-m", "EXACT");
 
         List<TMTextUnitVariant> targetTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesOrderByContent(targetRepository);
-        
+
         List<String> expectedTargetTranslations = new ArrayList<>();
-        
+
         expectedTargetTranslations.add("1 day"); // en
         expectedTargetTranslations.add("1 heure"); // fr
         expectedTargetTranslations.add("1 hour"); // en
@@ -131,14 +132,88 @@ public class LeveragingCommandTest extends CLITestBase {
         expectedTargetTranslations.add("1日"); // ja
         expectedTargetTranslations.add("1時間"); // ja
         expectedTargetTranslations.add("Description de 100 caractères :"); //fr
-                
+
         Iterator<TMTextUnitVariant> itTargetTranslations = targetTranslations.iterator();
         Iterator<String> itExpectedTargetTranslations = expectedTargetTranslations.iterator();
-        
+
         for (TMTextUnitVariant targetTranslation : targetTranslations) {
             logger.error("target translation: {}", targetTranslation.getContent());
         }
-        
+
+        while (itExpectedTargetTranslations.hasNext()) {
+            Assert.assertEquals("translation in source and target must be the same", itExpectedTargetTranslations.next(), itTargetTranslations.next().getContent());
+        }
+
+        Assert.assertFalse(itExpectedTargetTranslations.hasNext());
+        Assert.assertFalse(itTargetTranslations.hasNext());
+    }
+
+    @Test
+    public void copyTMModeTUIDs() throws Exception {
+
+        Repository sourceRepository = repositoryService.createRepository(testIdWatcher.getEntityName("source-repoisotry"));
+        Repository targetRepository = repositoryService.createRepository(testIdWatcher.getEntityName("target-repoisotry"));
+
+        repositoryService.addRepositoryLocale(sourceRepository, "fr-FR");
+        repositoryService.addRepositoryLocale(sourceRepository, "fr-CA", "fr-FR", false);
+        repositoryService.addRepositoryLocale(sourceRepository, "ja-JP");
+
+        repositoryService.addRepositoryLocale(targetRepository, "fr-FR");
+        repositoryService.addRepositoryLocale(targetRepository, "fr-CA", "fr-FR", false);
+        repositoryService.addRepositoryLocale(targetRepository, "ja-JP");
+
+        getL10nJCommander().run("push", "-r", sourceRepository.getName(),
+                "-s", getInputResourcesTestDir("source").getAbsolutePath());
+
+        getL10nJCommander().run("push", "-r", targetRepository.getName(),
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath());
+
+
+        List<TMTextUnitVariant> initialSource = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesOrderByContent(sourceRepository);
+        Long sourceTmTextUnitId1 = initialSource.get(0).getTmTextUnit().getId();
+        Long sourceTmTextUnitId2 = initialSource.get(3).getTmTextUnit().getId();
+
+
+        Asset asset = assetClient.getAssetByPathAndRepositoryId("source-xliff.xliff", sourceRepository.getId());
+        importTranslations(asset.getId(), "source-xliff_", "fr-FR");
+        importTranslations(asset.getId(), "source-xliff_", "ja-JP");
+
+        List<TMTextUnitVariant> initialTargetTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesOrderByContent(targetRepository);
+
+        assertEquals("There must be only english for now", 5, initialTargetTranslations.size());
+
+        Long targetTmTextUnitId1 = initialTargetTranslations.get(0).getTmTextUnit().getId();
+        Long targetTmTextUnitId2 = initialTargetTranslations.get(3).getTmTextUnit().getId();
+
+
+        String tmTextUnitIdMapping = new StringBuilder()
+                .append(sourceTmTextUnitId1).append(":").append(targetTmTextUnitId1).append(";")
+                .append(sourceTmTextUnitId2).append(":").append(targetTmTextUnitId2)
+                .toString();
+
+        getL10nJCommander().run("leveraging-copy-tm", "-m", "TUIDS", "--tuids-mapping", tmTextUnitIdMapping);
+
+        List<TMTextUnitVariant> targetTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesOrderByContent(targetRepository);
+
+        List<String> expectedTargetTranslations = new ArrayList<>();
+
+        expectedTargetTranslations.add("1 day"); // en
+        expectedTargetTranslations.add("1 hour"); // en
+        expectedTargetTranslations.add("1 jour"); // fr
+        expectedTargetTranslations.add("1 month"); // en
+        expectedTargetTranslations.add("100 character description:"); // en
+        expectedTargetTranslations.add("100文字の説明："); // ja
+        expectedTargetTranslations.add("15 min"); // en
+        expectedTargetTranslations.add("1日"); // ja
+        expectedTargetTranslations.add("Description de 100 caractères :"); //fr
+
+        Iterator<TMTextUnitVariant> itTargetTranslations = targetTranslations.iterator();
+        Iterator<String> itExpectedTargetTranslations = expectedTargetTranslations.iterator();
+
+        for (TMTextUnitVariant targetTranslation : targetTranslations) {
+            logger.error("target translation: {}", targetTranslation.getContent());
+        }
+
         while (itExpectedTargetTranslations.hasNext()) {
             Assert.assertEquals("translation in source and target must be the same", itExpectedTargetTranslations.next(), itTargetTranslations.next().getContent());
         }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/TmTextUnitMappingConverterTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/TmTextUnitMappingConverterTest.java
@@ -1,0 +1,36 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.ParameterException;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class TmTextUnitMappingConverterTest {
+
+    @Test
+    public void testConvertNull() {
+        TmTextUnitMappingConverter tmTextUnitMappingConverter = new TmTextUnitMappingConverter();
+        Map<Long, Long> convert = tmTextUnitMappingConverter.convert(null);
+        assertNull(convert);
+    }
+
+    @Test
+    public void testConvertValid() {
+        TmTextUnitMappingConverter tmTextUnitMappingConverter = new TmTextUnitMappingConverter();
+        Map<Long, Long> convert = tmTextUnitMappingConverter.convert("1001:2001;1002:2002");
+        assertEquals(2001L, convert.get(1001L).longValue());
+        assertEquals(2002L, convert.get(1002L).longValue());
+        assertEquals(2, convert.size());
+    }
+
+    @Test(expected = ParameterException.class)
+    public void testConvertInvalid() {
+        TmTextUnitMappingConverter tmTextUnitMappingConverter = new TmTextUnitMappingConverter();
+        Map<Long, Long> convert = tmTextUnitMappingConverter.convert("dsafdsf");
+        assertEquals(0, convert.size());
+    }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/source/source-xliff.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/source/source-xliff.xliff
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+    <file original="" source-language="en" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_" datatype="php">
+                <source>100 character description:</source>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
+                <source>15 min</source>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="duplicate_source" datatype="x-javascript+php">
+                <source>15 min</source>
+            </trans-unit>  
+            <trans-unit id="" resname="1_day_duration" datatype="x-javascript+php">
+                <source>1 day</source>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration" datatype="x-javascript+php">
+                <source>1 month</source>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/source2/source-xliff.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/source2/source-xliff.xliff
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+ <file original="" source-language="en" datatype="x-undefined">
+  <body>
+   <trans-unit id="" resname="id_modified" datatype="php">
+    <source>100 character description:</source>
+   </trans-unit>
+   <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
+    <source>15 min</source>
+    <note>File lock dialog duration</note>
+   </trans-unit>
+   <trans-unit id="" resname="1_day_duration" datatype="x-javascript+php">
+    <source>1 day</source>
+    <note>File lock dialog duration</note>
+   </trans-unit>
+   <trans-unit id="" resname="1_hour_duration" datatype="x-javascript+php">
+    <source>1 hour</source>
+    <note>File lock dialog duration</note>
+   </trans-unit>
+   <trans-unit id="" resname="1_month_duration" datatype="x-javascript+php">
+    <source>1 month</source>
+    <note>File lock dialog duration</note>
+   </trans-unit>
+  </body>
+ </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/translations/source-xliff_fr-FR.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/translations/source-xliff_fr-FR.xliff
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+    <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_" datatype="php">
+                <source>100 character description:</source>
+                <target>Description de 100 caractères :</target>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15 min</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="duplicate_source" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15 min duplicated</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_day_duration" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1 jour</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1 heure</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1 mois</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/LeveragingCommandTest/copyTMModeTUIDs/input/translations/source-xliff_ja-JP.xliff
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+    <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_" datatype="php">
+                <source>100 character description:</source>
+                <target>100文字の説明：</target>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15分</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="duplicate_source" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15分 duplicate</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_day_duration" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1日</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1時間</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1か月</target>
+                <note>File lock dialog duration</note>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CopyTmConfig.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/CopyTmConfig.java
@@ -3,6 +3,8 @@ package com.box.l10n.mojito.rest.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Configuration to start the copy TM process
  *
@@ -15,6 +17,8 @@ public class CopyTmConfig {
     Long targetAssetId;
     Long sourceAssetId;
     String nameRegex;
+    Map<Long, Long> sourceToTargetTmTextUnitIds;
+
     Mode mode = Mode.MD5;
 
     PollableTask pollableTask;
@@ -83,6 +87,14 @@ public class CopyTmConfig {
         this.targetAssetId = targetAssetId;
     }
 
+    public Map<Long, Long> getSourceToTargetTmTextUnitIds() {
+        return sourceToTargetTmTextUnitIds;
+    }
+
+    public void setSourceToTargetTmTextUnitIds(Map<Long, Long> sourceToTargetTmTextUnitIds) {
+        this.sourceToTargetTmTextUnitIds = sourceToTargetTmTextUnitIds;
+    }
+
     /**
      * Matching mode for leveraging
      */
@@ -96,6 +108,10 @@ public class CopyTmConfig {
          * comment are not checked).
          */
         EXACT,
+        /**
+         * Copy based on a map of source to target tmTextUnitId
+         */
+        TUIDS
     }
 
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/leveraging/CopyTmConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/leveraging/CopyTmConfig.java
@@ -4,6 +4,8 @@ import com.box.l10n.mojito.entity.PollableTask;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 /**
  * Configuration to start the copy TM process
  *
@@ -16,6 +18,7 @@ public class CopyTmConfig {
     Long targetAssetId;
     Long sourceAssetId;
     String nameRegex;
+    Map<Long, Long> sourceToTargetTmTextUnitIds;
 
     Mode mode = Mode.MD5;
 
@@ -85,6 +88,14 @@ public class CopyTmConfig {
         this.targetAssetId = targetAssetId;
     }
 
+    public Map<Long, Long> getSourceToTargetTmTextUnitIds() {
+        return sourceToTargetTmTextUnitIds;
+    }
+
+    public void setSourceToTargetTmTextUnitIds(Map<Long, Long> sourceToTargetTmTextUnitIds) {
+        this.sourceToTargetTmTextUnitIds = sourceToTargetTmTextUnitIds;
+    }
+
     /**
      * Matching mode for leveraging
      */
@@ -98,6 +109,10 @@ public class CopyTmConfig {
          * comment are not checked)
          */
         EXACT,
+        /**
+         * Copy based on a Map source to target tmTextUnitId
+         */
+        TUIDS
     }
 
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/leveraging/LeveragingServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/leveraging/LeveragingServiceTest.java
@@ -21,9 +21,6 @@ import com.box.l10n.mojito.service.tm.TMTextUnitVariantRepository;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,8 +28,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
 /**
- *
  * @author jaurambault
  */
 public class LeveragingServiceTest extends ServiceTestBase {
@@ -59,10 +61,10 @@ public class LeveragingServiceTest extends ServiceTestBase {
 
     @Autowired
     TMService tmService;
-    
+
     @Autowired
     LocaleService localeService;
-    
+
     @Test
     public void copyAllTranslationsWithMD5MatchBetweenRepositories() throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException, AssetWithIdNotFoundException, RepositoryWithIdNotFoundException {
 
@@ -152,6 +154,55 @@ public class LeveragingServiceTest extends ServiceTestBase {
     }
 
     @Test
+    public void copyTranslationForTmTextUnitMapping() throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException, AssetWithIdNotFoundException, RepositoryWithIdNotFoundException {
+
+        TMTestData tmTestDataSource = new TMTestData(testIdWatcher);
+
+        Repository sourceRepository = tmTestDataSource.repository;
+
+        logger.debug("Create the target repository");
+        Repository targetRepository = repositoryService.createRepository(testIdWatcher.getEntityName("targetRepository"));
+
+        TM tm = targetRepository.getTm();
+
+        Asset asset = assetService.createAssetWithContent(targetRepository.getId(), "fake_for_test", "fake for test");
+        Long assetId = asset.getId();
+
+        TMTextUnit targetTmTextUnit1 = tmService.addTMTextUnit(tm.getId(), assetId, "zuora_error_message_verify_state_province other", "Please enter a valid state, region or province", "Comment1");
+        TMTextUnit targetTmTextUnit2 = tmService.addTMTextUnit(tm.getId(), assetId, "TEST2 other", "Content2", "Comment2");
+        TMTextUnit targetTmTextUnit3 = tmService.addTMTextUnit(tm.getId(), assetId, "TEST3 other", "Content3", "Comment3");
+
+        Map<Long, Long> sourceTotTargetTmTextUnitIds = new HashMap<>();
+        sourceTotTargetTmTextUnitIds.put(tmTestDataSource.addTMTextUnit1.getId(), targetTmTextUnit1.getId());
+        sourceTotTargetTmTextUnitIds.put(tmTestDataSource.addTMTextUnit2.getId(), targetTmTextUnit2.getId());
+
+        CopyTmConfig copyTmConfig = new CopyTmConfig();
+        copyTmConfig.setSourceRepositoryId(sourceRepository.getId());
+        copyTmConfig.setTargetRepositoryId(targetRepository.getId());
+        copyTmConfig.setMode(CopyTmConfig.Mode.TUIDS);
+        copyTmConfig.setSourceToTargetTmTextUnitIds(sourceTotTargetTmTextUnitIds);
+
+        leveragingService.copyTm(copyTmConfig).get();
+
+        List<TMTextUnitVariant> sourceTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesAndLocale_Bcp47TagNotOrderByContent(sourceRepository, "en");
+        List<TMTextUnitVariant> targetTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesAndLocale_Bcp47TagNotOrderByContent(targetRepository, "en");
+
+        Assert.assertEquals(5, sourceTranslations.size());
+        Assert.assertEquals(3, targetTranslations.size());
+
+        Assert.assertEquals("Content2 fr-CA", targetTranslations.get(0).getContent());
+        Assert.assertEquals(targetTmTextUnit2.getId(), targetTranslations.get(0).getTmTextUnit().getId());
+
+
+        Assert.assertEquals("Veuillez indiquer un état, une région ou une province valide.", targetTranslations.get(1).getContent());
+        Assert.assertEquals(targetTmTextUnit1.getId(), targetTranslations.get(1).getTmTextUnit().getId());
+
+
+        Assert.assertEquals("올바른 국가, 지역 또는 시/도를 입력하십시오.", targetTranslations.get(2).getContent());
+        Assert.assertEquals(targetTmTextUnit1.getId(), targetTranslations.get(2).getTmTextUnit().getId());
+    }
+
+    @Test
     public void copyAllTranslationsWithExactMatchBetweenRepositories() throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException, AssetWithIdNotFoundException, RepositoryWithIdNotFoundException {
 
         TMTestData tmTestDataSource = new TMTestData(testIdWatcher);
@@ -222,41 +273,41 @@ public class LeveragingServiceTest extends ServiceTestBase {
             Assert.assertEquals(1, targetTranslation.getTmTextUnitVariantComments().size());
         }
     }
-    
+
     @Test
     public void copyBetweenAssets() throws InterruptedException, ExecutionException, RepositoryNameAlreadyUsedException, RepositoryLocaleCreationException, AssetWithIdNotFoundException, RepositoryWithIdNotFoundException {
- 
+
         Locale frFR = localeService.findByBcp47Tag("fr-FR");
 
         logger.debug("Create the source repository");
         Repository sourceRepository = repositoryService.createRepository(testIdWatcher.getEntityName("sourceRepository"));
         repositoryService.addRepositoryLocale(sourceRepository, frFR.getBcp47Tag());
-        
+
         Asset sourceAsset = assetService.createAssetWithContent(sourceRepository.getId(), "fake_for_test_1", "fake for test");
         Long sourceAssetId = sourceAsset.getId();
 
         TMTextUnit addTMTextUnit = tmService.addTMTextUnit(sourceRepository.getTm().getId(), sourceAssetId, "TEST3", "Content3", "Comment3");
         tmService.addCurrentTMTextUnitVariant(addTMTextUnit.getId(), frFR.getId(), "Content3 fr-FR from source");
-  
+
         Asset sourceAsset2 = assetService.createAssetWithContent(sourceRepository.getId(), "fake_for_test2", "fake for test");
         Long sourceAssetId2 = sourceAsset2.getId();
 
         TMTextUnit addTMTextUnit2 = tmService.addTMTextUnit(sourceRepository.getTm().getId(), sourceAssetId2, "TEST3", "Content3", "Comment3");
         tmService.addCurrentTMTextUnitVariant(addTMTextUnit2.getId(), frFR.getId(), "Content3 fr-FR from source2");
-  
+
         logger.debug("Create the target repository");
         Repository targetRepository = repositoryService.createRepository(testIdWatcher.getEntityName("targetRepository"));
- 
+
         Asset targetAsset = assetService.createAssetWithContent(targetRepository.getId(), "fake_for_test", "fake for test");
         Long targetAssetId = targetAsset.getId();
 
         tmService.addTMTextUnit(targetRepository.getTm().getId(), targetAssetId, "TEST3", "Content3", "Comment3");
-        
+
         Asset targetAsset2 = assetService.createAssetWithContent(targetRepository.getId(), "fake_for_test2", "fake for test");
         Long targetAssetId2 = targetAsset2.getId();
 
         tmService.addTMTextUnit(targetRepository.getTm().getId(), targetAssetId2, "TEST3", "Content3", "Comment3");
-        
+
         CopyTmConfig copyTmConfig = new CopyTmConfig();
         copyTmConfig.setSourceAssetId(sourceAssetId);
         copyTmConfig.setTargetAssetId(targetAssetId);
@@ -267,9 +318,9 @@ public class LeveragingServiceTest extends ServiceTestBase {
         List<TMTextUnitVariant> targetTranslations = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesAndLocale_Bcp47TagNotOrderByContent(targetRepository, "en");
         Assert.assertEquals("Content3 fr-FR from source", targetTranslations.get(0).getContent());
         Assert.assertEquals(targetAsset.getId(), targetTranslations.get(0).getTmTextUnit().getAsset().getId());
-        
+
         Assert.assertEquals(1, targetTranslations.size());
-        
+
         CopyTmConfig copyTmConfig2 = new CopyTmConfig();
         copyTmConfig2.setSourceAssetId(sourceAssetId2);
         copyTmConfig2.setTargetAssetId(targetAssetId2);
@@ -280,10 +331,10 @@ public class LeveragingServiceTest extends ServiceTestBase {
         List<TMTextUnitVariant> targetTranslations2 = tmTextUnitVariantRepository.findByTmTextUnitTmRepositoriesAndLocale_Bcp47TagNotOrderByContent(targetRepository, "en");
         Assert.assertEquals("Content3 fr-FR from source", targetTranslations2.get(0).getContent());
         Assert.assertEquals(targetAsset.getId(), targetTranslations2.get(0).getTmTextUnit().getAsset().getId());
-        
+
         Assert.assertEquals("Content3 fr-FR from source2", targetTranslations2.get(1).getContent());
-        Assert.assertEquals(targetAsset2.getId(), targetTranslations2.get(1).getTmTextUnit().getAsset().getId());     
-        
-        Assert.assertEquals(2, targetTranslations2.size());   
+        Assert.assertEquals(targetAsset2.getId(), targetTranslations2.get(1).getTmTextUnit().getAsset().getId());
+
+        Assert.assertEquals(2, targetTranslations2.size());
     }
 }


### PR DESCRIPTION
With mode "TUDS" it is possible to copy translation between text units of any projects. 
--tuids-mapping option is used to provide the mapping between the source and target tm text unit ids. All translations that are not rejected are copied (regardless of locale supported by the target project)

Example: leveraging-copy-tm -m TUID --tuids-mapping "12:33;32:23"