### PR TITLE
Add tmTextUnitId to plurals in AndroidDocumentWriter

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentWriter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentWriter.java
@@ -105,6 +105,7 @@ public class AndroidStringDocumentWriter {
         Element element = addChild(node, PLURAL_ITEM_ELEMENT_NAME);
         setContent(element, item.getContent());
         setQuantityAttribute(element, item.getQuantity());
+        setIdAttribute(element, item.getId().toString());
     }
 
     private void addComment(Node node, String comment){

--- a/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentReaderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentReaderTest.java
@@ -10,6 +10,7 @@ import static com.box.l10n.mojito.android.strings.AndroidPluralQuantity.MANY;
 import static com.box.l10n.mojito.android.strings.AndroidPluralQuantity.ONE;
 import static com.box.l10n.mojito.android.strings.AndroidPluralQuantity.OTHER;
 import static com.box.l10n.mojito.android.strings.AndroidPluralQuantity.TWO;
+import static com.box.l10n.mojito.android.strings.AndroidPluralQuantity.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AndroidStringDocumentReaderTest {
@@ -140,12 +141,12 @@ public class AndroidStringDocumentReaderTest {
                 + "<!--testing plural-->\n"
                 + "<plurals name=\"pins\">\n"
                 + "<!--testing plural-->\n"
-                + "<item quantity=\"zero\">0 Pin</item>\n"
-                + "<item quantity=\"one\">1 Pin</item>\n"
-                + "<item quantity=\"two\" tmTextUnitId=\"20\">2 Pins</item>\n"
-                + "<item quantity=\"few\">3 Pins</item>\n"
-                + "<item quantity=\"many\">4 Pins</item>\n"
-                + "<item quantity=\"other\">{num_pins} Pins</item>\n"
+                + "<item quantity=\"zero\" tmTextUnitId=\"100\">0 Pins</item>\n"
+                + "<item quantity=\"one\" tmTextUnitId=\"101\">1 Pin</item>\n"
+                + "<item quantity=\"two\" tmTextUnitId=\"102\">2 Pins</item>\n"
+                + "<item quantity=\"few\" tmTextUnitId=\"103\">3 Pins</item>\n"
+                + "<item quantity=\"many\" tmTextUnitId=\"104\">4 Pins</item>\n"
+                + "<item quantity=\"other\" tmTextUnitId=\"105\">{num_pins} Pins</item>\n"
                 + "</plurals>\n"
                 + "</resources>";
 
@@ -160,15 +161,17 @@ public class AndroidStringDocumentReaderTest {
         assertThat(plural.getComment()).isEqualTo("testing plural");
         assertThat(plural.getName()).isEqualTo("pins");
         assertThat(plural.getItems()).hasSize(6);
-        assertThat(plural.getItems().get(ONE).getId()).isNull();
+        assertThat(plural.getItems().get(ZERO).getId()).isEqualTo(100L);
+        assertThat(plural.getItems().get(ZERO).getContent()).isEqualTo("0 Pins");
+        assertThat(plural.getItems().get(ONE).getId()).isEqualTo(101L);
         assertThat(plural.getItems().get(ONE).getContent()).isEqualTo("1 Pin");
-        assertThat(plural.getItems().get(TWO).getId()).isEqualTo(20L);
+        assertThat(plural.getItems().get(TWO).getId()).isEqualTo(102L);
         assertThat(plural.getItems().get(TWO).getContent()).isEqualTo("2 Pins");
-        assertThat(plural.getItems().get(FEW).getId()).isNull();
+        assertThat(plural.getItems().get(FEW).getId()).isEqualTo(103L);
         assertThat(plural.getItems().get(FEW).getContent()).isEqualTo("3 Pins");
-        assertThat(plural.getItems().get(MANY).getId()).isNull();
+        assertThat(plural.getItems().get(MANY).getId()).isEqualTo(104L);
         assertThat(plural.getItems().get(MANY).getContent()).isEqualTo("4 Pins");
-        assertThat(plural.getItems().get(OTHER).getId()).isNull();
+        assertThat(plural.getItems().get(OTHER).getId()).isEqualTo(105L);
         assertThat(plural.getItems().get(OTHER).getContent()).isEqualTo("{num_pins} Pins");
     }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentWriterTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidStringDocumentWriterTest.java
@@ -143,13 +143,13 @@ public class AndroidStringDocumentWriterTest {
                 "<string name=\"string1\" tmTextUnitId=\"10\">string1 @ content</string>\n" +
                 "<!--plural1 @ comment-->\n" +
                 "<plurals name=\"plural1\">\n" +
-                "<item quantity=\"one\">One item</item>\n" +
-                "<item quantity=\"other\">{more} items</item>\n" +
+                "<item quantity=\"one\" tmTextUnitId=\"20\">One item</item>\n" +
+                "<item quantity=\"other\" tmTextUnitId=\"21\">{more} items</item>\n" +
                 "</plurals>\n" +
                 "<!--plural2 @ comment-->\n" +
                 "<plurals name=\"plural2\">\n" +
-                "<item quantity=\"one\">One test</item>\n" +
-                "<item quantity=\"other\">{more} tests</item>\n" +
+                "<item quantity=\"one\" tmTextUnitId=\"22\">One test</item>\n" +
+                "<item quantity=\"other\" tmTextUnitId=\"23\">{more} tests</item>\n" +
                 "</plurals>\n" +
                 "</resources>\n";
 
@@ -181,15 +181,15 @@ public class AndroidStringDocumentWriterTest {
                 "<string name=\"string1\" tmTextUnitId=\"10\">string1 @ content</string>\n" +
                 "<!--plural1 @ comment-->\n" +
                 "<plurals name=\"plural1\">\n" +
-                "<item quantity=\"one\">One item</item>\n" +
-                "<item quantity=\"other\">{more} items</item>\n" +
+                "<item quantity=\"one\" tmTextUnitId=\"20\">One item</item>\n" +
+                "<item quantity=\"other\" tmTextUnitId=\"21\">{more} items</item>\n" +
                 "</plurals>\n" +
                 "<!--test comment2-->\n" +
                 "<string name=\"string2\" tmTextUnitId=\"11\">string2 @ content</string>\n" +
                 "<!--plural2 @ comment-->\n" +
                 "<plurals name=\"plural2\">\n" +
-                "<item quantity=\"one\">One test</item>\n" +
-                "<item quantity=\"other\">{more} tests</item>\n" +
+                "<item quantity=\"one\" tmTextUnitId=\"22\">One test</item>\n" +
+                "<item quantity=\"other\" tmTextUnitId=\"23\">{more} tests</item>\n" +
                 "</plurals>\n" +
                 "</resources>\n";
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -324,7 +324,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 repository.getName() + "/00000_plural_source.xml");
         assertThat(result.stream().map(SmartlingFile::getFileContent)).containsOnly(
                 singularContent(testData),
-                pluralsContent());
+                pluralsContent(testData));
         verifyNoInteractions(smartlingClient);
     }
 
@@ -345,7 +345,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 repository.getName() + "/00000_plural_source.xml");
         assertThat(result.stream().map(SmartlingFile::getFileContent)).containsOnly(
                 singularContent(testData),
-                pluralsContent());
+                pluralsContent(testData));
 
         verify(smartlingClient, times(1)).uploadFile(
                 eq("projectId"),
@@ -532,9 +532,9 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         doReturn(singularContent(testData)).when(smartlingClient).downloadPublishedFile(eq("projectId"), eq(jaJP.getBcp47Tag()),
                 eq(singularFileName(repository, 0)), eq(false));
 
-        doReturn(pluralsContent()).when(smartlingClient).downloadPublishedFile(eq("projectId"), eq(frCA.getBcp47Tag()),
+        doReturn(pluralsContent(testData)).when(smartlingClient).downloadPublishedFile(eq("projectId"), eq(frCA.getBcp47Tag()),
                 eq(pluralFileName(repository, 0)), eq(false));
-        doReturn(pluralsContent()).when(smartlingClient).downloadPublishedFile(eq("projectId"), eq(jaJP.getBcp47Tag()),
+        doReturn(pluralsContent(testData)).when(smartlingClient).downloadPublishedFile(eq("projectId"), eq(jaJP.getBcp47Tag()),
                 eq(pluralFileName(repository, 0)), eq(false));
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
@@ -1148,15 +1148,15 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 "</resources>\n";
     }
 
-    public String pluralsContent() {
+    public String pluralsContent(ThirdPartyServiceTestData testData) {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?><resources>\n" +
                 "<plurals name=\"src/main/res/values/strings.xml#@#plural_things\">\n" +
-                "<item quantity=\"zero\">Multiple things</item>\n" +
-                "<item quantity=\"one\">One thing</item>\n" +
-                "<item quantity=\"two\">Multiple things</item>\n" +
-                "<item quantity=\"few\">Multiple things</item>\n" +
-                "<item quantity=\"many\">Multiple things</item>\n" +
-                "<item quantity=\"other\">Multiple things</item>\n" +
+                "<item quantity=\"zero\" tmTextUnitId=\"" + testData.tmTextUnitPluralThingsZero.getId() +"\">Multiple things</item>\n" +
+                "<item quantity=\"one\" tmTextUnitId=\"" + testData.tmTextUnitPluralThingsOne.getId() +"\">One thing</item>\n" +
+                "<item quantity=\"two\" tmTextUnitId=\"" + testData.tmTextUnitPluralThingsTwo.getId() +"\">Multiple things</item>\n" +
+                "<item quantity=\"few\" tmTextUnitId=\"" + testData.tmTextUnitPluralThingsFew.getId() +"\">Multiple things</item>\n" +
+                "<item quantity=\"many\" tmTextUnitId=\"" + testData.tmTextUnitPluralThingsMany.getId() +"\">Multiple things</item>\n" +
+                "<item quantity=\"other\" tmTextUnitId=\"" + testData.tmTextUnitPluralThingsOther.getId() +"\">Multiple things</item>\n" +
                 "</plurals>\n" +
                 "</resources>\n";
     }


### PR DESCRIPTION
Adding the `tmTextUnitId` attribute to plurals as we weren't writing them in the `AndroidDocumentWriter` class.