### PR TITLE
Improve matching for plural text units

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryService.java
@@ -91,7 +91,7 @@ public class RepositoryService {
      * Gets all the repositories that are not deleted, ordered by name
      * <p>
      * Could do something similar with criteria and more complex entity graph. When using more complex entity graph
-     * with spring it returns dupplicates that can be removed using "distinct" but that can't be provided with
+     * with spring it returns duplicates that can be removed using "distinct" but that can't be provided with
      * the basic spring repository. To do the equivalent with criteria:
      * <p>
      * Specifications<Repository> spec = where(deletedEquals(false)).and(ifParamNotNull(nameEquals(repositoryName)));

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnit.java
@@ -24,6 +24,11 @@ public class ThirdPartyTextUnit implements TextUnitForBatchMatcher {
      */
     String content;
 
+    /**
+     * If the name is a plural prefix (instead of the full text unit name) and so the entry map to a plural string in Mojito
+     */
+    boolean namePluralPrefix;
+
     public String getId() {
         return id;
     }
@@ -60,5 +65,14 @@ public class ThirdPartyTextUnit implements TextUnitForBatchMatcher {
     @Override
     public Long getTmTextUnitId() {
         return null;
+    }
+
+    @Override
+    public boolean isNamePluralPrefix() {
+        return namePluralPrefix;
+    }
+
+    public void setNamePluralPrefix(boolean namePluralPrefix) {
+        this.namePluralPrefix = namePluralPrefix;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TextUnitForBatchMatcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TextUnitForBatchMatcher.java
@@ -8,4 +8,6 @@ public interface TextUnitForBatchMatcher {
 
     Long getTmTextUnitId();
 
+    boolean isNamePluralPrefix();
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitForBatchMatcherImport.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitForBatchMatcherImport.java
@@ -22,7 +22,8 @@ public class TextUnitForBatchMatcherImport implements TextUnitForBatchMatcher {
     Long tmTextUnitId;
     TextUnitDTO currentTextUnit;
     boolean includedInLocalizedFile;
-    private TMTextUnitVariant.Status status;
+    TMTextUnitVariant.Status status;
+    boolean namePluralPrefix;
 
     public Repository getRepository() {
         return repository;
@@ -103,5 +104,10 @@ public class TextUnitForBatchMatcherImport implements TextUnitForBatchMatcher {
 
     public void setStatus(TMTextUnitVariant.Status status) {
         this.status = status;
+    }
+
+    @Override
+    public boolean isNamePluralPrefix() {
+        return false;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
@@ -84,11 +84,6 @@ public class SmartlingClient {
         return StreamSupport.stream(stringInfoPageFetcherSplitIterator, false);
     }
 
-    public Stream<StringInfo> getStringInfosFromFiles(String projectId, List<File> files) {
-        Stream<StringInfo> stringInfoStream = files.stream().flatMap(file -> getStringInfos(projectId, file.getFileUri()));
-        return stringInfoStream;
-    }
-
     public Items<File> getFiles(String projectId) {
         FilesResponse filesResponse = oAuth2RestTemplate.getForObject(API_FILES_LIST, FilesResponse.class, projectId);
         throwExceptionOnError(filesResponse, "Can't get files");

--- a/webapp/src/main/java/com/box/l10n/mojito/utils/Optionals.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/utils/Optionals.java
@@ -1,8 +1,6 @@
 package com.box.l10n.mojito.utils;
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +11,9 @@ public class Optionals {
 
     public static <T, R> Optional<R> or(T input, Function<T, Optional<R>>... functions) {
         Stream<Function<T, Optional<R>>> stream = Stream.of(functions);
-        return stream.map((f) -> f.apply(input)).filter(Optional::isPresent).map(Optional::get).findFirst();
+        return stream.map((f) -> f.apply(input)).
+                filter(Optional::isPresent).
+                map(Optional::get).findFirst();
     }
 
     public static <T> Optional<List<T>> optionalToOptionalList(Optional<T> optional) {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
@@ -133,7 +133,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         doAnswer(invocation -> Arrays.asList(
                 createThirdPartyTextUnit(asset.getPath(), "3rd-hello", "hello"),
                 createThirdPartyTextUnit(asset.getPath(), "3rd-bye", "bye"),
-                createThirdPartyTextUnit(asset.getPath(), "3rd-plural_things", "plural_things")
+                createThirdPartyTextUnit(asset.getPath(), "3rd-plural_things", "plural_things", true)
         )).when(thirdPartyTMSMock).getThirdPartyTextUnits(any(), any());
 
         doNothing().when(thirdPartyTMSMock).createImageToTextUnitMappings(any(), any());
@@ -208,7 +208,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void dupplicatedNamesSubSequentMapping() throws ExecutionException, InterruptedException {
+    public void duplicatedNamesSubSequentMapping() throws ExecutionException, InterruptedException {
         ThirdPartyServiceTestData thirdPartyServiceTestData = new ThirdPartyServiceTestData(testIdWatcher);
         Repository repository = thirdPartyServiceTestData.repository;
         Asset asset = thirdPartyServiceTestData.asset;
@@ -218,7 +218,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         doAnswer(invocation -> Arrays.asList(
                 createThirdPartyTextUnit(asset.getPath(), "3rd-hello", "hello")
         )).doAnswer(invocation -> Arrays.asList(
-                createThirdPartyTextUnit(asset.getPath(), "3rd-hello-dupplicate", "hello")
+                createThirdPartyTextUnit(asset.getPath(), "3rd-hello-duplicate", "hello")
         )).when(thirdPartyTMSMock).getThirdPartyTextUnits(any(), any());
 
         doNothing().when(thirdPartyTMSMock).createImageToTextUnitMappings(any(), any());
@@ -244,10 +244,10 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         assertEquals(thirdPartyServiceTestData.tmTextUnitHello.getId(), thirdPartyTextUnits.get(0).getTmTextUnit().getId());
         assertEquals("3rd-hello", thirdPartyTextUnits.get(0).getThirdPartyId());
 
-        logger.debug("Invoke function to test - dupplicate name");
+        logger.debug("Invoke function to test - duplicate name");
         thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(repository.getId(), projectId, Arrays.asList(ThirdPartyService.Action.MAP_TEXTUNIT), new ArrayList<>()).get();
 
-        logger.debug("Verify states - dupplicate name");
+        logger.debug("Verify states - duplicate name");
         thirdPartyTextUnits = thirdPartyTextUnitRepository.findAll().stream()
                 .filter(thirdPartyTextUnit -> thirdPartyTextUnit.getAsset().getId().equals(asset.getId()))
                 .collect(toList());
@@ -304,10 +304,15 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
     }
 
     ThirdPartyTextUnit createThirdPartyTextUnit(String assetPath, String id, String name) {
+        return createThirdPartyTextUnit(assetPath, id, name, false);
+    }
+
+    ThirdPartyTextUnit createThirdPartyTextUnit(String assetPath, String id, String name, boolean isNamePluralPrefix) {
         ThirdPartyTextUnit thirdPartyTextUnit = new ThirdPartyTextUnit();
         thirdPartyTextUnit.setAssetPath(assetPath);
         thirdPartyTextUnit.setId(id);
         thirdPartyTextUnit.setName(name);
+        thirdPartyTextUnit.setNamePluralPrefix(isNamePluralPrefix);
         return thirdPartyTextUnit;
     }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
@@ -14,8 +14,8 @@ import com.google.common.io.ByteStreams;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,11 +150,11 @@ public class SmartlingClientTest {
     }
 
     @Test
-    public void testGetStringInfosFromFiles() {
+    public void testGetStringInfosFromFile() {
         Assume.assumeNotNull(projectId);
         Items<File> files = smartlingClient.getFiles(projectId);
-        Stream<StringInfo> stringInfosFromFiles = smartlingClient.getStringInfosFromFiles(projectId, files.getItems());
-
+        Stream<StringInfo> stringInfosFromFiles = files.getItems().stream().flatMap(
+                file -> smartlingClient.getStringInfos(projectId, file.getFileUri()));
         stringInfosFromFiles.forEach(
                 stringInfo -> logger.debug(stringInfo.getHashcode())
         );


### PR DESCRIPTION
Before a text unit with same prefix as the name of a singular text unit could be match to it. Now we match first the plural entries and then match by name. Also match unused plural text units.