### PR TITLE
Make Mojito div float to fix issue rendering with latticehq

### DIFF
--- a/chromeextension/background.js
+++ b/chromeextension/background.js
@@ -25,7 +25,7 @@ function addMojitoIctHeader(details) {
 }
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
-        addMojitoIctHeader,
-        {urls: ['<all_urls>']},
-        ['requestHeaders', 'blocking','extraHeaders']
-        );
+    addMojitoIctHeader,
+    {urls: ['<all_urls>']},
+    ['requestHeaders', 'blocking','extraHeaders']
+);

--- a/webapp/src/main/resources/public/js/ict/Ict.js
+++ b/webapp/src/main/resources/public/js/ict/Ict.js
@@ -110,6 +110,9 @@ class Ict {
         var divIct = document.createElement('div');
 
         divIct.setAttribute('id', 'mojito-ict');
+        // latticehq.com adds forcibly "height: 100%" to the Mojito div, which in turn push the rendering of the lattice
+        // app one screen below. Make the Mojito div float to prevent the rendering issue...
+        divIct.setAttribute("style", 'float: left;');
         body.insertBefore(divIct, document.body.firstChild);
 
         ReactDOM.render(


### PR DESCRIPTION
latticehq.com adds forcibly "height: 100%" to the Mojito div, which in turn push the rendering of the lattice
app one screen below. Make the Mojito div float to prevent the rendering issue...