### PR TITLE
Add NO_DELETE push type to the push command

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommand.java
@@ -7,6 +7,7 @@ import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffService;
 import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffsPaths;
 import com.box.l10n.mojito.cli.command.extraction.ExtractionsPaths;
 import com.box.l10n.mojito.cli.command.extraction.MissingExtractionDirectoryExcpetion;
+import com.box.l10n.mojito.cli.command.param.Param;
 import com.box.l10n.mojito.cli.console.ConsoleWriter;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.rest.entity.Repository;
@@ -98,7 +99,7 @@ public class ExtractionDiffCommand extends Command {
     @Parameter(names = {"--push-to-branch-createdby", "-pbc"}, arity = 1, required = false, description = "Optional username who owns the branch when pusing to a repository")
     String pushToBranchCreatedBy;
 
-    @Parameter(names = "--push-type", arity = 1, required = false, description = "To choose the push type. Don't change unless you know exactly what it does")
+    @Parameter(names = Param.PUSH_TYPE_LONG, arity = 1, required = false, description = Param.PUSH_TYPE_DESCRIPTION)
     PushService.PushType pushType = PushService.PushType.NORMAL;
 
     @Parameter(names = "--fail-safe", arity = 1, required = false, description = "To fail safe, the command will exit succesfuly even if the processing failed")

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -61,6 +61,9 @@ public class PushCommand extends Command {
     @Parameter(names = {"--branch-createdby", "-bc"}, arity = 1, required = false, description = "username of text unit author")
     String branchCreatedBy;
 
+    @Parameter(names = Param.PUSH_TYPE_LONG, arity = 1, required = false, description = Param.PUSH_TYPE_DESCRIPTION)
+    PushService.PushType pushType = PushService.PushType.NORMAL;
+
     @Autowired
     RepositoryClient repositoryClient;
 
@@ -101,7 +104,7 @@ public class PushCommand extends Command {
             return sourceAsset;
         });
 
-        pushService.push(repository, sourceAssetStream, branchName, PushService.PushType.NORMAL);
+        pushService.push(repository, sourceAssetStream, branchName, pushType);
 
         consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
     }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
@@ -135,4 +135,6 @@ public class Param {
     public static final String EXTRACTION_INPUT_SHORT = "-i";
     public static final String EXTRACTION_INPUT_DESCRIPTION = "The input directory of the extractions commands (if not specified, uses the output directory)";
 
+    public static final String PUSH_TYPE_LONG = "--push-type";
+    public static final String PUSH_TYPE_DESCRIPTION = "To choose the push type. Don't change unless you know exactly what it does";
 }


### PR DESCRIPTION
Send asset but don't remove unused assets.

While it could be used to keep adding assets to a repository, that use case has never really showed up as it.

The actual use case we have now is to be used as a workaround for the fact that we can't provide multiple source directories (this should eventually be supported in some ways but is not simple). With NO_DELETE option you can chain push command with different source directory without marking the asset as deleted. The first call of the chain can do a normal push which will end removing used asset in the end