### PR TITLE
ThirdPartySyncCommand - Adding new parameters

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/EnumConverter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/EnumConverter.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.cli.command;
 
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
+import com.google.common.base.Strings;
 
 import java.util.Arrays;
 
@@ -15,7 +16,7 @@ public abstract class EnumConverter<T extends Enum<T>> implements IStringConvert
         T result = null;
         if (value != null) {
             try {
-                result = Enum.valueOf(getGenericClass(), value.toUpperCase());
+                result = Enum.valueOf(getGenericClass(), Strings.nullToEmpty(value).trim().toUpperCase());
             } catch (IllegalArgumentException iae) {
                 String msg = "Invalid type [" + value + "], should be one of: " + Arrays.toString(getGenericClass().getEnumConstants());
                 throw new ParameterException(msg);

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommand.java
@@ -54,8 +54,7 @@ public class ImportLocalizedAssetCommand extends Command {
     @Parameter(names = {Param.TARGET_DIRECTORY_LONG, Param.TARGET_DIRECTORY_SHORT}, arity = 1, required = false, description = Param.TARGET_DIRECTORY_DESCRIPTION)
     String targetDirectoryParam;
 
-    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = "Locale mapping, format: \"fr:fr-FR,ja:ja-JP\". "
-            + "The keys contain BCP47 tags of the generated files and the values indicate which repository locales are used to fetch the translations.")
+    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = Param.REPOSITORY_LOCALES_MAPPING_DESCRIPTION)
     String localeMappingParam;
 
     @Parameter(names = {Param.FILE_TYPE_LONG, Param.FILE_TYPE_SHORT}, arity = 1, required = false, description = Param.FILE_TYPE_DESCRIPTION,

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
@@ -53,8 +53,7 @@ public class PullCommand extends Command {
     @Parameter(names = {Param.TARGET_DIRECTORY_LONG, Param.TARGET_DIRECTORY_SHORT}, arity = 1, required = false, description = Param.TARGET_DIRECTORY_DESCRIPTION)
     String targetDirectoryParam;
 
-    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = "Locale mapping, format: \"fr:fr-FR,ja:ja-JP\". "
-            + "The keys contain BCP47 tags of the generated files and the values indicate which repository locales are used to fetch the translations.")
+    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = Param.REPOSITORY_LOCALES_MAPPING_DESCRIPTION)
     String localeMappingParam;
 
     @Parameter(names = {Param.FILE_TYPE_LONG, Param.FILE_TYPE_SHORT}, arity = 1, required = false, description = Param.FILE_TYPE_DESCRIPTION,

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ScreenshotCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ScreenshotCommand.java
@@ -64,8 +64,7 @@ public class ScreenshotCommand extends Command {
     @Parameter(names = {Param.REPOSITORY_LONG, Param.REPOSITORY_SHORT}, arity = 1, required = true, description = Param.REPOSITORY_DESCRIPTION)
     String repositoryParam;
 
-    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = "Locale mapping, format: \"fr:fr-FR,ja:ja-JP\". "
-            + "The keys contain BCP47 tags of the generated files and the values indicate which repository locales are used to fetch the translations.")
+    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = Param.REPOSITORY_LOCALES_MAPPING_DESCRIPTION)
     String localeMappingParam;
 
     @Parameter(names = {Param.SOURCE_DIRECTORY_LONG, Param.SOURCE_DIRECTORY_SHORT}, arity = 1, required = false, description = "Directory to scan for screenshot")

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ThirdPartySyncActionsConverter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ThirdPartySyncActionsConverter.java
@@ -1,15 +1,15 @@
 package com.box.l10n.mojito.cli.command;
 
-import com.box.l10n.mojito.rest.client.ThirdPartySync;
+import com.box.l10n.mojito.rest.ThirdPartySyncAction;
 
 /**
  *
  * @author sdemyanenko
  */
-public class ThirdPartySyncActionsConverter extends EnumConverter<ThirdPartySync.Action> {
+public class ThirdPartySyncActionsConverter extends EnumConverter<ThirdPartySyncAction> {
 
     @Override
-    protected Class<ThirdPartySync.Action> getGenericClass() {
-        return ThirdPartySync.Action.class;
+    protected Class<ThirdPartySyncAction> getGenericClass() {
+        return ThirdPartySyncAction.class;
     }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommand.java
@@ -4,8 +4,8 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.box.l10n.mojito.cli.command.param.Param;
 import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.ThirdPartySyncAction;
 import com.box.l10n.mojito.rest.client.ThirdPartyClient;
-import com.box.l10n.mojito.rest.client.ThirdPartySync;
 import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
 import org.fusesource.jansi.Ansi;
@@ -44,13 +44,19 @@ public class ThirdPartySyncCommand extends Command {
     String thirdPartyProjectId;
 
     @Parameter(names = {"--actions", "-a"}, variableArity = true, required = false, description = "Actions to synchronize", converter = ThirdPartySyncActionsConverter.class)
-    List<ThirdPartySync.Action> actions = Arrays.asList(ThirdPartySync.Action.MAP_TEXTUNIT, ThirdPartySync.Action.PUSH_SCREENSHOT);
+    List<ThirdPartySyncAction> actions = Arrays.asList(ThirdPartySyncAction.MAP_TEXTUNIT, ThirdPartySyncAction.PUSH_SCREENSHOT);
 
     @Parameter(names = {"--plural-separator", "-ps"}, arity = 1, required = false, description = "Plural separator for name")
     String pluralSeparator;
 
-    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = "Locale mapping")
+    @Parameter(names = {Param.REPOSITORY_LOCALES_MAPPING_LONG, Param.REPOSITORY_LOCALES_MAPPING_SHORT}, arity = 1, required = false, description = Param.REPOSITORY_LOCALES_MAPPING_DESCRIPTION)
     String localeMapping;
+
+    @Parameter(names = {"--skip-text-units-with-pattern", "-st"}, arity = 1, required = false, description = "Do not process text units matching with the SQL LIKE expression")
+    String skipTextUnitsWithPattern;
+
+    @Parameter(names = {"--skip-assets-path-pattern", "-sa"}, arity = 1, required = false, description = "Do not process text units whose assets path match the SQL LIKE expression")
+    String skipAssetsWithPathPattern;
 
     @Parameter(names = {"--options", "-o"}, variableArity = true, required = false, description = "Options to synchronize")
     List<String> options;
@@ -69,11 +75,14 @@ public class ThirdPartySyncCommand extends Command {
                 .a(" actions: ").fg(CYAN).a(Objects.toString(actions)).reset()
                 .a(" plural-separator: ").fg(CYAN).a(Objects.toString(pluralSeparator)).reset()
                 .a(" locale-mapping: ").fg(CYAN).a(Objects.toString(localeMapping)).reset()
+                .a(" skip-text-units-with-pattern: ").fg(CYAN).a(Objects.toString(skipTextUnitsWithPattern)).reset()
+                .a(" skip-assets-path-pattern: ").fg(CYAN).a(Objects.toString(skipAssetsWithPathPattern)).reset()
                 .a(" options: ").fg(CYAN).a(Objects.toString(options)).println(2);
 
         Repository repository = commandHelper.findRepositoryByName(repositoryParam);
 
-        PollableTask pollableTask = thirdPartyClient.sync(repository.getId(), thirdPartyProjectId, pluralSeparator, localeMapping, actions, options);
+        PollableTask pollableTask = thirdPartyClient.sync(repository.getId(), thirdPartyProjectId, pluralSeparator, localeMapping,
+                actions, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
 
         commandHelper.waitForPollableTask(pollableTask.getId());
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
@@ -59,6 +59,8 @@ public class Param {
 
     public static final String REPOSITORY_LOCALES_MAPPING_LONG = "--locale-mapping";
     public static final String REPOSITORY_LOCALES_MAPPING_SHORT = "-lm";
+    public static final String REPOSITORY_LOCALES_MAPPING_DESCRIPTION = "Locale mapping, format: \"fr:fr-FR,ja:ja-JP\". "
+            + "The keys contain BCP47 tags of the generated files and the values indicate which repository locales are used to fetch the translations.";
 
     public static final String REPOSITORY_SOURCE_LOCALE_LONG = "--source-locale";
     public static final String REPOSITORY_SOURCE_LOCALE_SHORT = "-sl";

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
@@ -1,32 +1,105 @@
 package com.box.l10n.mojito.cli.command;
 
 import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.utils.PollableTaskJobMatcher;
+import com.box.l10n.mojito.cli.utils.TestingJobListener;
 import com.box.l10n.mojito.entity.Repository;
-import com.box.l10n.mojito.rest.client.ThirdPartySync;
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction;
+import com.box.l10n.mojito.service.thirdparty.ThirdPartySyncJob;
+import com.box.l10n.mojito.service.thirdparty.ThirdPartySyncJobInput;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.quartz.JobKey;
+import org.quartz.Matcher;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 import java.util.Arrays;
+import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction.MAP_TEXTUNIT;
+import static com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction.PUSH_SCREENSHOT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThirdPartySyncCommandTest extends CLITestBase {
 
-    /**
-     * logger
-     */
-    static Logger logger = LoggerFactory.getLogger(ThirdPartySyncCommandTest.class);
+    @Autowired
+    @Qualifier("fail_on_unknown_properties_false")
+    ObjectMapper objectMapper;
+
+    @Autowired
+    Scheduler scheduler;
+
+    Matcher<JobKey> jobMatcher;
+    TestingJobListener testingJobListener;
+
+    @Before
+    public void setUp() throws SchedulerException {
+        testingJobListener = new TestingJobListener(objectMapper);
+        jobMatcher = new PollableTaskJobMatcher<>(ThirdPartySyncJob.class);
+        scheduler.getListenerManager().addJobListener(testingJobListener, jobMatcher);
+    }
+
+    @After
+    public void tearDown() throws SchedulerException {
+        scheduler.getListenerManager().removeJobListener(testingJobListener.getName());
+        scheduler.getListenerManager().removeJobListenerMatcher(testingJobListener.getName(), jobMatcher);
+    }
 
     @Test
     public void execute() throws Exception {
-        String repoName = testIdWatcher.getEntityName("thirdpartysync_execute");
-        Repository repository = repositoryService.createRepository(repoName, repoName + " description", null, false);
-        getL10nJCommander().run("thirdparty-sync", "-r", repository.getName(), "-p", "does-not-matter-yet", "-ps", " _");
 
-        String outputString = outputCapture.toString();
-        assertTrue(outputString.contains(Arrays.asList(ThirdPartySync.Action.MAP_TEXTUNIT, ThirdPartySync.Action.PUSH_SCREENSHOT).toString()));
+        String repoName = testIdWatcher.getEntityName("thirdpartysync_execute");
+
+        Repository repository = repositoryService.createRepository(repoName, repoName + " description", null, false);
+        String projectId = testIdWatcher.getEntityName("projectId");
+
+        // TODO: For a plural separator like " _" this test will fail. The current version we have for
+        //  JCommander trims the argument values, even when quoted.
+        // https://github.com/cbeust/jcommander/issues/417
+        // https://github.com/cbeust/jcommander/commit/4aec38b4a0ea63a8dc6f41636fa81c2ebafddc18
+        String pluralSeparator = "_";
+        String skipTextUnitPattern = "%skip_text_pattern";
+        String skipAssetPattern = "%skip_asset_pattern%";
+        List<String> options = Arrays.asList(
+                "special-option=value@of%Option",
+                "smartling-placeholder-custom=\\{\\{\\}\\}|\\{\\{?.+?\\}\\}?|\\%\\%\\(.+?\\)s|\\%\\(.+?\\)s|\\%\\(.+?\\)d|\\%\\%s|\\%s"
+        );
+
+        getL10nJCommander().run("thirdparty-sync",
+                "-r", repository.getName(),
+                "-p", projectId,
+                "-a", MAP_TEXTUNIT.name(), PUSH_SCREENSHOT.name(),
+                "-ps", pluralSeparator,
+                "-st", skipTextUnitPattern,
+                "-sa", skipAssetPattern,
+                "-o", options.get(0), options.get(1));
+
+        String output = outputCapture.toString();
+        assertThat(output).contains("repository: " + repository.getName());
+        assertThat(output).contains("project id: " + projectId);
+        assertThat(output).contains("actions: " + Arrays.asList(ThirdPartySyncAction.MAP_TEXTUNIT, ThirdPartySyncAction.PUSH_SCREENSHOT).toString());
+        assertThat(output).contains("skip-text-units-with-pattern: " + skipTextUnitPattern);
+        assertThat(output).contains("skip-assets-path-pattern: " + skipAssetPattern);
+        assertThat(output).contains("options: " + options.toString());
+
+        waitForCondition("Ensure ThirdPartySyncJob gets executed",
+                () -> testingJobListener.getExecuted().size() > 0);
+
+        ThirdPartySyncJobInput jobInput = testingJobListener.getFirstInputMapAs(ThirdPartySyncJobInput.class);
+
+        assertThat(jobInput).isNotNull();
+        assertThat(jobInput.getRepositoryId()).isEqualTo(repository.getId());
+        assertThat(jobInput.getThirdPartyProjectId()).isEqualTo(projectId);
+        assertThat(jobInput.getActions()).containsExactlyInAnyOrder(MAP_TEXTUNIT, PUSH_SCREENSHOT);
+        assertThat(jobInput.getPluralSeparator()).isEqualTo(pluralSeparator);
+        assertThat(jobInput.getSkipTextUnitsWithPattern()).isEqualTo(skipTextUnitPattern);
+        assertThat(jobInput.getSkipAssetsWithPathPattern()).isEqualTo(skipAssetPattern);
+        assertThat(jobInput.getOptions()).containsExactlyInAnyOrderElementsOf(options);
     }
 
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/utils/PollableTaskJobMatcher.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/utils/PollableTaskJobMatcher.java
@@ -1,0 +1,21 @@
+package com.box.l10n.mojito.cli.utils;
+
+import com.box.l10n.mojito.quartz.QuartzPollableJob;
+import org.quartz.JobKey;
+import org.quartz.Matcher;
+
+import static com.box.l10n.mojito.quartz.QuartzConfig.DYNAMIC_GROUP_NAME;
+
+public class PollableTaskJobMatcher<T extends QuartzPollableJob> implements Matcher<JobKey> {
+
+    private final Class<T> target;
+
+    public PollableTaskJobMatcher(Class<T> target) {
+        this.target = target;
+    }
+
+    @Override
+    public boolean isMatch(JobKey key) {
+        return key.getName().startsWith(target.getName()) && DYNAMIC_GROUP_NAME.equals(key.getGroup());
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/utils/TestingJobListener.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/utils/TestingJobListener.java
@@ -1,0 +1,65 @@
+package com.box.l10n.mojito.cli.utils;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static com.box.l10n.mojito.quartz.QuartzPollableJob.INPUT;
+
+public class TestingJobListener implements JobListener {
+
+    private final Queue<JobExecutionContext> toBeExecuted = new LinkedList<>();
+    private final Queue<JobExecutionContext> executed = new LinkedList<>();
+    private final Queue<JobExecutionException> exceptions = new LinkedList<>();
+    private final ObjectMapper objectMapper;
+
+    public TestingJobListener(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public TestingJobListener() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public String getName() {
+        return "TestingJobListener";
+    }
+
+    @Override
+    public void jobToBeExecuted(JobExecutionContext context) {
+        toBeExecuted.offer(context);
+    }
+
+    @Override
+    public void jobExecutionVetoed(JobExecutionContext context) {
+    }
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+        executed.offer(context);
+        exceptions.offer(jobException);
+    }
+
+    public Queue<JobExecutionContext> getExecuted() {
+        return executed;
+    }
+
+    public Queue<JobExecutionContext> getToBeExecuted() {
+        return toBeExecuted;
+    }
+
+    public <T> T getFirstInputMapAs(Class<T> klass) {
+        String input = getExecuted().stream()
+                .filter(context -> context.getMergedJobDataMap().containsKey(INPUT))
+                .map(context -> context.getMergedJobDataMap().getString(INPUT))
+                .findFirst()
+                .orElse("");
+
+        return objectMapper.readValueUnchecked(input, klass);
+    }
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
@@ -1,0 +1,9 @@
+package com.box.l10n.mojito.rest;
+
+public enum ThirdPartySyncAction {
+    PUSH,
+    PUSH_TRANSLATION,
+    PULL,
+    MAP_TEXTUNIT,
+    PUSH_SCREENSHOT
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartyClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartyClient.java
@@ -1,8 +1,7 @@
 package com.box.l10n.mojito.rest.client;
 
+import com.box.l10n.mojito.rest.ThirdPartySyncAction;
 import com.box.l10n.mojito.rest.entity.PollableTask;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -16,19 +15,19 @@ import java.util.List;
 @Component
 public class ThirdPartyClient extends BaseClient {
 
-    /**
-     * logger
-     */
-    static Logger logger = LoggerFactory.getLogger(ThirdPartyClient.class);
-
     @Override
     public String getEntityName() {
         return "thirdparty";
     }
 
-    public PollableTask sync(Long repositoryId, String projectId, String pluralSeparator, String localeMapping,
-        List<ThirdPartySync.Action> actions, List<String> options)
-    {
+    public PollableTask sync(Long repositoryId,
+                             String projectId,
+                             String pluralSeparator,
+                             String localeMapping,
+                             List<ThirdPartySyncAction> actions,
+                             String skipTextUnitsWithPattern,
+                             String skipAssetsWithPathPattern,
+                             List<String> options) {
 
         ThirdPartySync thirdPartySync = new ThirdPartySync();
 
@@ -37,6 +36,8 @@ public class ThirdPartyClient extends BaseClient {
         thirdPartySync.setActions(actions);
         thirdPartySync.setPluralSeparator(pluralSeparator);
         thirdPartySync.setLocaleMapping(localeMapping);
+        thirdPartySync.setSkipTextUnitsWithPattern(skipTextUnitsWithPattern);
+        thirdPartySync.setSkipAssetsWithPathPattern(skipAssetsWithPathPattern);
         thirdPartySync.setOptions(options);
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath(getBasePathForEntity()).pathSegment("sync");

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartySync.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartySync.java
@@ -1,23 +1,20 @@
 package com.box.l10n.mojito.rest.client;
 
+import com.box.l10n.mojito.rest.ThirdPartySyncAction;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public class ThirdPartySync {
 
-    public enum Action {
-        PUSH,
-        PUSH_TRANSLATION,
-        PULL,
-        MAP_TEXTUNIT,
-        PUSH_SCREENSHOT
-    }
-
     Long repositoryId;
     String projectId;
-    List<Action> actions;
+    List<ThirdPartySyncAction> actions = new ArrayList<>();
     String pluralSeparator;
     String localeMapping;
-    List<String> options;
+    String skipTextUnitsWithPattern;
+    String skipAssetsWithPathPattern;
+    List<String> options = new ArrayList<>();
 
     public Long getRepositoryId() {
         return repositoryId;
@@ -35,11 +32,11 @@ public class ThirdPartySync {
         this.projectId = projectId;
     }
 
-    public List<Action> getActions() {
+    public List<ThirdPartySyncAction> getActions() {
         return actions;
     }
 
-    public void setActions(List<Action> actions) {
+    public void setActions(List<ThirdPartySyncAction> actions) {
         this.actions = actions;
     }
 
@@ -57,6 +54,22 @@ public class ThirdPartySync {
 
     public void setLocaleMapping(String localeMapping) {
         this.localeMapping = localeMapping;
+    }
+
+    public String getSkipTextUnitsWithPattern() {
+        return skipTextUnitsWithPattern;
+    }
+
+    public void setSkipTextUnitsWithPattern(String skipTextUnitsWithPattern) {
+        this.skipTextUnitsWithPattern = skipTextUnitsWithPattern;
+    }
+
+    public String getSkipAssetsWithPathPattern() {
+        return skipAssetsWithPathPattern;
+    }
+
+    public void setSkipAssetsWithPathPattern(String skipAssetsWithPathPattern) {
+        this.skipAssetsWithPathPattern = skipAssetsWithPathPattern;
     }
 
     public List<String> getOptions() {

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -228,6 +228,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySync.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySync.java
@@ -1,17 +1,18 @@
 package com.box.l10n.mojito.rest.thirdparty;
 
-import com.box.l10n.mojito.service.thirdparty.ThirdPartyService;
-
+import java.util.ArrayList;
 import java.util.List;
 
 public class ThirdPartySync {
 
     Long repositoryId;
     String projectId;
-    List<ThirdPartyService.Action> actions;
+    List<ThirdPartySyncAction> actions = new ArrayList<>();
     String pluralSeparator;
-    String localMapping;
-    List<String> options;
+    String localeMapping;
+    String skipTextUnitsWithPattern;
+    String skipAssetsWithPathPattern;
+    List<String> options = new ArrayList<>();
 
     public Long getRepositoryId() {
         return repositoryId;
@@ -29,11 +30,11 @@ public class ThirdPartySync {
         this.projectId = projectId;
     }
 
-    public List<ThirdPartyService.Action> getActions() {
+    public List<ThirdPartySyncAction> getActions() {
         return actions;
     }
 
-    public void setActions(List<ThirdPartyService.Action> actions) {
+    public void setActions(List<ThirdPartySyncAction> actions) {
         this.actions = actions;
     }
 
@@ -45,12 +46,28 @@ public class ThirdPartySync {
         this.pluralSeparator = pluralSeparator;
     }
 
-    public String getLocalMapping() {
-        return localMapping;
+    public String getLocaleMapping() {
+        return localeMapping;
     }
 
-    public void setLocalMapping(String localMapping) {
-        this.localMapping = localMapping;
+    public void setLocaleMapping(String localeMapping) {
+        this.localeMapping = localeMapping;
+    }
+
+    public String getSkipTextUnitsWithPattern() {
+        return skipTextUnitsWithPattern;
+    }
+
+    public void setSkipTextUnitsWithPattern(String skipTextUnitsWithPattern) {
+        this.skipTextUnitsWithPattern = skipTextUnitsWithPattern;
+    }
+
+    public String getSkipAssetsWithPathPattern() {
+        return skipAssetsWithPathPattern;
+    }
+
+    public void setSkipAssetsWithPathPattern(String skipAssetsWithPathPattern) {
+        this.skipAssetsWithPathPattern = skipAssetsWithPathPattern;
     }
 
     public List<String> getOptions() {

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySyncAction.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySyncAction.java
@@ -1,0 +1,9 @@
+package com.box.l10n.mojito.rest.thirdparty;
+
+public enum ThirdPartySyncAction {
+    PUSH,
+    PUSH_TRANSLATION,
+    PULL,
+    MAP_TEXTUNIT,
+    PUSH_SCREENSHOT
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartyWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartyWS.java
@@ -1,7 +1,6 @@
 package com.box.l10n.mojito.rest.thirdparty;
 
 import com.box.l10n.mojito.entity.PollableTask;
-import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import com.box.l10n.mojito.service.thirdparty.ThirdPartyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-    public class ThirdPartyWS {
+public class ThirdPartyWS {
 
     /**
      * logger
@@ -23,13 +22,9 @@ import org.springframework.web.bind.annotation.RestController;
     ThirdPartyService thirdPartyService;
 
     @RequestMapping(value = "/api/thirdparty/sync", method = RequestMethod.POST)
-    public PollableTask thirdpartySyn(@RequestBody ThirdPartySync thirdPartySync) {
-        logger.debug("Sync repository: {} with third party project: {} actions: {} plural separator: {} locale mapping: {} options: {}",
-                thirdPartySync.getRepositoryId(), thirdPartySync.getProjectId(), thirdPartySync.getActions(),
-                thirdPartySync.getPluralSeparator(), thirdPartySync.getLocalMapping(), thirdPartySync.getOptions());
-        PollableFuture pollableFuture = thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(
-                thirdPartySync.getRepositoryId(), thirdPartySync.getProjectId(), thirdPartySync.getActions(),
-                thirdPartySync.getPluralSeparator(), thirdPartySync.getLocalMapping(), thirdPartySync.getOptions());
-        return pollableFuture.getPollableTask();
+    public PollableTask sync(@RequestBody ThirdPartySync thirdPartySync) {
+        logger.debug("Sync repository: {}", thirdPartySync);
+        return thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(thirdPartySync)
+                .getPollableTask();
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJob.java
@@ -25,7 +25,7 @@ public class ThirdPartySyncJob extends QuartzPollableJob<ThirdPartySyncJobInput,
     PollableTaskService pollableTaskService;
 
     @Override
-    public Void call(ThirdPartySyncJobInput input) throws Exception {
+    public Void call(ThirdPartySyncJobInput input) {
         logger.debug("Run ThirdPartyMapJob");
         thirdPartyService.syncMojitoWithThirdPartyTMS(
                 input.getRepositoryId(),
@@ -33,6 +33,8 @@ public class ThirdPartySyncJob extends QuartzPollableJob<ThirdPartySyncJobInput,
                 input.getActions(),
                 input.getPluralSeparator(),
                 input.getLocaleMapping(),
+                input.getSkipTextUnitsWithPattern(),
+                input.getSkipAssetsWithPathPattern(),
                 input.getOptions());
         return null;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJobInput.java
@@ -1,5 +1,8 @@
 package com.box.l10n.mojito.service.thirdparty;
 
+
+import com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction;
+
 import java.util.List;
 
 /**
@@ -9,9 +12,11 @@ public class ThirdPartySyncJobInput {
 
     Long repositoryId;
     String thirdPartyProjectId;
-    List<ThirdPartyService.Action> actions;
+    List<ThirdPartySyncAction> actions;
     String pluralSeparator;
     String localeMapping;
+    String skipTextUnitsWithPattern;
+    String skipAssetsWithPathPattern;
     List<String> options;
 
     public Long getRepositoryId() {
@@ -30,11 +35,11 @@ public class ThirdPartySyncJobInput {
         this.thirdPartyProjectId = thirdPartyProjectId;
     }
 
-    public List<ThirdPartyService.Action> getActions() {
+    public List<ThirdPartySyncAction> getActions() {
         return actions;
     }
 
-    public void setActions(List<ThirdPartyService.Action> actions) {
+    public void setActions(List<ThirdPartySyncAction> actions) {
         this.actions = actions;
     }
 
@@ -52,6 +57,22 @@ public class ThirdPartySyncJobInput {
 
     public void setLocaleMapping(String localeMapping) {
         this.localeMapping = localeMapping;
+    }
+
+    public String getSkipTextUnitsWithPattern() {
+        return skipTextUnitsWithPattern;
+    }
+
+    public void setSkipTextUnitsWithPattern(String skipTextUnitsWithPattern) {
+        this.skipTextUnitsWithPattern = skipTextUnitsWithPattern;
+    }
+
+    public String getSkipAssetsWithPathPattern() {
+        return skipAssetsWithPathPattern;
+    }
+
+    public void setSkipAssetsWithPathPattern(String skipAssetsWithPathPattern) {
+        this.skipAssetsWithPathPattern = skipAssetsWithPathPattern;
     }
 
     public List<String> getOptions() {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
@@ -5,7 +5,8 @@ import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.Screenshot;
 import com.box.l10n.mojito.entity.ScreenshotRun;
 import com.box.l10n.mojito.entity.ThirdPartyScreenshot;
-import com.box.l10n.mojito.okapi.asset.UnsupportedAssetFilterTypeException;
+import com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction;
+import com.box.l10n.mojito.rest.thirdparty.ThirdPartySync;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
@@ -122,7 +123,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void mapMojitoAndThirdPartyTextUnits() throws RepositoryNameAlreadyUsedException, InterruptedException, ExecutionException, UnsupportedAssetFilterTypeException, IOException {
+    public void mapMojitoAndThirdPartyTextUnits() throws InterruptedException, ExecutionException {
 
         ThirdPartyServiceTestData thirdPartyServiceTestData = new ThirdPartyServiceTestData(testIdWatcher);
         Repository repository = thirdPartyServiceTestData.repository;
@@ -139,9 +140,15 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         doNothing().when(thirdPartyTMSMock).createImageToTextUnitMappings(any(), any());
 
         logger.debug("Invoke function to test");
-        thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(repository.getId(), projectId,
-                Arrays.asList(ThirdPartyService.Action.MAP_TEXTUNIT, ThirdPartyService.Action.PUSH_SCREENSHOT),
-                " _", null, new ArrayList<>()).get();
+
+        ThirdPartySync thirdPartySync = new ThirdPartySync();
+        thirdPartySync.setRepositoryId(repository.getId());
+        thirdPartySync.setProjectId(projectId);
+        thirdPartySync.setActions(Arrays.asList(ThirdPartySyncAction.MAP_TEXTUNIT, ThirdPartySyncAction.PUSH_SCREENSHOT));
+        thirdPartySync.setPluralSeparator(" _");
+        thirdPartySync.setOptions(new ArrayList<>());
+
+        thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(thirdPartySync).get();
 
         logger.debug("Verify states");
         thirdPartyTextUnitRepository.findAll().stream()
@@ -226,9 +233,15 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         doNothing().when(thirdPartyTMSMock).createImageToTextUnitMappings(any(), any());
 
         logger.debug("Invoke function to test");
-        thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(repository.getId(), projectId,
-                Arrays.asList(ThirdPartyService.Action.MAP_TEXTUNIT),
-                " _", null, new ArrayList<>()).get();
+
+        ThirdPartySync thirdPartySync = new ThirdPartySync();
+        thirdPartySync.setRepositoryId(repository.getId());
+        thirdPartySync.setProjectId(projectId);
+        thirdPartySync.setActions(Arrays.asList(ThirdPartySyncAction.MAP_TEXTUNIT));
+        thirdPartySync.setPluralSeparator(" _");
+        thirdPartySync.setOptions(new ArrayList<>());
+
+        thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(thirdPartySync).get();
 
         logger.debug("Verify states");
         thirdPartyTextUnitRepository.findAll().stream()
@@ -249,9 +262,12 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         assertEquals("3rd-hello", thirdPartyTextUnits.get(0).getThirdPartyId());
 
         logger.debug("Invoke function to test - duplicate name");
-        thirdPartyService.asyncSyncMojitoWithThirdPartyTMS(repository.getId(), projectId,
-                Arrays.asList(ThirdPartyService.Action.MAP_TEXTUNIT),
-                " _", null, new ArrayList<>()).get();
+        thirdPartySync = new ThirdPartySync();
+        thirdPartySync.setRepositoryId(repository.getId());
+        thirdPartySync.setProjectId(projectId);
+        thirdPartySync.setActions(Arrays.asList(ThirdPartySyncAction.MAP_TEXTUNIT));
+        thirdPartySync.setPluralSeparator(" _");
+        thirdPartySync.setOptions(new ArrayList<>());
 
         logger.debug("Verify states - duplicate name");
         thirdPartyTextUnits = thirdPartyTextUnitRepository.findAll().stream()

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJobInputTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJobInputTest.java
@@ -1,0 +1,113 @@
+package com.box.l10n.mojito.service.thirdparty;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.rest.thirdparty.ThirdPartySyncAction;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThirdPartySyncJobInputTest {
+
+    @Test
+    public void testBackwardsCompatibility() {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        // The old representation of the ThirdPartySyncJobInput class
+        Long repositoryId = 120L;
+        String thirdPartyProjectId = "0p9o8i7u";
+        String localeMapping = "tr:tr-TR";
+        String pluralSeparator = " _";
+        List<ThirdPartySyncAction> actions = Arrays.asList(ThirdPartySyncAction.MAP_TEXTUNIT, ThirdPartySyncAction.PULL);
+        List<String> options = Arrays.asList(
+                "smartling-placeholder=CUSTOM",
+                "smartling-placeholder-custom=\\{\\{\\}\\}|\\{\\{?.+?\\}\\}?|\\%\\%\\(.+?\\)s|\\%\\(.+?\\)s|\\%\\(.+?\\)d|\\%\\%s|\\%s");
+
+        TPSyncJobInput oldInput = new TPSyncJobInput();
+        oldInput.setRepositoryId(repositoryId);
+        oldInput.setThirdPartyProjectId(thirdPartyProjectId);
+        oldInput.setActions(actions);
+        oldInput.setPluralSeparator(pluralSeparator);
+        oldInput.setLocaleMapping(localeMapping);
+        oldInput.setOptions(options);
+
+        String oldRes = objectMapper.writeValueAsStringUnchecked(oldInput);
+
+        ThirdPartySyncJobInput input = objectMapper.readValueUnchecked(oldRes, ThirdPartySyncJobInput.class);
+        assertThat(input).isNotNull();
+        assertThat(input.getRepositoryId()).isEqualTo(repositoryId);
+        assertThat(input.getThirdPartyProjectId()).isEqualTo(thirdPartyProjectId);
+        //assertThat(input.getActions()).conta(actions);
+        assertThat(input.getPluralSeparator()).isEqualTo(pluralSeparator);
+        assertThat(input.getLocaleMapping()).isEqualTo(localeMapping);
+        assertThat(input.getOptions()).containsExactlyInAnyOrderElementsOf(options);
+        assertThat(input.getSkipTextUnitsWithPattern()).isNull();
+        assertThat(input.getSkipAssetsWithPathPattern()).isNull();
+    }
+
+    /**
+     * Copy of the signature of the {@link ThirdPartySyncJobInput} class before we introduced new parameters to it
+     */
+    private static class TPSyncJobInput {
+
+        Long repositoryId;
+        String thirdPartyProjectId;
+        List<ThirdPartySyncAction> actions;
+        String pluralSeparator;
+        String localeMapping;
+        List<String> options;
+
+        public Long getRepositoryId() {
+            return repositoryId;
+        }
+
+        public void setRepositoryId(Long repositoryId) {
+            this.repositoryId = repositoryId;
+        }
+
+        public String getThirdPartyProjectId() {
+            return thirdPartyProjectId;
+        }
+
+        public void setThirdPartyProjectId(String thirdPartyProjectId) {
+            this.thirdPartyProjectId = thirdPartyProjectId;
+        }
+
+        public List<ThirdPartySyncAction> getActions() {
+            return actions;
+        }
+
+        public void setActions(List<ThirdPartySyncAction> actions) {
+            this.actions = actions;
+        }
+
+        public String getPluralSeparator() {
+            return pluralSeparator;
+        }
+
+        public void setPluralSeparator(String pluralSeparator) {
+            this.pluralSeparator = pluralSeparator;
+        }
+
+        public String getLocaleMapping() {
+            return localeMapping;
+        }
+
+        public void setLocaleMapping(String localeMapping) {
+            this.localeMapping = localeMapping;
+        }
+
+        public List<String> getOptions() {
+            return options;
+        }
+
+        public void setOptions(List<String> options) {
+            this.options = options;
+        }
+    }
+}


### PR DESCRIPTION
To implement the `PULL`, `PUSH` and `PUSH_TRANSLATIONS` commands in `ThirdPartyService`, we need to update `ThirdPartySyncCommand` and several dependencies to utilize these new parameters: `--skip-text-units-with-pattern` and `--skip-assets-path-pattern`.

Please note the TODO added to `ThirdPartySyncCommandTest` and documented in #612