### PR TITLE
Refactor DatabaseBlobStorageCleanupJob configuration

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/database/DatabaseBlobStorageCleanupJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/database/DatabaseBlobStorageCleanupJob.java
@@ -2,23 +2,13 @@ package com.box.l10n.mojito.service.blobstorage.database;
 
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
-import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.quartz.SimpleTrigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-import org.springframework.scheduling.quartz.JobDetailFactoryBean;
-import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
 
-@Profile("!disablescheduling")
 @DisallowConcurrentExecution
-@Configuration
 public class DatabaseBlobStorageCleanupJob implements Job {
 
     static Logger logger = LoggerFactory.getLogger(DatabaseBlobStorageCleanupJob.class);
@@ -30,23 +20,5 @@ public class DatabaseBlobStorageCleanupJob implements Job {
     public void execute(JobExecutionContext context) throws JobExecutionException {
         logger.debug("Cleanup expired blobs");
         databaseBlobStorage.deleteExpired();
-    }
-
-    @Bean(name = "jobDetailDatabaseBlobStorageCleanupJob")
-    public JobDetailFactoryBean jobDetailExpiringBlobCleanup() {
-        JobDetailFactoryBean jobDetailFactory = new JobDetailFactoryBean();
-        jobDetailFactory.setJobClass(DatabaseBlobStorageCleanupJob.class);
-        jobDetailFactory.setDescription("Cleanup expired blobs");
-        jobDetailFactory.setDurability(true);
-        return jobDetailFactory;
-    }
-
-    @Bean
-    public SimpleTriggerFactoryBean triggerExpiringBlobCleanup(@Qualifier("jobDetailDatabaseBlobStorageCleanupJob") JobDetail job) {
-        SimpleTriggerFactoryBean trigger = new SimpleTriggerFactoryBean();
-        trigger.setJobDetail(job);
-        trigger.setRepeatInterval(300000);
-        trigger.setRepeatCount(SimpleTrigger.REPEAT_INDEFINITELY);
-        return trigger;
     }
 }


### PR DESCRIPTION
- Move BlobStorageConfiguration to the right package (was in autoconfigure from development when it started as an Autoconfiguration class)
- Move the @Bean creation out of DatabaseBlobStorageCleanupJob, make more sense to configure the whole system in one place (plus since it is not Autoconfiguration anymore we can't test on presence of DatabaseBlobStorage instance)