### PR TITLE
Fix third party text unit mapping for duplicated names

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnitRepository.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.thirdparty;
 
+import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.ThirdPartyTextUnit;
@@ -21,6 +22,10 @@ public interface ThirdPartyTextUnitRepository extends JpaRepository<ThirdPartyTe
     @Query("select tptu.thirdPartyId from #{#entityName} tptu inner join tptu.asset a where a.repository = ?1")
     HashSet<String> findThirdPartyIdsByRepository(Repository repository);
 
+    @Query("select tptu.tmTextUnit.id from #{#entityName} tptu where tptu.asset = ?1")
+    HashSet<Long> findTmTextUnitIdsByAsset(Asset a);
+
     ThirdPartyTextUnit findByTmTextUnit(TMTextUnit tmTextUnit);
+
     List<ThirdPartyTextUnit> findByTmTextUnitIdIn(Collection<Long> TmTextUnitIdList);
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -109,6 +109,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 "<resources>\n" +
                 "    <!--comment 1-->\n" +
                 "    <string name=\"src/main/res/values/strings.xml#@#hello\" tmTextUnitId=\"946852\">Hello</string>\n" +
+                "    <!-- twice the same name in the 3rd party tms shouldn't break the mapping -->\n" +
+                "    <string name=\"src/main/res/values/strings.xml#@#hello\" tmTextUnitId=\"8464561\">Hello-samename</string>\n" +
                 "    <!--comment 2-->\n" +
                 "    <string name=\"src/main/res/values/strings.xml#@#bye\" tmTextUnitId=\"946853\">Bye</string>\n" +
                 "    <plurals name=\"src/main/res/values/strings.xml#@#plural_things\">\n" +


### PR DESCRIPTION
Subsequent mappings were failing if there were 2 text units with the same
name which is uncommon but may happen. Initial mapping was working because
of local deduplication.

To fix, only get text units that are not mapped as candidates which should
have been the implementation in a first place since they can only be mapped
once.