### PR TITLE
Maven frontend plugin update

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -70,7 +70,7 @@
     "mojito-drop-export": "java -jar ../cli/target/mojito-cli-*.jar drop-export -r Mojito",
     "mojito-drop-import": "java -jar ../cli/target/mojito-cli-*.jar drop-import -r Mojito",
     "create-demo-data": "java -jar ../cli/target/mojito-cli-*-exec.jar demo-create -n Demo",
-    "preinstall": "npx npm-force-resolutions"
+    "preinstall": "if type npx >/dev/null 2>&1; then npx npm-force-resolutions; fi"
   },
   "resolutions": {
     "kind-of": "^6.0.3",

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <start-class>com.box.l10n.mojito.Application</start-class>
-        <frontend.maven.plugin.version>1.8.0</frontend.maven.plugin.version>
+        <frontend.maven.plugin.version>1.10.0</frontend.maven.plugin.version>
         <node.version>v8.8.1</node.version>
         <npm.version>6.11.3</npm.version>
     </properties>
@@ -509,6 +509,18 @@
                                 <configuration>
                                     <nodeVersion>${node.version}</nodeVersion>
                                     <npmVersion>${npm.version}</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npx force resolutions</id>
+                                <goals>
+                                    <goal>npx</goal>
+                                </goals>
+
+                                <phase>generate-resources</phase>
+
+                                <configuration>
+                                    <arguments>npm-force-resolutions</arguments>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Enabling `npx npm-force-resolutions` to be run from maven in case the `preinstall` phase for `npm` fails.