### PR TITLE
Add command to export Phabricator Diff info to list of envrionment va…

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommand.java
@@ -50,7 +50,11 @@ import java.util.stream.Stream;
  * Get username from git log, eg:
  * BRANCH_CREATEDBY=$(git log --format='%ae' HEAD^\!)
  * BRANCH_CREATEDBY=${BRANCH_CREATOR%%"@somemail.com"}
- *
+ * <p>
+ * Get diff info from phabricator diff, {@see com.box.l10n.mojito.cli.command.PhabricatorDiffInfoCommand}
+ * source <(mojito phab-diff-to-env-variables --diff-id 12345)
+ * echo ${MOJITO_PHAB_BASE_COMMIT}
+ * ...
  * @author jaurambault
  */
 @Component

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommand.java
@@ -1,0 +1,74 @@
+package com.box.l10n.mojito.cli.command;
+
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.phabricator.DifferentialDiff;
+import com.box.l10n.mojito.phabricator.payload.QueryDiffsFields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * Command to export Phabricator Diff info to list of envrionment variables
+ *
+ * It will export revision id, base commit, author email and author username
+ * (that's computed by removing the email part from the author email, it is not coming from phabricator).
+ *
+ * Format is a list of environment variables like this:
+ * MOJITO_PHAB_REVISION_ID=789456
+ * MOJITO_PHAB_BASE_COMMIT=c32dadb23
+ * MOJITO_PHAB_AUTHOR_EMAIL=user@test.com
+ * MOJITO_PHAB_AUTHOR_USERNAME=user
+ *
+ * Example how to source the result of the command in bash shell
+ * source <(mojito phab-diff-to-env-variables --diff-id 123456)
+ */
+@Component
+@Scope("prototype")
+@Parameters(commandNames = {"phab-diff-to-env-variables"}, commandDescription = "Get diff info: revision id, base commit, " +
+        "author email and username (computed by removing email part) as a list of enviroment variables")
+public class PhabricatorDiffInfoCommand extends Command {
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(PhabricatorDiffInfoCommand.class);
+
+    @Qualifier("ansiCodeEnabledFalse")
+    @Autowired
+    ConsoleWriter consoleWriterAnsiCodeEnabledFalse;
+
+    @Autowired(required = false)
+    DifferentialDiff differentialDiff;
+
+    @Parameter(names = {"--diff-id"}, arity = 1, required = true, description = "Diff id")
+    String diffId = null;
+
+    @Override
+    public void execute() throws CommandException {
+        if (differentialDiff == null) {
+            throw new CommandException("Phabricator must be configured with properties: l10n.phabricator.url and l10n.phabricator.token");
+        }
+
+        QueryDiffsFields queryDiffsFields = differentialDiff.queryDiff(diffId);
+        consoleWriterAnsiCodeEnabledFalse.a("MOJITO_PHAB_REVISION_ID=").a(queryDiffsFields.getRevisionId()).println();
+        consoleWriterAnsiCodeEnabledFalse.a("MOJITO_PHAB_BASE_COMMIT=").a(queryDiffsFields.getSourceControlBaseRevision()).println();
+        consoleWriterAnsiCodeEnabledFalse.a("MOJITO_PHAB_AUTHOR_EMAIL=").a(queryDiffsFields.getAuthorEmail()).println();
+        consoleWriterAnsiCodeEnabledFalse.a("MOJITO_PHAB_AUTHOR_USERNAME=").a(getUsernameForAuthorEmail(queryDiffsFields.getAuthorEmail())).println();
+    }
+
+
+    String getUsernameForAuthorEmail(String email) {
+        String username = null;
+
+        if (email != null) {
+            username = email.replaceFirst("(.*)@.*$", "$1");
+        }
+
+        return username;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorRevisionCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorRevisionCommand.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope("prototype")
-@Parameters(commandNames = {"phabricator-get-revision-id"}, commandDescription = "Get the revision id for a target phid")
+@Parameters(commandNames = {"phab-targetphid-to-revisionid"}, commandDescription = "Get the revision id for a target phid")
 public class PhabricatorRevisionCommand extends Command {
     /**
      * logger

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommandTest.java
@@ -1,0 +1,29 @@
+package com.box.l10n.mojito.cli.command;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhabricatorDiffInfoCommandTest {
+
+    @Test
+    public void testGetUsernameForAuthorEmailNull() {
+        PhabricatorDiffInfoCommand phabricatorDiffInfoCommand = new PhabricatorDiffInfoCommand();
+        String usernameForAuthorEmail = phabricatorDiffInfoCommand.getUsernameForAuthorEmail(null);
+        assertEquals(null, usernameForAuthorEmail);
+    }
+
+    @Test
+    public void testGetUsernameForAuthorEmail() {
+        PhabricatorDiffInfoCommand phabricatorDiffInfoCommand = new PhabricatorDiffInfoCommand();
+        String usernameForAuthorEmail = phabricatorDiffInfoCommand.getUsernameForAuthorEmail("username@test.com");
+        assertEquals("username", usernameForAuthorEmail);
+    }
+
+    @Test
+    public void testGetUsernameForAuthorInvalid() {
+        PhabricatorDiffInfoCommand phabricatorDiffInfoCommand = new PhabricatorDiffInfoCommand();
+        String usernameForAuthorEmail = phabricatorDiffInfoCommand.getUsernameForAuthorEmail("notanemail");
+        assertEquals("notanemail", usernameForAuthorEmail);
+    }
+}

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/DifferentialDiff.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/DifferentialDiff.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.phabricator;
 
 import com.box.l10n.mojito.phabricator.payload.DiffSearchResult;
+import com.box.l10n.mojito.phabricator.payload.QueryDiffsFields;
+import com.box.l10n.mojito.phabricator.payload.QueryDiffsResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +42,20 @@ public class DifferentialDiff {
             return revisionPHID;
         } catch (Exception e) {
             throw new PhabricatorException("Can't find revision PHID", e);
+        }
+    }
+
+    public QueryDiffsFields queryDiff(String diffId) {
+        try {
+            QueryDiffsResult queryDiffsResult = phabricatorHttpClient.postEntityAndCheckResponse(
+                    Method.DIFFERENTIAL_QUERYDIFFS,
+                    phabricatorHttpClient.withId(diffId),
+                    QueryDiffsResult.class);
+
+            QueryDiffsFields queryDiffsFields = queryDiffsResult.getResult().get(diffId);
+            return queryDiffsFields;
+        } catch (Exception e) {
+            throw new PhabricatorException("Can't get diff", e);
         }
     }
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/Method.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/Method.java
@@ -7,6 +7,7 @@ public enum Method {
     HARBORMASTER_BUILDABLE_SEARCH("harbormaster.buildable.search"),
 
     DIFFERENTIAL_DIFF_SEARCH("differential.diff.search"),
+    DIFFERENTIAL_QUERYDIFFS("differential.querydiffs"),
     DIFFERENTIAL_REVISION_SEARCH("differential.revision.search"),
     DIFFERENTIAL_REVISION_EDIT("differential.revision.edit");
 

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/PhabricatorHttpClient.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/PhabricatorHttpClient.java
@@ -15,6 +15,7 @@ class PhabricatorHttpClient {
 
     static final String API_TOKEN = "api.token";
     static final String CONSTRAINTS_PHIDS_0 = "constraints[phids][0]";
+    static final String IDS_0 = "ids[0]";
 
     /**
      * logger
@@ -38,6 +39,7 @@ class PhabricatorHttpClient {
             Class<T> clazz) throws PhabricatorException {
 
         String url = getUrl(method.getMethod());
+
         T responseWithError = restTemplate.postForObject(
                 url,
                 httpEntity,
@@ -58,6 +60,12 @@ class PhabricatorHttpClient {
     public HttpEntity<MultiValueMap<String, Object>> getConstraintsForPHID(String phid) {
         HttpEntity<MultiValueMap<String, Object>> httpEntity = getHttpEntityFormUrlEncoded();
         httpEntity.getBody().add(CONSTRAINTS_PHIDS_0, phid);
+        return httpEntity;
+    }
+
+    public HttpEntity<MultiValueMap<String, Object>> withId(String id) {
+        HttpEntity<MultiValueMap<String, Object>> httpEntity = getHttpEntityFormUrlEncoded();
+        httpEntity.getBody().add(IDS_0, id);
         return httpEntity;
     }
 

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/BuildSearchResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/BuildSearchResult.java
@@ -1,4 +1,4 @@
 package com.box.l10n.mojito.phabricator.payload;
 
-public class BuildSearchResult extends ResultWithError<BuildSearchFields> {
+public class BuildSearchResult extends ListResultWithError<BuildSearchFields> {
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/BuildableSearchResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/BuildableSearchResult.java
@@ -1,4 +1,4 @@
 package com.box.l10n.mojito.phabricator.payload;
 
-public class BuildableSearchResult extends ResultWithError<BuildableSearchFields> {
+public class BuildableSearchResult extends ListResultWithError<BuildableSearchFields> {
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/DiffSearchResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/DiffSearchResult.java
@@ -1,4 +1,4 @@
 package com.box.l10n.mojito.phabricator.payload;
 
-public class DiffSearchResult extends ResultWithError<DiffSearchFields> {
+public class DiffSearchResult extends ListResultWithError<DiffSearchFields> {
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ListResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ListResult.java
@@ -2,7 +2,7 @@ package com.box.l10n.mojito.phabricator.payload;
 
 import java.util.List;
 
-public class Result<FieldsT> {
+public class ListResult<FieldsT> {
     List<Data<FieldsT>> data;
 
     public List<Data<FieldsT>> getData() {

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ListResultWithError.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ListResultWithError.java
@@ -1,0 +1,14 @@
+package com.box.l10n.mojito.phabricator.payload;
+
+public class ListResultWithError<FiledsT> extends ResultWithError {
+
+    ListResult<FiledsT> result;
+
+    public ListResult<FiledsT> getResult() {
+        return result;
+    }
+
+    public void setResult(ListResult<FiledsT> result) {
+        this.result = result;
+    }
+}

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/MapResultWithError.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/MapResultWithError.java
@@ -1,0 +1,16 @@
+package com.box.l10n.mojito.phabricator.payload;
+
+import java.util.Map;
+
+public class MapResultWithError<FiledsT>  extends ResultWithError {
+
+    Map<String, FiledsT> result;
+
+    public Map<String, FiledsT> getResult() {
+        return result;
+    }
+
+    public void setResult(Map<String, FiledsT> result) {
+        this.result = result;
+    }
+}

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ObjectResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ObjectResult.java
@@ -1,0 +1,13 @@
+package com.box.l10n.mojito.phabricator.payload;
+
+public class ObjectResult extends ResultWithError {
+    Object result;
+
+    public Object getResult() {
+        return result;
+    }
+
+    public void setResult(Object result) {
+        this.result = result;
+    }
+}

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/QueryDiffsFields.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/QueryDiffsFields.java
@@ -1,0 +1,37 @@
+package com.box.l10n.mojito.phabricator.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class QueryDiffsFields {
+
+    @JsonProperty("revisionID")
+    String revisionId;
+
+    String sourceControlBaseRevision;
+
+    String authorEmail;
+
+    public String getRevisionId() {
+        return revisionId;
+    }
+
+    public void setRevisionId(String revisionId) {
+        this.revisionId = revisionId;
+    }
+
+    public String getSourceControlBaseRevision() {
+        return sourceControlBaseRevision;
+    }
+
+    public void setSourceControlBaseRevision(String sourceControlBaseRevision) {
+        this.sourceControlBaseRevision = sourceControlBaseRevision;
+    }
+
+    public String getAuthorEmail() {
+        return authorEmail;
+    }
+
+    public void setAuthorEmail(String authorEmail) {
+        this.authorEmail = authorEmail;
+    }
+}

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/QueryDiffsResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/QueryDiffsResult.java
@@ -1,0 +1,4 @@
+package com.box.l10n.mojito.phabricator.payload;
+
+public class QueryDiffsResult extends MapResultWithError<QueryDiffsFields> {
+}

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ResultWithError.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/ResultWithError.java
@@ -2,15 +2,13 @@ package com.box.l10n.mojito.phabricator.payload;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class ResultWithError<FiledsT> {
+public class ResultWithError {
 
     @JsonProperty("error_code")
     String errorCode;
 
     @JsonProperty("error_info")
     String errorInfo;
-
-    Result<FiledsT> result;
 
     public String getErrorCode() {
         return errorCode;
@@ -26,13 +24,5 @@ public class ResultWithError<FiledsT> {
 
     public void setErrorInfo(String errorInfo) {
         this.errorInfo = errorInfo;
-    }
-
-    public Result<FiledsT> getResult() {
-        return result;
-    }
-
-    public void setResult(Result<FiledsT> result) {
-        this.result = result;
     }
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/RevisionSearchResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/RevisionSearchResult.java
@@ -1,4 +1,4 @@
 package com.box.l10n.mojito.phabricator.payload;
 
-public class RevisionSearchResult extends ResultWithError<RevisionSearchFields> {
+public class RevisionSearchResult extends ListResultWithError<RevisionSearchFields> {
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/payload/TargetSearchResult.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/payload/TargetSearchResult.java
@@ -1,4 +1,4 @@
 package com.box.l10n.mojito.phabricator.payload;
 
-public class TargetSearchResult extends ResultWithError<TargetSearchFields> {
+public class TargetSearchResult extends ListResultWithError<TargetSearchFields> {
 }

--- a/common/src/test/java/com/box/l10n/mojito/phabricator/DifferentialDiffTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/phabricator/DifferentialDiffTest.java
@@ -1,0 +1,51 @@
+package com.box.l10n.mojito.phabricator;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.phabricator.payload.ObjectResult;
+import com.box.l10n.mojito.phabricator.payload.QueryDiffsFields;
+import com.box.l10n.mojito.test.IOTestBase;
+import com.box.l10n.mojito.test.TestWithEnableAutoConfiguration;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = {
+        TestWithEnableAutoConfiguration.class,
+        PhabricatorConfiguration.class,
+        PhabricatorConfigurationProperties.class})
+public class DifferentialDiffTest extends IOTestBase {
+
+    static Logger logger = LoggerFactory.getLogger(DifferentialDiff.class);
+
+    @Autowired(required = false)
+    PhabricatorHttpClient phabricatorHttpClient;
+
+    @Value("${test.l10n.phabricator.differentialdiff.diffId:}")
+    String diffId;
+
+    @Test
+    public void queryDiff() {
+        Assume.assumeNotNull(phabricatorHttpClient, diffId);
+        DifferentialDiff differentialDiff = new DifferentialDiff(phabricatorHttpClient);
+        QueryDiffsFields revisionPHID = differentialDiff.queryDiff(diffId);
+        QueryDiffsFields queryDiffsFields = differentialDiff.queryDiff(diffId);
+        logger.debug("queryDiff, revision: {}, base commit: {}", queryDiffsFields.getRevisionId(), queryDiffsFields.getSourceControlBaseRevision());
+    }
+
+    @Test
+    public void justCallAPI() {
+        Assume.assumeNotNull(phabricatorHttpClient, diffId);
+        ObjectResult objectResult = phabricatorHttpClient.postEntityAndCheckResponse(
+                Method.DIFFERENTIAL_QUERYDIFFS,
+                phabricatorHttpClient.withId(diffId),
+                ObjectResult.class);
+        logger.debug("{}", new ObjectMapper().writeValueAsStringUnchecked(objectResult));
+    }
+}

--- a/common/src/test/java/com/box/l10n/mojito/phabricator/DifferentialRevisionTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/phabricator/DifferentialRevisionTest.java
@@ -22,10 +22,10 @@ public class DifferentialRevisionTest extends IOTestBase {
     @Autowired(required = false)
     DifferentialRevision differentialRevision;
 
-    @Value("${test.l10n.phabricator.differentielrevision.to:}")
+    @Value("${test.l10n.phabricator.differentialrevision.to:}")
     String objectIdentifier;
 
-    @Value("${test.l10n.phabricator.differentielrevision.reviewer:}")
+    @Value("${test.l10n.phabricator.differentialrevision.reviewer:}")
     String reviewer;
 
     @Test

--- a/common/src/test/java/com/box/l10n/mojito/phabricator/PhabricatorHttpClientTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/phabricator/PhabricatorHttpClientTest.java
@@ -4,7 +4,6 @@ import com.box.l10n.mojito.phabricator.payload.ResultWithError;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -12,13 +11,10 @@ import org.springframework.http.HttpEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.URI;
-
 import static com.box.l10n.mojito.phabricator.PhabricatorHttpClient.API_TOKEN;
 import static com.box.l10n.mojito.phabricator.PhabricatorHttpClient.CONSTRAINTS_PHIDS_0;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,7 +34,7 @@ public class PhabricatorHttpClientTest {
     @Test
     public void postEntityAndCheckResponse() {
 
-        ResultWithError<Object> objectResultWithError = new ResultWithError<>();
+        ResultWithError objectResultWithError = new ResultWithError();
         Mockito.doReturn(objectResultWithError).when(mockRestTemplate).postForObject(
                 eq("https://secure.phabricator.com/api/differential.revision.search"),
                 any(),
@@ -55,7 +51,7 @@ public class PhabricatorHttpClientTest {
     @Test(expected = PhabricatorException.class)
     public void postEntityAndCheckResponseError() {
 
-        ResultWithError<Object> objectResultWithError = new ResultWithError<>();
+        ResultWithError objectResultWithError = new ResultWithError();
         objectResultWithError.setErrorCode("ERROR");
         Mockito.doReturn(objectResultWithError).when(mockRestTemplate).postForObject(
                 eq("https://secure.phabricator.com/api/differential.revision.search"),
@@ -92,7 +88,7 @@ public class PhabricatorHttpClientTest {
 
     @Test(expected = PhabricatorException.class)
     public void checkNoError() {
-        ResultWithError<Object> objectResultWithError = new ResultWithError<>();
+        ResultWithError objectResultWithError = new ResultWithError();
         objectResultWithError.setErrorCode("ERR_CODE");
         phabricatorHttpClient.checkNoError(objectResultWithError);
     }


### PR DESCRIPTION
…riables

It will export revision id, base commit, author email and author username
(that's computed by removing the email part from the author email, it is not coming from phabricator).

Format is a list of environment variables like this:
MOJITO_PHAB_REVISION_ID=789456
MOJITO_PHAB_BASE_COMMIT=c32dadb23
MOJITO_PHAB_AUTHOR_EMAIL=user@test.com
MOJITO_PHAB_AUTHOR_USERNAME=user

Example how to source the result of the command in bash shell
source <(mojito phab-diff-to-env-variables --diff-id 123456)