### PR TITLE
Add fail-safe and option to send assets without waiting for processin…

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -101,7 +101,7 @@ public class PushCommand extends Command {
             return sourceAsset;
         });
 
-        pushService.push(repository, sourceAssetStream, branchName);
+        pushService.push(repository, sourceAssetStream, branchName, PushService.PushType.NORMAL);
 
         consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
     }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest.java
@@ -162,6 +162,21 @@ public class ExtractionDiffCommandTest extends CLITestBase {
         Assert.assertEquals("edf", diffExtractionNameOrDefault);
     }
 
+    @Test
+    public void buildFailSafeMailCommand() {
+        ExtractionDiffCommand extractionDiffCommand = new ExtractionDiffCommand();
+        extractionDiffCommand.failSafeEmail = "username@test.com";
+        extractionDiffCommand.failSafeMessage = "https://mybuildurl.org/1234";
+        extractionDiffCommand.pushToBranchName = "BRANCH";
+        assertEquals("echo 'https://mybuildurl.org/1234' | mail -s 'Extraction diff command failed for branch: BRANCH' username@test.com", extractionDiffCommand.buildFailSafeMailCommand());
+    }
+
+    @Test
+    public void buildFailSafeMailCommandAllNull() {
+        ExtractionDiffCommand extractionDiffCommand = new ExtractionDiffCommand();
+        assertEquals("echo 'null' | mail -s 'Extraction diff command failed for branch: null' null", extractionDiffCommand.buildFailSafeMailCommand());
+    }
+
     List<TextUnitDTO> getTextUnitDTOS(Repository repository) {
         TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
         textUnitSearcherParameters.setRepositoryIds(repository.getId());


### PR DESCRIPTION
…g to be finished

- enable this only for ExtractionDiffCommand, normal Push keeps the normal behavior only
- allow fail safe to avoid breaking builds and to avoid impacting dev velocity - this can be removed if the system is more stable.
- Option to try to send a simple email notification on failure

command example: dmojito extract-diff -c es1 -b es2 --push-to donotexsit --fail-safe true --fail-safe-email "username@test.com" --fail-safe-message "https://mybuild.org/1234" -pb D56789