### PR TITLE
Fix NPE for locale mapping in ThirdPartyService

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -22,6 +22,7 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.utils.MergeFunctions;
+import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -129,12 +131,12 @@ public class ThirdPartyService {
         }
         if (actions.contains(ThirdPartySyncAction.PUSH_TRANSLATION)) {
             thirdPartyTMS.pushTranslations(repository, thirdPartyProjectId, pluralSeparator,
-                    localeMappingHelper.getInverseLocaleMapping(localeMapping),
+                    parseLocaleMapping(localeMapping),
                     skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
         }
         if (actions.contains(ThirdPartySyncAction.PULL)) {
             thirdPartyTMS.pull(repository, thirdPartyProjectId, pluralSeparator,
-                    localeMappingHelper.getInverseLocaleMapping(localeMapping),
+                    parseLocaleMapping(localeMapping),
                     skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
         }
         if (actions.contains(ThirdPartySyncAction.MAP_TEXTUNIT)) {
@@ -346,6 +348,11 @@ public class ThirdPartyService {
 
     String replaceSpacePlaceholder(String input) {
         return input.replaceAll(PLURAL_SEPARATOR_SPACE, " ");
+    }
+
+    Map<String, String> parseLocaleMapping(String input) {
+        return Optional.ofNullable(localeMappingHelper.getInverseLocaleMapping(Strings.emptyToNull(input)))
+                       .orElseGet(Collections::emptyMap);
     }
 }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import static com.box.l10n.mojito.entity.Screenshot.Status.ACCEPTED;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -531,6 +532,18 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         assertThat(thirdPartyService.replaceSpacePlaceholder("%s-s")).isEqualTo(" -s");
         assertThat(thirdPartyService.replaceSpacePlaceholder("%%ss")).isEqualTo("% s");
         assertThat(thirdPartyService.replaceSpacePlaceholder("%s%s")).isEqualTo("  ");
+    }
+
+    @Test
+    public void testParseLocaleMapping() {
+        assertThat(thirdPartyService.parseLocaleMapping(null)).isEmpty();
+        assertThat(thirdPartyService.parseLocaleMapping("")).isEmpty();
+        assertThat(thirdPartyService.parseLocaleMapping("es:es-MX")).containsKey("es-MX").containsValue("es");
+        assertThat(thirdPartyService.parseLocaleMapping("es:es-MX,fr:fr-FR"))
+                .containsKeys("es-MX", "fr-FR").containsValues("es", "fr");
+        assertThatThrownBy(() -> thirdPartyService.parseLocaleMapping("unparseable"))
+                .isInstanceOf(IllegalArgumentException.class);
+
     }
 
     ThirdPartyTextUnit createThirdPartyTextUnit(String assetPath, String id, String name) {


### PR DESCRIPTION
Fixing an NPE that is thrown if no `localeMapping` is passed to the `ThirdPartySyncCommand`