### PR TITLE
New search criterions for TextUnitSearcher

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/NativeNotILikeExp.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/nativecriteria/NativeNotILikeExp.java
@@ -1,0 +1,45 @@
+package com.box.l10n.mojito.nativecriteria;
+
+import com.github.pnowy.nc.core.NativeQuery;
+import com.github.pnowy.nc.core.expressions.NativeExp;
+import com.github.pnowy.nc.utils.Strings;
+
+/**
+ * NOT ILIKE expression.
+ */
+public class NativeNotILikeExp implements NativeExp {
+
+    private String columnName;
+    private String varName;
+    private String value;
+
+    /**
+     * @param columnName the column name
+     * @param value the value
+     */
+    public NativeNotILikeExp(String columnName, String value) {
+
+        if (Strings.isBlank(columnName)) {
+            throw new IllegalStateException("columnName is null!");
+        }
+
+        if (Strings.isBlank(value)) {
+            throw new IllegalStateException("value is null!");
+        }
+
+        this.columnName = columnName;
+        this.value = value;
+    }
+
+    @Override
+    public String toSQL() {
+        varName = VarGenerator.gen(columnName);
+        return "lower(" + columnName + ") NOT LIKE :" + varName;
+    }
+
+    @Override
+    public void setValues(NativeQuery query) {
+        query.setString(varName, value.toLowerCase());
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -1,14 +1,15 @@
 package com.box.l10n.mojito.service.tm.search;
 
-import com.box.l10n.mojito.nativecriteria.NativeContainsExp;
-import com.box.l10n.mojito.nativecriteria.NativeILikeExp;
-import com.box.l10n.mojito.nativecriteria.NativeColumnEqExp;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.nativecriteria.JpaQueryProvider;
+import com.box.l10n.mojito.nativecriteria.NativeColumnEqExp;
+import com.box.l10n.mojito.nativecriteria.NativeContainsExp;
 import com.box.l10n.mojito.nativecriteria.NativeDateGteExp;
 import com.box.l10n.mojito.nativecriteria.NativeDateLteExp;
 import com.box.l10n.mojito.nativecriteria.NativeEqExpFix;
+import com.box.l10n.mojito.nativecriteria.NativeILikeExp;
 import com.box.l10n.mojito.nativecriteria.NativeInExpFix;
+import com.box.l10n.mojito.nativecriteria.NativeNotILikeExp;
 import com.github.pnowy.nc.core.CriteriaResult;
 import com.github.pnowy.nc.core.NativeCriteria;
 import com.github.pnowy.nc.core.NativeExps;
@@ -21,8 +22,6 @@ import com.github.pnowy.nc.core.expressions.NativeOrderExp;
 import com.github.pnowy.nc.core.expressions.NativeProjection;
 import com.github.pnowy.nc.core.mappers.CriteriaResultTransformer;
 import com.google.common.base.Preconditions;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +30,9 @@ import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Text Unit searcher allows to search/build a list of translated and/or
@@ -282,6 +284,14 @@ public class TextUnitSearcher {
 
         if (searchParameters.getBranchId() != null) {
             conjunction.add(new NativeEqExpFix("atu.branch_id", searchParameters.getBranchId()));
+        }
+
+        if (searchParameters.getSkipTextUnitWithPattern() != null) {
+            conjunction.add(new NativeNotILikeExp("tu.name", searchParameters.getSkipTextUnitWithPattern()));
+        }
+
+        if (searchParameters.getSkipAssetPathWithPattern() != null) {
+            conjunction.add(new NativeNotILikeExp("a.path", searchParameters.getSkipAssetPathWithPattern()));
         }
 
         StatusFilter statusFilter = searchParameters.getStatusFilter();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -45,6 +45,8 @@ public class TextUnitSearcherParameters {
     DateTime tmTextUnitCreatedBefore;
     DateTime tmTextUnitCreatedAfter;
     Long branchId;
+    String skipTextUnitWithPattern;
+    String skipAssetPathWithPattern;
 
     public String getName() {
         return name;
@@ -280,5 +282,21 @@ public class TextUnitSearcherParameters {
         if (!filtered.isEmpty()) {
             this.tmTextUnitIds = filtered;
         }
+    }
+
+    public String getSkipTextUnitWithPattern() {
+        return skipTextUnitWithPattern;
+    }
+
+    public void setSkipTextUnitWithPattern(String skipTextUnitWithPattern) {
+        this.skipTextUnitWithPattern = skipTextUnitWithPattern;
+    }
+
+    public String getSkipAssetPathWithPattern() {
+        return skipAssetPathWithPattern;
+    }
+
+    public void setSkipAssetPathWithPattern(String skipAssetPathWithPattern) {
+        this.skipAssetPathWithPattern = skipAssetPathWithPattern;
     }
 }


### PR DESCRIPTION
Adding new search criterions on the `TextUnitSearcherParameters` class to allow filtering through the `tm_text_unit.name` and the `asset.path` columns. Both of them will compare using a `lowercase(:column_name:) NOT LIKE 'pattern'` to filter down either text units or assets matching the pattern being passed to `TextUnitSearcher`.