### PR TITLE
Show actual type and message for unexpected errors in pollable

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/ExceptionHolder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pollableTask/ExceptionHolder.java
@@ -48,27 +48,11 @@ public class ExceptionHolder {
 
     @JsonProperty("type")
     public String getType() {
-        String type;
-
-        if (isExpected()) {
-            type = exception.getClass().getName();
-        } else {
-            type = "unexpected";
-        }
-
-        return type;
+        return exception != null ? exception.getClass().getName() : null;
     }
 
     @JsonProperty("message")
     public String getMessage() {
-        String type;
-
-        if (isExpected()) {
-            type = exception.getMessage();
-        } else {
-            type = "An unexpected error happened, task=" + pollableTask.getId();
-        }
-
-        return type;
+        return exception != null ? exception.getMessage() : null;
     }
 }


### PR DESCRIPTION
Not sure about what was the rational of hiding the error, but it seems to just make it hard to troubleshot without any benefits