### PR TITLE
Specify UTF-8 explicitly when setting the application json header whe…

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/evolve/Evolve.java
+++ b/common/src/main/java/com/box/l10n/mojito/evolve/Evolve.java
@@ -60,7 +60,7 @@ public class Evolve {
     public void createCourseTranslationsById(String courseId, String translatedCourse, String locale, boolean isRTL) {
         translatedCourse = addVersionAndRtlAttributeToTranslations(translatedCourse, locale, isRTL);
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         HttpEntity<String> httpEntity = new HttpEntity<>(translatedCourse, headers);
         String response = restTemplate.postForObject("translate/{courseId}", httpEntity, String.class, courseId);
         logger.debug("course created: {}", response);

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
@@ -130,6 +130,7 @@ public class AuthenticatedRestTemplate {
 
             // The default encoding is set to ISO-8559-1 for String type, which is why we have to override it here
             // For more info: https://jira.spring.io/browse/SPR-9099
+            //TODO investigate but this should probalby replaced with setting the right header: headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
             if (httpMessageConverter instanceof StringHttpMessageConverter) {
                 StringHttpMessageConverter stringHttpMessageConverter = (StringHttpMessageConverter) httpMessageConverter;
                 stringHttpMessageConverter.setSupportedMediaTypes(Arrays.asList(

--- a/webapp/src/main/java/com/box/l10n/mojito/slack/SlackClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/slack/SlackClient.java
@@ -120,7 +120,7 @@ public class SlackClient {
 
     HttpHeaders getHttpHeadersForJson() {
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         headers.set("Authorization", "Bearer " + authToken);
         return headers;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClient.java
@@ -162,7 +162,7 @@ public class SmartlingClient {
 
     public void createBindings(Bindings bindings, String projectId) {
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         HttpEntity<Bindings> requestEntity = new HttpEntity<>(bindings, headers);
         String s = oAuth2RestTemplate.postForObject(API_BINDINGS, requestEntity, String.class, projectId);
         logger.debug("create binding: {}", s);


### PR DESCRIPTION
…n using rest template

This actually makes sure that String objects are serialized as UTF8 by the resttemplate else they are not (default uses: ISO-8859-1). This fix a regression for the evolve client where the content wasn't read anymore and mojibake started to appear.