### PR TITLE
Updating logback-json config to log ISO8601 timestamps

### DIFF
--- a/webapp/src/main/resources/logback/logback-json.xml
+++ b/webapp/src/main/resources/logback/logback-json.xml
@@ -6,7 +6,6 @@
 
     <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timestampPattern>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampPattern>
             <timeZone>UTC</timeZone>
         </encoder>
         <file>/var/log/mojito/mojito-webapp.log</file>


### PR DESCRIPTION
In #605 we introduced JSON logging through the logback-json configuration, but the timestamp pattern that [was defined there](https://github.com/box/mojito/pull/605/files#diff-686cfa9fbc5d1f0170f170011dee9673R9) isn't fully compatible with logstash/ELK. If we don't specify a pattern, the logstash-logback-enconder will [default to ISO 8601](https://github.com/logstash/logstash-logback-encoder#customizing-timestamp), which is the [preferred pattern for ELK](https://www.rubydoc.info/gems/logstash-core/1.5.0/LogStash%2FTimestamp.coerce).