### PR TITLE
Fixing bad argument ordering in ThirdPartyTMSSmartling

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -339,9 +339,9 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
 
         if (!options.isDryRun()) {
             logger.debug("Push Android file to Smartling project: {} and locale: {}", projectId, localeTag);
-            smartlingClient.uploadLocalizedFile(projectId, sourceFilename, "android", file.getFileContent(),
-                    getSmartlingLocale(localeMapping, localeTag), options.getPlaceholderFormat(),
-                    options.getCustomPlaceholderFormat());
+            smartlingClient.uploadLocalizedFile(projectId, sourceFilename, "android",
+                    getSmartlingLocale(localeMapping, localeTag), file.getFileContent(),
+                    options.getPlaceholderFormat(), options.getCustomPlaceholderFormat());
         }
 
         return file;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -67,6 +67,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -707,8 +708,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                     eq("projectId"),
                     eq(singularFileName(repository, 0)),
                     eq("android"),
-                    any(),
                     eq(locale.getBcp47Tag()),
+                    startsWith("<?xml version="),
                     eq(null),
                     eq(null));
         });
@@ -768,8 +769,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                     eq("projectId"),
                     eq(singularFileName(repository, 0)),
                     eq("android"),
-                    any(),
                     eq(locale.getBcp47Tag()),
+                    startsWith("<?xml version="),
                     eq(null),
                     eq(null));
         });
@@ -857,8 +858,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                     eq("projectId"),
                     eq(singularFileName(repository, 0)),
                     eq("android"),
-                    any(),
                     eq(locale.getBcp47Tag()),
+                    startsWith("<?xml version="),
                     eq(null),
                     eq(null));
 
@@ -866,8 +867,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                     eq("projectId"),
                     eq(pluralFileName(repository, 0)),
                     eq("android"),
-                    any(),
                     eq(locale.getBcp47Tag()),
+                    startsWith("<?xml version="),
                     eq(null),
                     eq(null));
         });
@@ -947,8 +948,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                     eq("projectId"),
                     eq(pluralFileName(repository, 0)),
                     eq("android"),
-                    any(),
                     eq(locale.getBcp47Tag()),
+                    startsWith("<?xml version="),
                     eq(null),
                     eq(null))
         );
@@ -1051,8 +1052,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                             eq("projectId"),
                             eq(singularFileName(repository, idx)),
                             eq("android"),
-                            any(),
                             eq(locale.getBcp47Tag()),
+                            startsWith("<?xml version="),
                             eq(null),
                             eq(null)));
 
@@ -1061,8 +1062,8 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                             eq("projectId"),
                             eq(pluralFileName(repository, idx)),
                             eq("android"),
-                            any(),
                             eq(locale.getBcp47Tag()),
+                            startsWith("<?xml version="),
                             eq(null),
                             eq(null)));
         });


### PR DESCRIPTION
When calling `pushTranslations` without `dryRun`, the process won't upload content correctly as argument order was mixed up.