### PR TITLE
Updating JCommander to 1.78

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.48</version>
+            <version>1.78</version>
         </dependency>
 
         <dependency>

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
@@ -194,7 +194,7 @@ public class L10nJCommander {
      */
     public void usage(String commandName) {
         StringBuilder stringBuilder = new StringBuilder();
-        jCommander.usage(commandName, stringBuilder, "");
+        jCommander.getUsageFormatter().usage(commandName, stringBuilder, "");
         consoleWriter.a(stringBuilder).println();
     }
 
@@ -206,7 +206,8 @@ public class L10nJCommander {
         logger.debug("Create JCommander instance");
         jCommander = new JCommander();
 
-        jCommander.setAcceptUnknownOptions(true);
+        // TODO: Cant enable this until https://github.com/cbeust/jcommander/issues/377 is fixed
+        // jCommander.setAcceptUnknownOptions(true);
 
         logger.debug("Initialize the JCommander instance");
         jCommander.setProgramName(PROGRAM_NAME);

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/DropImportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/DropImportCommandTest.java
@@ -119,7 +119,7 @@ public class DropImportCommandTest extends CLITestBase {
 
         localizeDropFiles(dropRepository.findById(dropId).orElse(null));
 
-        l10nJCommander.run(new String[]{"drop-import", "-r", repository.getName(), "--number-drop-fetched", "1000"});
+        l10nJCommander.run(new String[]{"drop-import", "-r", repository.getName(), "--number-drops-fetched", "1000"});
 
         int numberOfFrenchTranslationsAfter = getNumberOfFrenchTranslations(repository);
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
@@ -345,7 +345,6 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
 
         getL10nJCommander().run("push", "-r", repository.getName(),
                 "-s", getInputResourcesTestDir("source").getAbsolutePath(),
-                "-t", getInputResourcesTestDir("translations").getAbsolutePath(),
                 "-ft", "XCODE_XLIFF");
 
         getL10nJCommander().run("import", "-r", repository.getName(),

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
@@ -58,11 +58,7 @@ public class ThirdPartySyncCommandTest extends CLITestBase {
         Repository repository = repositoryService.createRepository(repoName, repoName + " description", null, false);
         String projectId = testIdWatcher.getEntityName("projectId");
 
-        // TODO: For a plural separator like " _" this test will fail. The current version we have for
-        //  JCommander trims the argument values, even when quoted.
-        // https://github.com/cbeust/jcommander/issues/417
-        // https://github.com/cbeust/jcommander/commit/4aec38b4a0ea63a8dc6f41636fa81c2ebafddc18
-        String pluralSeparator = "_";
+        String pluralSeparator = " _";
         String skipTextUnitPattern = "%skip_text_pattern";
         String skipAssetPattern = "%skip_asset_pattern%";
         List<String> options = Arrays.asList(


### PR DESCRIPTION
Fixes #612 

There's a known issue with `jCommander.setAcceptUnknownOptions(true)`, described [here](https://github.com/cbeust/jcommander/issues/377). Disabling that option and updating tests that were using unknown parameters helped to get a green build.