### PR TITLE
SmartlingClient: Add uploadLocalizedFile method

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
@@ -4,6 +4,7 @@ import com.box.l10n.mojito.smartling.request.Binding;
 import com.box.l10n.mojito.smartling.request.Bindings;
 import com.box.l10n.mojito.smartling.response.AuthenticationResponse;
 import com.box.l10n.mojito.smartling.response.File;
+import com.box.l10n.mojito.smartling.response.FileUploadResponse;
 import com.box.l10n.mojito.smartling.response.Items;
 import com.box.l10n.mojito.smartling.response.StringInfo;
 import com.box.l10n.mojito.test.TestIdWatcher;
@@ -27,6 +28,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = {SmartlingClientTest.class, SmartlingClientConfiguration.class, ObjectMapper.class, SmartlingTestConfig.class})
@@ -124,6 +127,42 @@ public class SmartlingClientTest {
         } finally {
             smartlingClient.deleteFile(smartlingTestConfig.projectId, fileName);
         }
+    }
+
+    @Test
+    public void testUploadDownloadAndDeleteLocalizedFile() {
+        Assume.assumeNotNull(smartlingTestConfig.projectId);
+
+        FileUploadResponse response;
+        String downloadFile;
+        String fileName = "strings.xml";
+
+        uploadFile(smartlingTestConfig.projectId, fileName);
+
+        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<resources>\n" +
+                "    <string name=\"hello\">Hola</string>\n" +
+                "    <string name=\"bye\">Adios</string>\n" +
+                "</resources>";
+
+        response =  smartlingClient.uploadLocalizedFile(smartlingTestConfig.projectId,
+                fileName,
+                "android",
+                "es-MX",
+                content,
+                null,
+                null);
+
+        downloadFile = smartlingClient.downloadFile(smartlingTestConfig.projectId,
+                "es-MX",
+                fileName,
+                false,
+                SmartlingClient.RetrievalType.PENDING);
+
+        assertThat(response.getCode()).isEqualTo("SUCCESS");
+        assertThat(downloadFile).isEqualTo(content);
+
+        smartlingClient.deleteFile(smartlingTestConfig.projectId, fileName);
     }
 
     @Test


### PR DESCRIPTION
Adding the `uploadLocalizedFile` method to the `SmartlingClient` class, to allow for localized files to be uploaded with their API.

Integrations tests where run locally:

<img width="538" alt="Screen Shot 2020-07-23 at 3 12 42 PM" src="https://user-images.githubusercontent.com/4760146/88343780-028ced00-ccf7-11ea-88c3-ce9ac500d4e0.png">
