### PR TITLE
Add dependencies to enable json logging when required

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -295,6 +295,12 @@
             <artifactId>httpclient</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>6.4</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/webapp/src/main/resources/logback.xml
+++ b/webapp/src/main/resources/logback.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    
-    <logger name="NativeCriteriaPerformance" level="ERROR"/>
-    <logger name="com.box.l10n.mojito.service.repository.RepositoryStatisticsScheduler" level="INFO"/>
-    <logger name="com.box.l10n.mojito.service.repository.RepositoryStatisticService" level="INFO"/>
-     
+    <include resource="logback/base.xml"/>
 </configuration>

--- a/webapp/src/main/resources/logback/base.xml
+++ b/webapp/src/main/resources/logback/base.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default logback configuration for imports -->
+<included>
+    <logger name="NativeCriteriaPerformance" level="ERROR"/>
+    <logger name="com.box.l10n.mojito.service.repository.RepositoryStatisticsScheduler" level="INFO"/>
+    <logger name="com.box.l10n.mojito.service.repository.RepositoryStatisticService" level="INFO"/>
+</included>

--- a/webapp/src/main/resources/logback/logback-json.xml
+++ b/webapp/src/main/resources/logback/logback-json.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+    <include resource="base.xml" />
+
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <timestampPattern>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampPattern>
+            <timeZone>UTC</timeZone>
+        </encoder>
+        <file>/var/log/mojito/mojito-webapp.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <cleanHistoryOnStart>false</cleanHistoryOnStart>
+            <fileNamePattern>/var/log/mojito/mojito-webapp.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>0</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON_FILE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
The [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) will allow JSON logging to be enabled if required. When not configured as such, logging will remain unchanged, but if the `LogstashEncoder` is used for any Appender, then this encoder will be used.

- An example logback configuration file is provided in `logback/logback-json.xml`

- Then, to start the application applying the above configuration, we can do:

`LOGGING_CONFIG=classpath:logback/logback-json.xml java -jar webapp/target/mojito-webapp-0.111-SNAPSHOT-exec.jar`

With this configuration, the resulting log file will look like:
```json
{
  "@timestamp": "2020-07-07 22:54:18.753",
  "@version": 1,
  "message": "Starting Application v0.111-SNAPSHOT",
  "logger_name": "com.box.l10n.mojito.Application",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:18.765",
  "@version": 1,
  "message": "No active profile set, falling back to default profiles: default",
  "logger_name": "com.box.l10n.mojito.Application",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:22.122",
  "@version": 1,
  "message": "Bootstrapping Spring Data JPA repositories in DEFAULT mode.",
  "logger_name": "org.springframework.data.repository.config.RepositoryConfigurationDelegate",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:23.998",
  "@version": 1,
  "message": "Finished Spring Data repository scanning in 1858ms. Found 41 JPA repository interfaces.",
  "logger_name": "org.springframework.data.repository.config.RepositoryConfigurationDelegate",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:25.832",
  "@version": 1,
  "message": "Bean 'org.springframework.retry.annotation.RetryConfiguration' of type [org.springframework.retry.annotation.RetryConfiguration$$EnhancerBySpringCGLIB$$7ebe1a98] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)",
  "logger_name": "org.springframework.context.support.PostProcessorRegistrationDelegate$BeanPostProcessorChecker",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:26.333",
  "@version": 1,
  "message": "Tomcat initialized with port(s): 8080 (http)",
  "logger_name": "org.springframework.boot.web.embedded.tomcat.TomcatWebServer",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:26.344",
  "@version": 1,
  "message": "Starting service [Tomcat]",
  "logger_name": "org.apache.catalina.core.StandardService",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
{
  "@timestamp": "2020-07-07 22:54:26.345",
  "@version": 1,
  "message": "Starting Servlet engine: [Apache Tomcat/9.0.36]",
  "logger_name": "org.apache.catalina.core.StandardEngine",
  "thread_name": "main",
  "level": "INFO",
  "level_value": 20000
}
```