### PR TITLE
Quartz queue monitoring - Job counting fix

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTask.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/monitoring/QuartzPendingJobsReportingTask.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.monitoring;
 
+import io.micrometer.core.instrument.Tags;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
@@ -8,11 +9,16 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
 
 @Profile("!disablescheduling")
 @Component
@@ -21,29 +27,48 @@ public class QuartzPendingJobsReportingTask {
 
     private JdbcTemplate jdbcTemplate;
     private MeterRegistry meterRegistry;
+    private Map<String, AtomicLong> queueSizes;
 
     public QuartzPendingJobsReportingTask(@Autowired DataSource dataSource,
                                           @Autowired MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
         this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.queueSizes = new ConcurrentHashMap<>();
     }
 
     @Scheduled(fixedRateString = "${l10n.management.metrics.quartz.sql-queue-monitoring.execution-rate}")
     public void reportPendingJobs() {
-        fetchResults().forEach(this::reportResults);
+        Map<String, PendingJob> results = fetchResults();
+        updateQueueSizes(results);
+        results.forEach(this::registerJobQueueSize);
     }
 
-    private void reportResults(PendingJob pendingJob){
-        meterRegistry.gauge("quartz.pending.jobs",
-                            Tags.of("jobClass", pendingJob.jobClass, "jobGroup", pendingJob.jobGroup),
-                            pendingJob.count);
+    private void registerJobQueueSize(String key, PendingJob pendingJob) {
+        queueSizes.computeIfAbsent(key, k -> createGauge(pendingJob))
+                .set(pendingJob.count);
     }
 
-    List<PendingJob> fetchResults(){
-        return jdbcTemplate.query(
-            "SELECT job_class_name, job_group, COUNT(*) FROM QRTZ_JOB_DETAILS GROUP BY job_class_name, job_group",
-            (rs, num) -> new PendingJob(extractClassName(rs.getString(1)), rs.getString(2), rs.getLong(3))
+    private AtomicLong createGauge(PendingJob pendingJob) {
+        return meterRegistry.gauge("quartz.pending.jobs",
+                Tags.of("jobClass", pendingJob.jobClass, "jobGroup", pendingJob.jobGroup),
+                new AtomicLong(pendingJob.count));
+    }
+
+    private void updateQueueSizes(Map<String, PendingJob> pendingJobs) {
+        queueSizes.forEach((key, val) -> {
+            Long size = pendingJobs.containsKey(key) ? pendingJobs.get(key).count : 0L;
+            // If the list of yielded results doesn't contains the pendingjob, then we update its value to be zero
+            queueSizes.get(key).set(size);
+        });
+    }
+
+    Map<String, PendingJob> fetchResults() {
+        List<PendingJob> result = jdbcTemplate.query(
+                "SELECT job_class_name, job_group, COUNT(*) FROM QRTZ_JOB_DETAILS GROUP BY job_class_name, job_group",
+                (rs, num) -> new PendingJob(extractClassName(rs.getString(1)), rs.getString(2), rs.getLong(3))
         );
+
+        return result.stream().collect(Collectors.toMap(PendingJob::getKey, Function.identity()));
     }
 
     static String extractClassName(String input) {
@@ -52,18 +77,21 @@ public class QuartzPendingJobsReportingTask {
     }
 
     /*
-    * This class represents data associated with a group of jobs pending to be executed in our Quartz instance
-    * */
+     * This class represents data associated with a group of jobs pending to be executed in our Quartz instance
+     * */
     static class PendingJob {
         public String jobClass;
         public String jobGroup;
-        public Long   count;
+        public Long count;
 
         public PendingJob(String jobClass, String jobGroup, Long count) {
             this.jobClass = jobClass;
             this.jobGroup = jobGroup;
             this.count = count;
         }
-    }
 
+        public String getKey() {
+            return jobClass + "-" + jobGroup;
+        }
+    }
 }


### PR DESCRIPTION
The job queue monitoring code we have for Quartz its flawed since it uses a variable reference as the value to be reported in the gauge, but we need a function reference instead to return the exact value at reporting time. Hence, we create a cache with the results obtained each time from the DB and we gather the value for the gauge using that cache instead.

I've added test cases to our integration tests to ensure subsequent runs report queue sizes correctly.