### PR TITLE
Adding missing attributes in for ThirdPartySync PULL

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -223,24 +223,25 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
                      List<String> optionList) {
 
         SmartlingOptions options = SmartlingOptions.parseList(optionList);
-        AndroidStringDocumentMapper mapper = new AndroidStringDocumentMapper(pluralSeparator, null);
 
         Long singulars = singularCount(repository.getId(), LOCALE_EN, skipTextUnitsWithPattern, skipAssetsWithPathPattern);
         LongStream.range(0, batchesFor(singulars))
-                  .forEach(num -> processPullBatch(num, mapper, repository, projectId, options, localeMapping, Prefix.SINGULAR));
+                  .forEach(num -> processPullBatch(num, pluralSeparator, repository, projectId, options, localeMapping, Prefix.SINGULAR));
 
         Long plurals = pluralCount(repository.getId(), LOCALE_EN, skipTextUnitsWithPattern, skipAssetsWithPathPattern);
         LongStream.range(0, batchesFor(plurals))
-                  .forEach(num -> processPullBatch(num, mapper, repository, projectId, options, localeMapping, Prefix.PLURAL));
+                  .forEach(num -> processPullBatch(num, pluralSeparator, repository, projectId, options, localeMapping, Prefix.PLURAL));
     }
 
     private void processPullBatch(Long batchNumber,
-                                  AndroidStringDocumentMapper mapper,
+                                  String pluralSeparator,
                                   Repository repository,
                                   String projectId,
                                   SmartlingOptions options,
                                   Map<String, String> localeMapping,
                                   Prefix filePrefix) {
+
+        AndroidStringDocumentMapper mapper;
 
         for (RepositoryLocale locale : repository.getRepositoryLocales()) {
 
@@ -251,6 +252,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
             String localeTag = locale.getLocale().getBcp47Tag();
             String smartlingLocale = getSmartlingLocale(localeMapping, localeTag);
             String fileName = getOutputSourceFile(batchNumber, repository.getName(), filePrefix.getType());
+            mapper = new AndroidStringDocumentMapper(pluralSeparator, null, localeTag, repository.getName());
 
             logger.debug("Download localized file from Smartling for file: {}, Mojito locale: {} and Smartling locale: {}",
                     fileName, localeTag, smartlingLocale);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingPluralFix.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingPluralFix.java
@@ -25,6 +25,10 @@ public final class SmartlingPluralFix {
                     tu.setPluralForm("many");
                     tu.setPluralFormOther(textUnit.getPluralFormOther());
                     tu.setTarget(textUnit.getTarget());
+                    tu.setRepositoryName(textUnit.getRepositoryName());
+                    tu.setAssetPath(textUnit.getAssetPath());
+                    tu.setTargetLocale(textUnit.getTargetLocale());
+
                     return tu;
                 });
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -395,23 +395,24 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         List<List<TextUnitDTO>> captured = textUnitListCaptor.getAllValues();
 
+        String assetPath = "src/main/res/values/strings.xml";
         assertThat(captured.subList(0,2).stream().flatMap(List::stream))
-                .extracting("name", "comment", "target", "assetPath")
+                .extracting("name", "comment", "target", "assetPath", "targetLocale", "repositoryName")
                 .containsExactlyInAnyOrder(
-                        tuple("hello", "comment 1", "Hello in ja-JP", "src/main/res/values/strings.xml"),
-                        tuple("bye", "comment 2", "Bye in ja-JP", "src/main/res/values/strings.xml"),
-                        tuple("hello", "comment 1", "Hello in fr-CA", "src/main/res/values/strings.xml"),
-                        tuple("bye", "comment 2", "Bye in fr-CA", "src/main/res/values/strings.xml"));
+                        tuple("hello", "comment 1", "Hello in ja-JP", assetPath, "ja-JP", repository.getName()),
+                        tuple("bye", "comment 2", "Bye in ja-JP", assetPath, "ja-JP", repository.getName()),
+                        tuple("hello", "comment 1", "Hello in fr-CA", assetPath, "fr-CA", repository.getName()),
+                        tuple("bye", "comment 2", "Bye in fr-CA", assetPath, "fr-CA", repository.getName()));
 
         assertThat(captured.subList(2,4).stream().flatMap(List::stream))
-                .extracting("name", "target", "pluralForm")
+                .extracting("name", "target", "pluralForm", "assetPath", "targetLocale", "repositoryName")
                 .containsExactlyInAnyOrder(
-                        tuple("plural_things _one", "One thing in ja-JP", "one"),
-                        tuple("plural_things _few", "Few things in ja-JP", "few"),
-                        tuple("plural_things _other", "Other things in ja-JP", "other"),
-                        tuple("plural_things _one", "One thing in fr-CA", "one"),
-                        tuple("plural_things _few", "Few things in fr-CA", "few"),
-                        tuple("plural_things _other", "Other things in fr-CA", "other"));
+                        tuple("plural_things _one", "One thing in ja-JP", "one", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _few", "Few things in ja-JP", "few", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _other", "Other things in ja-JP", "other", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _one", "One thing in fr-CA", "one", assetPath, "fr-CA", repository.getName()),
+                        tuple("plural_things _few", "Few things in fr-CA", "few", assetPath, "fr-CA", repository.getName()),
+                        tuple("plural_things _other", "Other things in fr-CA", "other", assetPath, "fr-CA", repository.getName()));
     }
 
     @Test
@@ -446,23 +447,24 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         List<List<TextUnitDTO>> captured = textUnitListCaptor.getAllValues();
 
+        String assetPath = "src/main/res/values/strings.xml";
         assertThat(captured.subList(0,2).stream().flatMap(List::stream))
-                .extracting("name", "comment", "target", "assetPath")
+                .extracting("name", "comment", "target", "assetPath", "targetLocale", "repositoryName")
                 .containsExactlyInAnyOrder(
-                        tuple("hello", "comment 1", "Hello in ja-JP", "src/main/res/values/strings.xml"),
-                        tuple("bye", "comment 2", "Bye in ja-JP", "src/main/res/values/strings.xml"),
-                        tuple("hello", "comment 1", "Hello in fr", "src/main/res/values/strings.xml"),
-                        tuple("bye", "comment 2", "Bye in fr", "src/main/res/values/strings.xml"));
+                        tuple("hello", "comment 1", "Hello in ja-JP", assetPath, "ja-JP", repository.getName()),
+                        tuple("bye", "comment 2", "Bye in ja-JP", assetPath, "ja-JP", repository.getName()),
+                        tuple("hello", "comment 1", "Hello in fr", assetPath, "fr-CA", repository.getName()),
+                        tuple("bye", "comment 2", "Bye in fr", assetPath, "fr-CA", repository.getName()));
 
         assertThat(captured.subList(2,4).stream().flatMap(List::stream))
-                .extracting("name", "target", "pluralForm")
+                .extracting("name", "target", "pluralForm", "assetPath", "targetLocale", "repositoryName")
                 .containsExactlyInAnyOrder(
-                        tuple("plural_things _one", "One thing in ja-JP", "one"),
-                        tuple("plural_things _few", "Few things in ja-JP", "few"),
-                        tuple("plural_things _other", "Other things in ja-JP", "other"),
-                        tuple("plural_things _one", "One thing in fr", "one"),
-                        tuple("plural_things _few", "Few things in fr", "few"),
-                        tuple("plural_things _other", "Other things in fr", "other"));
+                        tuple("plural_things _one", "One thing in ja-JP", "one", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _few", "Few things in ja-JP", "few", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _other", "Other things in ja-JP", "other", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _one", "One thing in fr", "one", assetPath, "fr-CA", repository.getName()),
+                        tuple("plural_things _few", "Few things in fr", "few", assetPath, "fr-CA", repository.getName()),
+                        tuple("plural_things _other", "Other things in fr", "other", assetPath, "fr-CA", repository.getName()));
     }
 
     @Test
@@ -497,13 +499,25 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         List<List<TextUnitDTO>> captured = textUnitListCaptor.getAllValues();
 
+        String assetPath = "src/main/res/values/strings.xml";
         assertThat(captured.subList(0,2).stream().flatMap(List::stream))
-                .extracting("name", "comment", "target", "assetPath")
+                .extracting("name", "comment", "target", "assetPath", "targetLocale", "repositoryName")
                 .containsExactlyInAnyOrder(
-                        tuple("hello", "comment 1", "Hello in ja-JP", "src/main/res/values/strings.xml"),
-                        tuple("bye", "comment 2", "Bye in ja-JP", "src/main/res/values/strings.xml"),
-                        tuple("hello", "comment 1", "Hello in fr-CA", "src/main/res/values/strings.xml"),
-                        tuple("bye", "comment 2", "Bye in fr-CA", "src/main/res/values/strings.xml"));
+                        tuple("hello", "comment 1", "Hello in ja-JP", assetPath, "ja-JP", repository.getName()),
+                        tuple("bye", "comment 2", "Bye in ja-JP", assetPath, "ja-JP", repository.getName()),
+                        tuple("hello", "comment 1", "Hello in fr-CA", assetPath, "fr-CA", repository.getName()),
+                        tuple("bye", "comment 2", "Bye in fr-CA", assetPath, "fr-CA", repository.getName()));
+
+        assertThat(captured.subList(2,4).stream().flatMap(List::stream))
+                .extracting("name", "target", "pluralForm", "assetPath", "targetLocale", "repositoryName")
+                .containsExactlyInAnyOrder(
+                        tuple("plural_things _one", "One thing in ja-JP", "one", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _few", "Few things in ja-JP", "few", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _other", "Other things in ja-JP", "other", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _many", "Other things in ja-JP", "many", assetPath, "ja-JP", repository.getName()),
+                        tuple("plural_things _one", "One thing in fr-CA", "one", assetPath, "fr-CA", repository.getName()),
+                        tuple("plural_things _few", "Few things in fr-CA", "few", assetPath, "fr-CA", repository.getName()),
+                        tuple("plural_things _other", "Other things in fr-CA", "other", assetPath, "fr-CA", repository.getName()));
 
         assertThat(captured.subList(2,4).stream().flatMap(List::stream))
                 .extracting("name", "target", "pluralForm")

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingPluralFixTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingPluralFixTest.java
@@ -1,7 +1,9 @@
 package com.box.l10n.mojito.service.thirdparty.smartling;
 
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.collect.ImmutableList;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
@@ -12,70 +14,89 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class SmartlingPluralFixTest {
 
+    @Rule
+    public TestIdWatcher testIdWatcher = new TestIdWatcher();
+
     @Test
     public void testFixTextUnits() {
         List<TextUnitDTO> input = ImmutableList.of();
         assertThat(fixTextUnits(input)).isEmpty();
+        String textContent = testIdWatcher.getEntityName("textContent");
 
         input = ImmutableList.of(
-                textUnit("singular1", "textContent", null, null),
-                textUnit("singular2", "textContent", null, null));
+                textUnit("singular1", textContent, null, null),
+                textUnit("singular2", textContent, null, null));
 
         assertThat(fixTextUnits(input)).containsExactlyElementsOf(input);
 
+        textContent = testIdWatcher.getEntityName("textContent2");
         input = ImmutableList.of(
-                textUnit("singular1", "textContent", null, null),
-                textUnit("singular2", "textContent", null, null),
-                textUnit("plural1_zero", "textContent", "zero", "plural1_other"),
-                textUnit("plural1_other", "textContent", "other", "plural1_other"));
+                textUnit("singular1", textContent, null, null),
+                textUnit("singular2", textContent, null, null),
+                textUnit("plural1_zero", textContent, "zero", "plural1_other"),
+                textUnit("plural1_other", textContent, "other", "plural1_other"));
 
         assertThat(fixTextUnits(input)).extracting("name", "target", "pluralForm", "pluralFormOther")
                 .containsExactlyInAnyOrder(
-                        tuple("singular1", "textContent", null, null),
-                        tuple("singular2", "textContent", null, null),
-                        tuple("plural1_zero", "textContent", "zero", "plural1_other"),
-                        tuple("plural1_many", "textContent", "many", "plural1_other"),
-                        tuple("plural1_other", "textContent", "other", "plural1_other"));
+                        tuple("singular1", textContent, null, null),
+                        tuple("singular2", textContent, null, null),
+                        tuple("plural1_zero", textContent, "zero", "plural1_other"),
+                        tuple("plural1_many", textContent, "many", "plural1_other"),
+                        tuple("plural1_other", textContent, "other", "plural1_other"));
 
+        textContent = testIdWatcher.getEntityName("textContent3");
         input = ImmutableList.of(
-                textUnit("plural1_zero", "textContent", "zero", "plural1_other"),
-                textUnit("plural1_other", "textContent", "other", "plural1_other"),
-                textUnit("plural2_zero", "textContent", "zero", null),
-                textUnit("plural2_one", "textContent", "one", null));
+                textUnit("plural1_zero", textContent, "zero", "plural1_other"),
+                textUnit("plural1_other", textContent, "other", "plural1_other"),
+                textUnit("plural2_zero", textContent, "zero", null),
+                textUnit("plural2_one", textContent, "one", null));
 
         assertThat(fixTextUnits(input)).extracting("name", "target", "pluralForm", "pluralFormOther")
                 .containsExactlyInAnyOrder(
-                        tuple("plural1_zero", "textContent", "zero", "plural1_other"),
-                        tuple("plural1_many", "textContent", "many", "plural1_other"),
-                        tuple("plural1_other", "textContent", "other", "plural1_other"),
-                        tuple("plural2_zero", "textContent", "zero", null),
-                        tuple("plural2_one", "textContent", "one", null));
+                        tuple("plural1_zero", textContent, "zero", "plural1_other"),
+                        tuple("plural1_many", textContent, "many", "plural1_other"),
+                        tuple("plural1_other", textContent, "other", "plural1_other"),
+                        tuple("plural2_zero", textContent, "zero", null),
+                        tuple("plural2_one", textContent, "one", null));
+
+        String repository = testIdWatcher.getEntityName("repository");
+        String assetPath = testIdWatcher.getEntityName("asset");
+        String targetLocale = "cz-CZ";
+        textContent = testIdWatcher.getEntityName("textContent4");
 
         input = ImmutableList.of(
-                textUnit("plural1_zero", "textContent", "zero", "plural1_other"),
-                textUnit("plural1_other", "textContent", "other", "plural1_other"),
-                textUnit("plural2_zero", "textContent", "zero", "plural2_other"),
-                textUnit("plural2_one", "textContent", "one", "plural2_other"),
-                textUnit("plural2_other", "textContent", "other", "plural2_other"));
+                textUnit("plural1_zero", textContent, "zero", "plural1_other", repository, assetPath, targetLocale),
+                textUnit("plural1_other", textContent, "other", "plural1_other", repository, assetPath, targetLocale),
+                textUnit("plural2_zero", textContent, "zero", "plural2_other", repository, assetPath, targetLocale),
+                textUnit("plural2_one", textContent, "one", "plural2_other", repository, assetPath, targetLocale),
+                textUnit("plural2_other", textContent, "other", "plural2_other", repository, assetPath, targetLocale));
 
-        assertThat(fixTextUnits(input)).extracting("name", "target", "pluralForm", "pluralFormOther")
+        assertThat(fixTextUnits(input)).extracting("name", "target", "pluralForm", "pluralFormOther", "repositoryName", "assetPath", "targetLocale")
                 .containsExactlyInAnyOrder(
-                        tuple("plural1_zero", "textContent", "zero", "plural1_other"),
-                        tuple("plural1_other", "textContent", "other", "plural1_other"),
-                        tuple("plural1_many", "textContent", "many", "plural1_other"),
-                        tuple("plural2_zero", "textContent", "zero", "plural2_other"),
-                        tuple("plural2_one", "textContent", "one", "plural2_other"),
-                        tuple("plural2_many", "textContent", "many", "plural2_other"),
-                        tuple("plural2_other", "textContent", "other", "plural2_other"));
+                        tuple("plural1_zero", textContent, "zero", "plural1_other", repository, assetPath, targetLocale),
+                        tuple("plural1_other", textContent, "other", "plural1_other", repository, assetPath, targetLocale),
+                        tuple("plural1_many", textContent, "many", "plural1_other", repository, assetPath, targetLocale),
+                        tuple("plural2_zero", textContent, "zero", "plural2_other", repository, assetPath, targetLocale),
+                        tuple("plural2_one", textContent, "one", "plural2_other", repository, assetPath, targetLocale),
+                        tuple("plural2_many", textContent, "many", "plural2_other", repository, assetPath, targetLocale),
+                        tuple("plural2_other", textContent, "other", "plural2_other", repository, assetPath, targetLocale));
     }
 
     private TextUnitDTO textUnit(String name, String content, String pluralForm, String pluralFormOther){
+        return textUnit(name, content, pluralForm, pluralFormOther, null, null, null);
+    }
+
+    private TextUnitDTO textUnit(String name, String content, String pluralForm, String pluralFormOther,
+                                 String repositoryName, String assetPath, String targetLocale){
 
         TextUnitDTO textUnit = new TextUnitDTO();
         textUnit.setName(name);
         textUnit.setTarget(content);
         textUnit.setPluralForm(pluralForm);
         textUnit.setPluralFormOther(pluralFormOther);
+        textUnit.setRepositoryName(repositoryName);
+        textUnit.setAssetPath(assetPath);
+        textUnit.setTargetLocale(targetLocale);
 
         return textUnit;
     }


### PR DESCRIPTION
The `AndroidStringDocumentMapper` instance we are using in the `ThirdPartySync` PULL action is missing some attributes.