### PR TITLE
Adding JobListener to report Quartz metrics

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -260,6 +260,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- TODO(spring2) migrate joda time? complicated -->
         <!-- Joda Time -->
         <dependency>

--- a/webapp/src/main/java/com/box/l10n/mojito/monitoring/QuartzMetricsReportingJobListener.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/monitoring/QuartzMetricsReportingJobListener.java
@@ -1,0 +1,45 @@
+package com.box.l10n.mojito.monitoring;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+
+@ConditionalOnProperty(value = "l10n.management.metrics.quartz.enabled", havingValue = "true")
+@Component
+public class QuartzMetricsReportingJobListener implements JobListener {
+
+    private MeterRegistry meterRegistry;
+
+    public QuartzMetricsReportingJobListener(@Autowired MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+        Tags timerTags = Tags.of("jobGroup", context.getJobDetail().getKey().getGroup(),
+                                 "jobClass", context.getJobDetail().getJobClass().getSimpleName());
+
+        meterRegistry.timer("quartz.jobs.execution", timerTags)
+                     .record(context.getJobRunTime(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void jobToBeExecuted(JobExecutionContext context) { }
+
+    @Override
+    public void jobExecutionVetoed(JobExecutionContext context) { }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTask.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTask.java
@@ -1,0 +1,69 @@
+package com.box.l10n.mojito.monitoring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+
+@Profile("!disablescheduling")
+@Component
+@ConditionalOnProperty(value = "l10n.management.metrics.quartz.sql-queue-monitoring.enabled", havingValue = "true")
+public class QuartzPendingJobsReportingTask {
+
+    private JdbcTemplate jdbcTemplate;
+    private MeterRegistry meterRegistry;
+
+    public QuartzPendingJobsReportingTask(@Autowired DataSource dataSource,
+                                          @Autowired MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Scheduled(fixedRateString = "${l10n.management.metrics.quartz.sql-queue-monitoring.execution-rate}")
+    public void reportPendingJobs() {
+        fetchResults().forEach(this::reportResults);
+    }
+
+    private void reportResults(PendingJob pendingJob){
+        meterRegistry.gauge("quartz.pending.jobs",
+                            Tags.of("jobClass", pendingJob.jobClass, "jobGroup", pendingJob.jobGroup),
+                            pendingJob.count);
+    }
+
+    List<PendingJob> fetchResults(){
+        return jdbcTemplate.query(
+            "SELECT job_class_name, job_group, COUNT(*) FROM QRTZ_JOB_DETAILS GROUP BY job_class_name, job_group",
+            (rs, num) -> new PendingJob(extractClassName(rs.getString(1)), rs.getString(2), rs.getLong(3))
+        );
+    }
+
+    static String extractClassName(String input) {
+        String[] parts = input.split("\\.");
+        return parts.length > 0 ? parts[parts.length - 1] : "";
+    }
+
+    /*
+    * This class represents data associated with a group of jobs pending to be executed in our Quartz instance
+    * */
+    static class PendingJob {
+        public String jobClass;
+        public String jobGroup;
+        public Long   count;
+
+        public PendingJob(String jobClass, String jobGroup, Long count) {
+            this.jobClass = jobClass;
+            this.jobGroup = jobGroup;
+            this.count = count;
+        }
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSchedulerConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzSchedulerConfig.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.quartz;
 
+import com.box.l10n.mojito.monitoring.QuartzMetricsReportingJobListener;
+
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.slf4j.Logger;
@@ -38,6 +40,9 @@ public class QuartzSchedulerConfig {
     QuartzPropertiesConfig quartzPropertiesConfig;
 
     @Autowired(required = false)
+    QuartzMetricsReportingJobListener quartzMetricsReportingJobListener;
+
+    @Autowired(required = false)
     List<Trigger> triggers = new ArrayList<>();
 
 
@@ -69,6 +74,10 @@ public class QuartzSchedulerConfig {
         schedulerFactory.setOverwriteExistingJobs(true);
         schedulerFactory.setTriggers(triggers.toArray(new Trigger[]{}));
         schedulerFactory.setAutoStartup(false);
+
+        if (quartzMetricsReportingJobListener != null){
+            schedulerFactory.setGlobalJobListeners(quartzMetricsReportingJobListener);
+        }
 
         return schedulerFactory;
     }

--- a/webapp/src/test/java/com/box/l10n/mojito/monitoring/EmptyTestJob.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/monitoring/EmptyTestJob.java
@@ -1,0 +1,11 @@
+package com.box.l10n.mojito.monitoring;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+
+public class EmptyTestJob implements Job {
+
+    @Override
+    public void execute(JobExecutionContext context) {
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/monitoring/QuartzMetricsReportingJobListenerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/monitoring/QuartzMetricsReportingJobListenerTest.java
@@ -1,0 +1,80 @@
+package com.box.l10n.mojito.monitoring;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import org.assertj.core.data.Percentage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.RequiredSearch;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import static com.box.l10n.mojito.quartz.QuartzConfig.DYNAMIC_GROUP_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.quartz.JobBuilder.newJob;
+
+public class QuartzMetricsReportingJobListenerTest {
+
+    static final int JOB_SLEEP_TIME = 25;
+
+    Scheduler scheduler;
+    QuartzMetricsReportingJobListener jobListener;
+    MeterRegistry meterRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        meterRegistry = new SimpleMeterRegistry();
+        jobListener = new QuartzMetricsReportingJobListener(meterRegistry);
+        scheduler = StdSchedulerFactory.getDefaultScheduler();
+        scheduler.getListenerManager().addJobListener(jobListener);
+        scheduler.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        scheduler.shutdown(true);
+    }
+
+    @Test
+    public void testTimersAreUpdatedUponExecution() throws Exception {
+
+        for (int i = 0; i < 5; i++) {
+            JobDetail job = newJob(TestJob.class).withIdentity("TestJob_" + i, "DEFAULT").build();
+            scheduler.scheduleJob(job, TriggerBuilder.newTrigger().forJob(job).startNow().build());
+        }
+
+        await().until(() -> scheduler.isStarted());
+
+        RequiredSearch timerSearch = meterRegistry.get("quartz.jobs.execution")
+                                                  .tag("jobClass", "TestJob")
+                                                  .tag("jobGroup", "DEFAULT");
+
+        await().untilAsserted(() -> assertThat(timerSearch.timers()).isNotEmpty());
+
+        assertThat(timerSearch.timer().takeSnapshot().count()).isGreaterThanOrEqualTo(5);
+        assertThat(timerSearch.timer().takeSnapshot().mean()).isGreaterThanOrEqualTo(JOB_SLEEP_TIME);
+    }
+
+    public static class TestJob implements Job {
+        @Override
+        public void execute(JobExecutionContext context) {
+            Uninterruptibles.sleepUninterruptibly(JOB_SLEEP_TIME, TimeUnit.MILLISECONDS);
+        }
+    }
+
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTaskTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTaskTest.java
@@ -1,0 +1,215 @@
+package com.box.l10n.mojito.monitoring;
+
+import com.box.l10n.mojito.service.DBUtils;
+import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import com.box.l10n.mojito.test.TestIdWatcher;
+
+import org.awaitility.core.ConditionFactory;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.search.RequiredSearch;
+
+import static com.box.l10n.mojito.monitoring.QuartzPendingJobsReportingTask.extractClassName;
+import static com.box.l10n.mojito.quartz.QuartzConfig.DYNAMIC_GROUP_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.quartz.JobBuilder.newJob;
+
+public class QuartzPendingJobsReportingTaskTest extends ServiceTestBase {
+
+    public static final String MY_GROUP = "MY_GROUP";
+
+    @Autowired
+    MeterRegistry meterRegistry;
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    Scheduler scheduler;
+
+    @Autowired
+    DBUtils dbUtils;
+
+    @Value("${l10n.management.metrics.quartz.sql-queue-monitoring.enabled:false}")
+    Boolean monitoringEnabled;
+
+    QuartzPendingJobsReportingTask task;
+
+    /*
+     * This sets up the condition we'll use for await() later on. Given jobs can take some time
+     * to start and be processed, we wait at most 5 seconds and we ignore exceptions of Meters not
+     * found while we search for them (at t0 we might not have a specific meter given by the
+     * RequiredSearch conditions, but then at t1 the process that populates that
+     * Meter might have completed and populated that search)
+     */
+    ConditionFactory await = await().atMost(Duration.ofSeconds(5))
+                                    .ignoreException(MeterNotFoundException.class);
+
+    @Rule
+    public TestIdWatcher testIdWatcher = new TestIdWatcher();
+
+    @Before
+    public void setUp() throws SchedulerException {
+
+
+        task = new QuartzPendingJobsReportingTask(dataSource, meterRegistry);
+
+        scheduler.clear();
+    }
+
+    @Test
+    public void testGaugesCountPendingJobsForNonDynamicGroup() throws Exception {
+
+        Assume.assumeTrue(dbUtils.isMysql() && monitoringEnabled);
+
+        JobDetail job;
+        TriggerBuilder<Trigger> builder;
+
+        job = newJob(Test1Job.class).withIdentity(testIdWatcher.getEntityName("Test1Job"), MY_GROUP).build();
+        builder = TriggerBuilder.newTrigger()
+                                .forJob(job)
+                                .startAt(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
+        scheduler.scheduleJob(job, builder.build());
+
+        job = newJob(Test2Job.class).withIdentity(testIdWatcher.getEntityName("Test2Job"), MY_GROUP).build();
+        builder = TriggerBuilder.newTrigger()
+                                .forJob(job)
+                                .startAt(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()));
+        scheduler.scheduleJob(job, builder.build());
+
+        task.reportPendingJobs();
+
+        RequiredSearch search1 = meterRegistry.get("quartz.pending.jobs")
+                                              .tag("jobGroup", MY_GROUP)
+                                              .tag("jobClass", "QuartzPendingJobsReportingTaskTest$Test1Job");
+        RequiredSearch search2 = meterRegistry.get("quartz.pending.jobs")
+                                              .tag("jobGroup", MY_GROUP)
+                                              .tag("jobClass", "QuartzPendingJobsReportingTaskTest$Test2Job");
+
+
+        await.untilAsserted(() -> assertThat(search1.gauge().value()).isEqualTo(1));
+        await.untilAsserted(() -> assertThat(search2.gauge().value()).isEqualTo(1));
+    }
+
+    @Test
+    public void testGaugesCountPendingJobsForDynamicGroup() throws Exception {
+
+        Assume.assumeTrue(dbUtils.isMysql() && monitoringEnabled);
+
+        JobDetail job;
+        TriggerBuilder<Trigger> builder;
+
+        for (int i = 1; i <= 5; i++) {
+            job = newJob(Test1Job.class).withIdentity(testIdWatcher.getEntityName("Test1Job_" + i), DYNAMIC_GROUP_NAME)
+                                        .build();
+            builder = TriggerBuilder.newTrigger()
+                                    .forJob(job)
+                                    .startAt(Date.from(ZonedDateTime.now().plusHours(i).toInstant()));
+            scheduler.scheduleJob(job, builder.build());
+
+            job = newJob(EmptyTestJob.class).withIdentity(testIdWatcher.getEntityName("EmptyJob_" + i), DYNAMIC_GROUP_NAME)
+                                            .build();
+            builder = TriggerBuilder.newTrigger()
+                                    .forJob(job)
+                                    .startAt(Date.from(ZonedDateTime.now().plusHours(i).toInstant()));
+            scheduler.scheduleJob(job, builder.build());
+        }
+
+        task.reportPendingJobs();
+
+        RequiredSearch test1Gauges = meterRegistry.get("quartz.pending.jobs")
+                                                  .tag("jobClass", "QuartzPendingJobsReportingTaskTest$Test1Job")
+                                                  .tag("jobGroup", DYNAMIC_GROUP_NAME);
+
+        RequiredSearch test2Gauges = meterRegistry.get("quartz.pending.jobs")
+                                                  .tag("jobClass", "EmptyTestJob")
+                                                  .tag("jobGroup", DYNAMIC_GROUP_NAME);
+
+        await.untilAsserted(() -> assertThat(test1Gauges.gauges()).isNotEmpty());
+        await.untilAsserted(() -> assertThat(test2Gauges.gauges()).isNotEmpty());
+        await.untilAsserted(() -> assertThat(test1Gauges.gauge().value()).isEqualTo(5));
+        await.untilAsserted(() -> assertThat(test2Gauges.gauge().value()).isEqualTo(5));
+    }
+
+    @Test
+    public void testFetchResults() throws Exception {
+
+        Assume.assumeTrue(dbUtils.isMysql() && monitoringEnabled);
+
+        JobDetail job;
+        TriggerBuilder<Trigger> builder;
+
+        for (int i = 1; i <= 5; i++) {
+            job = newJob(Test1Job.class).withIdentity(testIdWatcher.getEntityName("Test1Job_" + i), DYNAMIC_GROUP_NAME)
+                                        .build();
+            builder = TriggerBuilder.newTrigger()
+                                    .forJob(job)
+                                    .startAt(Date.from(ZonedDateTime.now().plusHours(i).toInstant()));
+            scheduler.scheduleJob(job, builder.build());
+
+            job = newJob(EmptyTestJob.class).withIdentity(testIdWatcher.getEntityName("EmptyJob_" + i), DYNAMIC_GROUP_NAME)
+                                            .build();
+            builder = TriggerBuilder.newTrigger()
+                                    .forJob(job)
+                                    .startAt(Date.from(ZonedDateTime.now().plusHours(i).toInstant()));
+            scheduler.scheduleJob(job, builder.build());
+        }
+
+        List<QuartzPendingJobsReportingTask.PendingJob> pendingJobs = task.fetchResults();
+
+        assertThat(pendingJobs).hasSize(2);
+        assertThat(pendingJobs).extracting("jobClass")
+                               .containsExactlyInAnyOrder("QuartzPendingJobsReportingTaskTest$Test1Job", "EmptyTestJob");
+        assertThat(pendingJobs).extracting("jobGroup")
+                               .contains(DYNAMIC_GROUP_NAME);
+        assertThat(pendingJobs).extracting("count")
+                               .containsExactlyInAnyOrder((long) 5, (long) 5);
+    }
+
+    @Test
+    public void testExtractClassName() {
+        assertThat(extractClassName(".")).isEqualTo("");
+        assertThat(extractClassName("")).isEqualTo("");
+        assertThat(extractClassName("-")).isEqualTo("-");
+        assertThat(extractClassName("ClassName")).isEqualTo("ClassName");
+        assertThat(extractClassName("org.package.ClassName")).isEqualTo("ClassName");
+        assertThat(extractClassName(EmptyTestJob.class.getName())).isEqualTo("EmptyTestJob");
+        assertThat(extractClassName(getClass().getCanonicalName())).isEqualTo("QuartzPendingJobsReportingTaskTest");
+        assertThat(extractClassName(Test1Job.class.getName())).isEqualTo("QuartzPendingJobsReportingTaskTest$Test1Job");
+    }
+
+    public static class Test1Job implements Job {
+        @Override
+        public void execute(JobExecutionContext context) {
+        }
+    }
+
+    public static class Test2Job implements Job {
+        @Override
+        public void execute(JobExecutionContext context) {
+        }
+    }
+}


### PR DESCRIPTION
On top of what we've added to publish instrumentation metrics using micrometer and statsd, this change adds two classes:

- A Quartz `JobListener` that runs upon completion of each job defined within the codebase and publishes timing metrics for each job's execution time (in milliseconds) in the `quartz.jobs.execution` timer, including `jobGroup` and `jobClass` tags. To enable this metric, the `l10n.management.metrics.quartz.enabled` property must be `true`.
- A `Scheduled` task, which collects "queue" sizes and publishes them as gauges in the `quartz.pending.jobs` gauge, including `jobGroup` and `jobClass` tags. This task runs only when MySQL is being used as the datasource. To enable this metric, the `l10n.management.metrics.quartz.queue-monitoring.enabled` property must be `true`. Also, a `l10n.management.metrics.quartz.queue-monitoring.execution-rate` property is provided to execute the task with a fixed period in milliseconds between invocations. It can be defined in milliseconds, of following a [Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) compliant string.