### PR TITLE
Space placeholder for plural separator in ThirdPartySync

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommandTest.java
@@ -62,7 +62,7 @@ public class ThirdPartySyncCommandTest extends CLITestBase {
         //  JCommander trims the argument values, even when quoted.
         // https://github.com/cbeust/jcommander/issues/417
         // https://github.com/cbeust/jcommander/commit/4aec38b4a0ea63a8dc6f41636fa81c2ebafddc18
-        String pluralSeparator = "_";
+        String pluralSeparator = "%s_";
         String skipTextUnitPattern = "%skip_text_pattern";
         String skipAssetPattern = "%skip_asset_pattern%";
         List<String> options = Arrays.asList(

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -52,6 +52,8 @@ public class ThirdPartyService {
 
     static Logger logger = LoggerFactory.getLogger(ThirdPartyService.class);
 
+    static final String PLURAL_SEPARATOR_SPACE = "%s";
+
     @Autowired
     TextUnitSearcher textUnitSearcher;
 
@@ -111,7 +113,13 @@ public class ThirdPartyService {
                                      String skipTextUnitsWithPattern,
                                      String skipAssetsWithPathPattern,
                                      List<String> options) {
-        logger.debug("thirdparty TMS: {}", thirdPartyTMS);
+        pluralSeparator = replaceSpacePlaceholder(pluralSeparator);
+        logger.debug("Thirdparty TMS Sync: repositoryId={} thirdPartyProjectId={} " +
+                "actions={} pluralSeparator={} localeMapping={} " +
+                "skipTextUnitsWithPattern={} skipAssetsWithPattern={} " +
+                "options={}", repositoryId, thirdPartyProjectId, actions,
+                pluralSeparator, localeMapping, skipTextUnitsWithPattern,
+                skipAssetsWithPathPattern, options);
 
         Repository repository = repositoryRepository.findById(repositoryId).orElse(null);
 
@@ -334,6 +342,10 @@ public class ThirdPartyService {
                     return Optional.ofNullable(asset);
                 })
         );
+    }
+
+    String replaceSpacePlaceholder(String input) {
+        return input.replaceAll(PLURAL_SEPARATOR_SPACE, " ");
     }
 }
 


### PR DESCRIPTION
Required as a follow-up and temporary fix for #612 - We can use `%s` in the plural separator argument to signal the app that the placeholder must be replaced with space, so, `%s_` will be converted to ` _`, `%s_%s` to ` _ `, etc