### PR TITLE
Add header base authentication

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/security/user/User.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/security/user/User.java
@@ -8,10 +8,8 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonView;
+import org.springframework.data.annotation.CreatedBy;
 
-import java.io.Serializable;
-import java.util.HashSet;
-import java.util.Set;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,7 +20,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import org.springframework.data.annotation.CreatedBy;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(
@@ -59,8 +59,8 @@ public class User extends AuditableEntity implements Serializable {
 
     /**
      * Sets this flag if the user is created by a process that don't have all the information. Eg. pushing an asset
-     * for a branch with an owner. If the owner is not in the system yet, the user will be created but the information
-     * will be minimal.
+     * for a branch with an owner or header base authentication. If the owner is not in the system yet,
+     * the user will be created but the information will be minimal.
      *
      * Usually user are created the first time the user connect to the system via LDAP or OAuth and have more information
      * Partially created user can be updated later when the first login happens.

--- a/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceCreatePartialImpl.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/UserDetailsServiceCreatePartialImpl.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.security;
+
+import com.box.l10n.mojito.entity.security.user.User;
+import com.box.l10n.mojito.service.security.user.UserService;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class UserDetailsServiceCreatePartialImpl implements UserDetailsService {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(UserDetailsServiceCreatePartialImpl.class);
+
+    @Autowired
+    UserService userService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userService.getOrCreatePartialBasicUser(username);
+        return new UserDetailsImpl(user);
+    }
+}


### PR DESCRIPTION
- can be enabled using l10n.security.header-auth.enabled=true
- will work with other method of authentication (missing header won't fail)
- similar to what is done for oauth2, the user is created (though we just have a username so make it partialy created for now)