### PR TITLE
Duplicate key exception for Android plural builder

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPlural.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPlural.java
@@ -19,7 +19,7 @@ public class AndroidPlural extends AbstractAndroidString {
 
     public AndroidPlural(String name, String comment, List<AndroidPluralItem> items) {
         super(name, comment);
-        this.items = items.stream().collect(Collectors.toMap(AndroidPluralItem::getQuantity, Function.identity()));
+        this.items = buildItemMap(items);
     }
 
     public Map<AndroidPluralQuantity, AndroidPluralItem> getItems() {
@@ -34,6 +34,14 @@ public class AndroidPlural extends AbstractAndroidString {
         return items.values()
                 .stream()
                 .sorted(Comparator.comparingInt(item -> item.getQuantity().ordinal()));
+    }
+
+    private Map<AndroidPluralQuantity, AndroidPluralItem> buildItemMap(List<AndroidPluralItem> items) {
+        try {
+            return items.stream().collect(Collectors.toMap(AndroidPluralItem::getQuantity, Function.identity()));
+        } catch (IllegalStateException e) {
+            throw new AndroidPluralDuplicateKeyException("A duplicate was found when building an Android Plural", e);
+        }
     }
 
     @Override

--- a/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPluralDuplicateKeyException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPluralDuplicateKeyException.java
@@ -1,0 +1,8 @@
+package com.box.l10n.mojito.android.strings;
+
+public class AndroidPluralDuplicateKeyException extends IllegalStateException {
+
+    public AndroidPluralDuplicateKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPluralItem.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/android/strings/AndroidPluralItem.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.android.strings;
 
+import java.util.StringJoiner;
+
 public class AndroidPluralItem {
 
     private final Long id;
@@ -26,5 +28,14 @@ public class AndroidPluralItem {
 
     public String getContent() {
         return content;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", AndroidPluralItem.class.getSimpleName() + "[", "]")
+                .add("id=" + id)
+                .add("quantity=" + quantity)
+                .add("content='" + content + "'")
+                .toString();
     }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidPluralTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/android/strings/AndroidPluralTest.java
@@ -1,0 +1,45 @@
+package com.box.l10n.mojito.android.strings;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AndroidPluralTest {
+
+    @Test
+    public void testPluralBuilder(){
+        AndroidPlural plural;
+        List<AndroidPluralItem> items;
+
+        items = ImmutableList.of(
+                new AndroidPluralItem("one", 100L, "content one"),
+                new AndroidPluralItem("other", 101L, "content other"),
+                new AndroidPluralItem("many", 102L, "content many"));
+
+        plural = new AndroidPlural("plural", "comment", items);
+
+        assertThat(plural).isNotNull();
+        assertThat(plural.getComment()).isEqualTo("comment");
+        assertThat(plural.getName()).isEqualTo("plural");
+        assertThat(plural.getItems().get(AndroidPluralQuantity.ONE).getId()).isEqualTo(100L);
+        assertThat(plural.getItems().get(AndroidPluralQuantity.ONE).getContent()).isEqualTo("content one");
+        assertThat(plural.getItems().get(AndroidPluralQuantity.OTHER).getId()).isEqualTo(101L);
+        assertThat(plural.getItems().get(AndroidPluralQuantity.OTHER).getContent()).isEqualTo("content other");
+        assertThat(plural.getItems().get(AndroidPluralQuantity.MANY).getId()).isEqualTo(102L);
+        assertThat(plural.getItems().get(AndroidPluralQuantity.MANY).getContent()).isEqualTo("content many");
+
+        List<AndroidPluralItem> badItems = ImmutableList.of(
+                new AndroidPluralItem("one", 100L, "content one"),
+                new AndroidPluralItem("one", 101L, "content one")
+        );
+
+        assertThatThrownBy(() -> new AndroidPlural("plural", "comment", badItems))
+                .hasMessageContaining("A duplicate was found when building an Android Plural")
+                .isInstanceOf(AndroidPluralDuplicateKeyException.class);
+    }
+
+}


### PR DESCRIPTION
Whenever the `AndroidPlural` class constructor gets created, this assumes the `List<AndroidPluralItem>` of plural items that its passed contains one, and only one plural item for each plural quantity. If that's not the case, the constructor fails with a cryptic `IllegalStateException`. This change allows the exception to be better scoped and have some context attached to the exception message.