### PR TITLE
Address unit test failure for: BranchDeleteCommandTest (fixes #679)

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
@@ -209,7 +209,7 @@ public class RepositoryClient extends BaseClient {
     public List<Branch> getBranches(Long repositoryId, String branchName, String branchNameRegex,
                                     Boolean deleted, Boolean translated, boolean includeNullBranch,
                                     DateTime createdBefore) {
-        Map<String, String> filterParams = new HashMap<>();
+        Map<String, Object> filterParams = new HashMap<>();
 
         if (branchName != null) {
             filterParams.put("name", branchName);
@@ -224,7 +224,7 @@ public class RepositoryClient extends BaseClient {
         }
 
         if (createdBefore != null) {
-            filterParams.put("createdBefore", createdBefore.toString());
+            filterParams.put("createdBefore", createdBefore);
         }
 
         List<Branch> branches = authenticatedRestTemplate.getForObjectAsListWithQueryStringParams(

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -191,7 +195,29 @@ public class AuthenticatedRestTemplate {
             uriBuilder.queryParam(entry.getKey(), entry.getValue());
         }
 
-        return uriBuilder.build(false).toUri();
+        // Encode illegal characters in the URI
+        URI uri = uriBuilder.build(false).toUri();
+
+        // Encode DateTime objects in place fully, to ensure the '+' timezone separator doesn't get decoded as a space on the API side
+        uriBuilder = UriComponentsBuilder.fromUri(uri);
+
+        for (Map.Entry<String, ?> entry : queryStringParams.entrySet()) {
+            if (entry.getValue() instanceof DateTime)
+            {
+                String encodedDatetime = null;
+                try {
+                    encodedDatetime = URLEncoder.encode(entry.getValue().toString(), StandardCharsets.UTF_8.toString());
+                } catch (UnsupportedEncodingException ex) {
+                    throw new RuntimeException(ex);
+                }
+
+                uriBuilder.replaceQueryParam(entry.getKey(), encodedDatetime);
+            }
+        }
+
+        // Disable any further encoding on the builder to prevent double encoding
+        uri = uriBuilder.build(true).toUri();
+        return uri;
     }
 
     /**
@@ -310,7 +336,7 @@ public class AuthenticatedRestTemplate {
     }
 
     /**
-     * Delegate, see {@link RestTemplate#delete(String)}
+     * Delegate, see {@link RestTemplate#delete(String, Object...)}}
      *
      * @param resourcePath resource path transformed into final URI by this instance
      * @throws RestClientException


### PR DESCRIPTION
Addresses: #679 by ensuring the '+' character is encoded to '%2B' in the Rest template only for DateTime objects, so that Spring Boot decodes on the server as '+' instead of space ' '.

The encoding changes are only done for dates and the order of the parameters is preserved.