### PR TITLE
Adding ability to configure password via console using java defines

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/SystemPromptCredentialProvider.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/SystemPromptCredentialProvider.java
@@ -17,6 +17,7 @@ public class SystemPromptCredentialProvider implements CredentialProvider {
     @Value("${user.name}")
     String systemUserName;
 
+    @Value("${user.password}")
     String password;
 
     @Override


### PR DESCRIPTION
Allows to specify username/password to the CLI in a non-interactive way.

Ex:
```
java 
-Duser.name=foo \
-Duser.password=bar \
-Dl10n.resttemplate.authentication.credentialProvider=CONSOLE \
-jar mojito-cli.jar
```
