### PR TITLE
Add an in-memory implementation of ThirdPartyTMS interface which is n…

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.rest.client.RepositoryClient;
+import com.box.l10n.mojito.rest.entity.Locale;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThirdPartySyncCommandTest extends CLITestBase {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(ThirdPartySyncCommandTest.class);
+
+    @Test
+    public void execute() throws Exception {
+        String repoName = testIdWatcher.getEntityName("thirdpartysync_execute");
+        Repository repository = repositoryService.createRepository(repoName, repoName + " description", null, false);
+        getL10nJCommander().run("thirdparty-sync", "-r", repository.getName(), "-p", "does-not-matter-yet");
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -78,7 +78,7 @@ public class ThirdPartyService {
     @Autowired
     ImageService imageService;
 
-    @Autowired(required = false)
+    @Autowired
     ThirdPartyTMS thirdPartyTMS;
 
     public PollableFuture asyncSyncMojitoWithThirdPartyTMS(Long repositoryId, String thirdPartyProjectId) {
@@ -90,10 +90,6 @@ public class ThirdPartyService {
 
     void syncMojitoWithThirdPartyTMS(Long repositoryId, String thirdPartyProjectId) {
         logger.debug("thirdparty TMS: {}", thirdPartyTMS);
-        if (thirdPartyTMS == null) {
-            throw new RuntimeException("No ThirdPartyTMS is configured");
-        }
-
         Repository repository = repositoryRepository.findOne(repositoryId);
         mapMojitoAndThirdPartyTextUnits(repository, thirdPartyProjectId);
         uploadScreenshotsAndCreateMappings(repository, thirdPartyProjectId);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
@@ -1,0 +1,66 @@
+package com.box.l10n.mojito.service.thirdparty;
+
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.smartling.request.Binding;
+import com.box.l10n.mojito.smartling.request.Bindings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@ConditionalOnProperty(value = "l10n.ThirdPartyTMS.impl", havingValue = "ThirdPartyTMSInMemory", matchIfMissing = true)
+@Component
+public class ThirdPartyTMSInMemory implements ThirdPartyTMS {
+
+    static Logger logger = LoggerFactory.getLogger(ThirdPartyTMSInMemory.class);
+
+    HashMap<String, byte[]> images = new HashMap<>();
+    HashMap<String, HashMap<String, String>> imageToTextUnitMappings = new HashMap<>();
+
+    /**
+     * Storing the uploaded images, that could be useful for testing but at the moment is useless...
+     * TODO remove if we don't need for testing
+     */
+    @Override
+    public ThirdPartyTMSImage uploadImage(String projectId, String name, byte[] content) {
+        logger.debug("Upload image to ThirdPartyTMSInMemory, project id: {}, name: {}", projectId, name);
+
+        String imageId = UUID.randomUUID().toString();
+        images.put(imageId, content);
+
+        ThirdPartyTMSImage thirdPartyTMSImage = new ThirdPartyTMSImage();
+        thirdPartyTMSImage.setId(imageId);
+        return thirdPartyTMSImage;
+    }
+
+    @Override
+    public List<ThirdPartyTextUnit> getThirdPartyTextUnits(Repository repository, String projectId) {
+        logger.debug("Get third party text units for repository: {} and project id: {}", repository.getId(), projectId);
+
+        // TODO return empty for now but later the interface will support adding strings and so this can retrun them
+        return Collections.emptyList();
+    }
+
+    /**
+     * Save the mappings, that could be useful for testing but at the moment is useless...
+     * TODO remove if we don't need for testing
+     */
+    @Override
+    public void createImageToTextUnitMappings(String projectId, List<ThirdPartyImageToTextUnit> thirdPartyImageToTextUnits) {
+        logger.debug("Upload image to text units mapping for project id: {}", projectId);
+
+        HashMap<String, String> forProject = imageToTextUnitMappings.computeIfAbsent(projectId, s -> new HashMap<>());
+
+        for (ThirdPartyImageToTextUnit thirdPartyImageToTextUnit : thirdPartyImageToTextUnits) {
+            forProject.put(thirdPartyImageToTextUnit.getImageId(), thirdPartyImageToTextUnit.getTextUnitId());
+        }
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -11,13 +11,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-@ConditionalOnBean(SmartlingClient.class)
+@ConditionalOnProperty(value = "l10n.ThirdPartyTMS.impl", havingValue = "ThirdPartyTMSSmartling")
 @Component
 public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
 


### PR DESCRIPTION
…ow default impl.

This allow to have a fully working webapp and to run the thirdparty-sync commands in demo mode. Strictly speaking, that has no real interest since the data won't be accessible but at least it is working configuration (before the backend would throw NPE and the command fail).

This will be useful for testing though.