### PR TITLE
Adding MDC parameters to QuartzPollableJob and ThirdPartyService

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableJob.java
@@ -12,6 +12,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -55,7 +56,7 @@ public abstract class QuartzPollableJob<I, O> implements Job {
 
         ExceptionHolder exceptionHolder = new ExceptionHolder(currentPollableTask);
 
-        try {
+        try (MDC.MDCCloseable closeable = MDC.putCloseable(POLLABLE_TASK_ID, pollableTaskId.toString())) {
             I callInput;
 
             String inputStringFromJob = context.getMergedJobDataMap().getString(INPUT);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -26,6 +26,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,6 +50,8 @@ import static java.util.stream.Collectors.toList;
 @Component
 public class ThirdPartyService {
 
+    public static final String REPOSITORY_ID = "repositoryId";
+    public static final String THIRD_PARTY_PROJECT_ID = "thirdPartyProjectId";
     static Logger logger = LoggerFactory.getLogger(ThirdPartyService.class);
 
     @Autowired
@@ -107,24 +110,29 @@ public class ThirdPartyService {
                                      String skipTextUnitsWithPattern,
                                      String skipAssetsWithPathPattern,
                                      List<String> options) {
-        logger.debug("thirdparty TMS: {}", thirdPartyTMS);
 
-        Repository repository = repositoryRepository.findById(repositoryId).orElse(null);
+        try (MDC.MDCCloseable repoCloseable = MDC.putCloseable(REPOSITORY_ID, repositoryId.toString());
+             MDC.MDCCloseable projectCloseable = MDC.putCloseable(THIRD_PARTY_PROJECT_ID, thirdPartyProjectId)) {
 
-        if (actions.contains(ThirdPartySyncAction.PUSH)) {
-            throw new UnsupportedOperationException();
-        }
-        if (actions.contains(ThirdPartySyncAction.PUSH_TRANSLATION)) {
-            throw new UnsupportedOperationException();
-        }
-        if (actions.contains(ThirdPartySyncAction.PULL)) {
-            throw new UnsupportedOperationException();
-        }
-        if (actions.contains(ThirdPartySyncAction.MAP_TEXTUNIT)) {
-            mapMojitoAndThirdPartyTextUnits(repository, thirdPartyProjectId);
-        }
-        if (actions.contains(ThirdPartySyncAction.PUSH_SCREENSHOT)) {
-            uploadScreenshotsAndCreateMappings(repository, thirdPartyProjectId);
+            logger.debug("thirdparty TMS: {}", thirdPartyTMS);
+
+            Repository repository = repositoryRepository.findById(repositoryId).orElse(null);
+
+            if (actions.contains(ThirdPartySyncAction.PUSH)) {
+                throw new UnsupportedOperationException();
+            }
+            if (actions.contains(ThirdPartySyncAction.PUSH_TRANSLATION)) {
+                throw new UnsupportedOperationException();
+            }
+            if (actions.contains(ThirdPartySyncAction.PULL)) {
+                throw new UnsupportedOperationException();
+            }
+            if (actions.contains(ThirdPartySyncAction.MAP_TEXTUNIT)) {
+                mapMojitoAndThirdPartyTextUnits(repository, thirdPartyProjectId);
+            }
+            if (actions.contains(ThirdPartySyncAction.PUSH_SCREENSHOT)) {
+                uploadScreenshotsAndCreateMappings(repository, thirdPartyProjectId);
+            }
         }
     }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableJobTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/quartz/QuartzPollableJobTest.java
@@ -1,0 +1,90 @@
+package com.box.l10n.mojito.quartz;
+
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.box.l10n.mojito.entity.PollableTask;
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import com.box.l10n.mojito.service.pollableTask.PollableTaskRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+import static com.box.l10n.mojito.quartz.QuartzPollableJob.INPUT;
+import static com.box.l10n.mojito.quartz.QuartzPollableJob.POLLABLE_TASK_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QuartzPollableJobTest extends ServiceTestBase {
+
+    @Autowired
+    AutowireCapableBeanFactory beanFactory;
+
+    @Autowired
+    PollableTaskRepository pollableTaskRepository;
+
+    @Autowired
+    @Qualifier("fail_on_unknown_properties_false")
+    ObjectMapper objectMapper;
+
+    JobExecutionContext context;
+    JobDataMap dataMap;
+    StubPollableJob job;
+    PollableTask pollableTask;
+
+    @Before
+    public void setUp() {
+        job = new StubPollableJob();
+        beanFactory.autowireBean(job);
+
+        pollableTask = new PollableTask();
+        pollableTask.setName("Name");
+        pollableTask.setMessage("Message");
+        pollableTask = pollableTaskRepository.save(pollableTask);
+
+        dataMap = new JobDataMap();
+        dataMap.put(POLLABLE_TASK_ID, pollableTask.getId());
+        dataMap.put(INPUT, objectMapper.writeValueAsStringUnchecked(""));
+
+        // We dont really need to build a real-world JobExecutionContext
+        context = mock(JobExecutionContext.class);
+        when(context.getMergedJobDataMap()).thenReturn(dataMap);
+    }
+
+    @Test
+    public void testPollableTaskMDCKeyIsAdded() throws Exception {
+
+        // Intercept the QuartzPollableJob logger to fetch events added to it
+        Logger jobLogger = (Logger) LoggerFactory.getLogger(QuartzPollableJob.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        jobLogger.addAppender(listAppender);
+        jobLogger.setLevel(Level.ALL);
+
+        job.execute(context);
+
+        assertThat(listAppender.list).isNotEmpty();
+        assertThat(listAppender.list).allSatisfy(event -> {
+            assertThat(event.getMDCPropertyMap()).containsKeys(POLLABLE_TASK_ID);
+            assertThat(event.getMDCPropertyMap().get(POLLABLE_TASK_ID)).isEqualTo(pollableTask.getId().toString());
+        });
+    }
+
+    private static class StubPollableJob extends QuartzPollableJob<String, String> {
+
+        @Override
+        public String call(String input) {
+            return input;
+        }
+    }
+
+}


### PR DESCRIPTION
This change adds MDC parameters to be shown in the log events appended by the changed class loggers. This will allow easy discoverability when debugging. This is an example of the log event produced by the `ThirdPartyService`:

```json
{
  "@timestamp": "2020-07-28T21:18:41.781Z",
  "@version": "1",
  "message": "thirdparty TMS: thirdPartyTMSMock",
  "logger_name": "com.box.l10n.mojito.service.thirdparty.ThirdPartyService",
  "thread_name": "main",
  "level": "DEBUG",
  "level_value": 10000,
  "thirdPartyProjectId": "someProjectIdForTest",
  "repositoryId": "123"
}
```