### PR TITLE
Increasing Smartling auth token expiration delay

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
@@ -45,7 +44,6 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
 
     @Override
     public OAuth2AccessToken obtainAccessToken(OAuth2ProtectedResourceDetails details, AccessTokenRequest accessTokenRequest) throws UserRedirectRequiredException, UserApprovalRequiredException, AccessDeniedException {
-
 
         logger.debug("Get access token");
         Map<String, String> request = new HashMap<>();
@@ -105,12 +103,13 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
     }
 
     /**
-     * Since Smartling gives the TTL of the token but not the emission time, play safe taking now() minus 1 seconds as
-     * "now" time.
+     * Since Smartling gives the TTL of the token but not the emission time, play safe taking now() minus 15 seconds as
+     * "now" time. If the token is already expired it's better to take it as expired, even if it has some leeway, and
+     * just refresh it while keeping the token alive.
      *
      * @return
      */
     DateTime getNowForToken() {
-        return DateTime.now().minusSeconds(1);
+        return DateTime.now().minusSeconds(15);
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClientConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingClientConfiguration.java
@@ -12,14 +12,12 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
-import org.springframework.security.oauth2.client.token.AccessTokenProviderChain;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.util.DefaultUriTemplateHandler;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 /**
  * @author jaurambault
@@ -62,14 +60,10 @@ public class SmartlingClientConfiguration {
         RestTemplateUtils restTemplateUtils = new RestTemplateUtils();
         restTemplateUtils.enableFeature(oAuth2RestTemplate, DeserializationFeature.UNWRAP_ROOT_VALUE);
 
-        AccessTokenProviderChain accessTokenProviderChain = new AccessTokenProviderChain(Arrays.asList(
-                new SmartlingAuthorizationCodeAccessTokenProvider())
-        );
-        oAuth2RestTemplate.setAccessTokenProvider(accessTokenProviderChain);
+        oAuth2RestTemplate.setAccessTokenProvider(new SmartlingAuthorizationCodeAccessTokenProvider());
+        oAuth2RestTemplate.setRetryBadAccessTokens(true);
 
-        DefaultUriTemplateHandler defaultUriTemplateHandler = new DefaultUriTemplateHandler();
-        defaultUriTemplateHandler.setBaseUrl(baseUri);
-
+        DefaultUriBuilderFactory defaultUriTemplateHandler = new DefaultUriBuilderFactory(baseUri);
         oAuth2RestTemplate.setUriTemplateHandler(defaultUriTemplateHandler);
 
         oAuth2RestTemplate.setErrorHandler(new DefaultResponseErrorHandler() {

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingClientTest.java
@@ -15,6 +15,7 @@ import com.google.common.io.ByteStreams;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,6 +87,48 @@ public class SmartlingClientTest {
                 logger.debug("\n\n");
             }
         });
+    }
+
+    @Ignore
+    public void testRefreshToken() throws InterruptedException {
+        Assume.assumeNotNull(smartlingTestConfig.projectId);
+        Assume.assumeNotNull(smartlingTestConfig.fileUri);
+
+        smartlingClient.getStringInfos(smartlingTestConfig.projectId, smartlingTestConfig.fileUri).forEach(stringInfo -> {
+            if (stringInfo.getKeys().size() == 1) {
+                logger.debug("hashcode: {}\nvariant: {}\nparsed string: {}\n stringtext: {}\nkeys:",
+                        stringInfo.getHashcode(),
+                        stringInfo.getStringVariant(),
+                        stringInfo.getParsedStringText(),
+                        stringInfo.getStringText());
+
+                stringInfo.getKeys().stream().forEach(key -> logger.debug("key: {}, file: {}", key.getKey(), key.getFileUri()));
+
+                logger.debug("\n\n");
+            }
+        });
+
+        System.out.println("Sleeping until token is almost expired");
+        Thread.sleep(460*1000L);
+
+        for (int i = 0; i < 350; i++) {
+            smartlingClient.getStringInfos(smartlingTestConfig.projectId, smartlingTestConfig.fileUri).forEach(stringInfo -> {
+                if (stringInfo.getKeys().size() == 1) {
+                    logger.debug("hashcode: {}\nvariant: {}\nparsed string: {}\n stringtext: {}\nkeys:",
+                            stringInfo.getHashcode(),
+                            stringInfo.getStringVariant(),
+                            stringInfo.getParsedStringText(),
+                            stringInfo.getStringText());
+
+                    stringInfo.getKeys().stream().forEach(key -> logger.debug("key: {}, file: {}", key.getKey(), key.getFileUri()));
+
+                    logger.debug("\n\n");
+                }
+            });
+
+            System.out.println("Sleeping for token to expire and get refreshed");
+            Thread.sleep(100L);
+        }
     }
 
     @Test


### PR DESCRIPTION
The delay we have currently (1 sec) might not be able to catch all scenarios where we would try to use an already expired token (E.g: Smartling grants a token at t0. Then, at t1 (t0 + 2 seconds), we receive that token and save it as valid from t1, but given it was granted at t0, once we're about to reach the grant expiry we could run into authorization errors.