### PR TITLE
Re-implement mapping to support N Mojito TU to 1 Third party TU

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTextUnitRepository.java
@@ -1,9 +1,9 @@
 package com.box.l10n.mojito.service.thirdparty;
 
 import com.box.l10n.mojito.entity.Asset;
-import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.ThirdPartyTextUnit;
+import com.google.common.collect.ImmutableMap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -19,11 +19,8 @@ import java.util.List;
 @RepositoryRestResource(exported = false)
 public interface ThirdPartyTextUnitRepository extends JpaRepository<ThirdPartyTextUnit, Long>, JpaSpecificationExecutor<ThirdPartyTextUnit> {
 
-    @Query("select tptu.thirdPartyId from #{#entityName} tptu inner join tptu.asset a where a.repository = ?1")
-    HashSet<String> findThirdPartyIdsByRepository(Repository repository);
-
     @Query("select tptu.tmTextUnit.id from #{#entityName} tptu where tptu.asset = ?1")
-    HashSet<Long> findTmTextUnitIdsByAsset(Asset a);
+    HashSet<Long> findTmTextUnitIdsByAsset(Asset asset);
 
     ThirdPartyTextUnit findByTmTextUnit(TMTextUnit tmTextUnit);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/utils/Optionals.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/utils/Optionals.java
@@ -1,19 +1,24 @@
 package com.box.l10n.mojito.utils;
 
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class Optionals {
 
-    public static <T, R> Optional<R> or(T input, Function<T, Optional<R>>... functions) {
+    public static <T, R> Optional<R> or(T input, Predicate<R> filter, Function<T, Optional<R>>... functions) {
         Stream<Function<T, Optional<R>>> stream = Stream.of(functions);
-        return stream.map((f) -> f.apply(input)).
-                filter(Optional::isPresent).
-                map(Optional::get).findFirst();
+        return stream.map((f) -> f.apply(input))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(filter)
+                .findFirst();
     }
 
     public static <T> Optional<List<T>> optionalToOptionalList(Optional<T> optional) {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTestData.java
@@ -16,6 +16,8 @@ import com.box.l10n.mojito.service.screenshot.ScreenshotService;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.io.ByteStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.core.io.ClassPathResource;
@@ -28,6 +30,8 @@ import static org.junit.Assert.assertEquals;
 
 @Configurable
 public class ThirdPartyServiceTestData {
+
+    static Logger logger = LoggerFactory.getLogger(ThirdPartyServiceTestData.class);
 
     @Autowired
     RepositoryService repositoryService;
@@ -70,6 +74,7 @@ public class ThirdPartyServiceTestData {
 
     @PostConstruct
     public ThirdPartyServiceTestData init() throws Exception {
+        logger.debug("Starting init of ThirdPartyServiceTestData");
         repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
 
         String assetContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -152,6 +157,7 @@ public class ThirdPartyServiceTestData {
         screenshotRun.getScreenshots().add(screen4);
         screenshotService.createOrAddToScreenshotRun(screenshotRun, false);
 
+        logger.debug("Finished init of ThirdPartyServiceTestData");
         return this;
     }
 }


### PR DESCRIPTION
Multiple Mojito text units can be mapped to the same third party text unit. This wasn't supported before. Typicall example is a change in comment only in Mojito will create a new text unit. In some TMS, it would still be the same text unit. So we need to map (by name) the single third party TU to the 2 Mojito TUs