### PR TITLE
Use smartling refresh token if it exists

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
@@ -52,10 +52,10 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
 
         OAuth2AccessToken accessToken = null;
         OAuth2AccessToken existingToken = accessTokenRequest.getExistingToken();
-        if(existingToken != null && existingToken.getRefreshToken() != null){
+        if (existingToken != null && existingToken.getRefreshToken() != null) {
             logger.debug("Token exists with refresh token, refreshing access token");
             accessToken = refreshAccessToken(details, existingToken.getRefreshToken(), accessTokenRequest);
-        }else {
+        } else {
             try {
                 DateTime now = getNowForToken();
                 AuthenticationResponse authenticationResponse = getRestTemplate().postForObject(details.getAccessTokenUri(), request, AuthenticationResponse.class);
@@ -119,7 +119,7 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
         return DateTime.now().minusSeconds(15);
     }
 
-    protected RestTemplate getRestTemplate(){
+    protected RestTemplate getRestTemplate() {
         return restTemplate;
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProvider.java
@@ -58,7 +58,7 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
         }else {
             try {
                 DateTime now = getNowForToken();
-                AuthenticationResponse authenticationResponse = restTemplate.postForObject(details.getAccessTokenUri(), request, AuthenticationResponse.class);
+                AuthenticationResponse authenticationResponse = getRestTemplate().postForObject(details.getAccessTokenUri(), request, AuthenticationResponse.class);
                 accessToken = getDefaultOAuth2AccessToken(now, authenticationResponse);
             } catch (Exception e) {
                 String msg = "Can't get Smartling token";
@@ -82,7 +82,7 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
         DefaultOAuth2AccessToken defaultOAuth2AccessToken = null;
         try {
             DateTime now = getNowForToken();
-            AuthenticationResponse authenticationResponse = restTemplate.postForObject(smartlingOAuth2ProtectedResourceDetails.getRefreshUri(), request, AuthenticationResponse.class);
+            AuthenticationResponse authenticationResponse = getRestTemplate().postForObject(smartlingOAuth2ProtectedResourceDetails.getRefreshUri(), request, AuthenticationResponse.class);
             defaultOAuth2AccessToken = getDefaultOAuth2AccessToken(now, authenticationResponse);
         } catch (Exception e) {
             String msg = "Can't get Smartling refresh token";
@@ -118,4 +118,10 @@ public class SmartlingAuthorizationCodeAccessTokenProvider implements AccessToke
     DateTime getNowForToken() {
         return DateTime.now().minusSeconds(15);
     }
+
+    protected RestTemplate getRestTemplate(){
+        return restTemplate;
+    }
+
+
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProviderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProviderTest.java
@@ -1,0 +1,91 @@
+package com.box.l10n.mojito.smartling;
+
+import com.box.l10n.mojito.smartling.response.AuthenticationData;
+import com.box.l10n.mojito.smartling.response.AuthenticationResponse;
+import com.box.l10n.mojito.utils.RestTemplateUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+
+public class SmartlingAuthorizationCodeAccessTokenProviderTest {
+
+    @Spy
+    SmartlingAuthorizationCodeAccessTokenProvider smartlingAuthorizationCodeAccessTokenProvider;
+
+    @Mock
+    RestTemplate mockRestTemplate;
+
+    @Mock
+    SmartlingOAuth2ProtectedResourceDetails mockResourceDetails;
+
+    @Mock
+    AccessTokenRequest mockAccessTokenRequest;
+
+    @Mock
+    AuthenticationResponse mockResp;
+
+    AuthenticationData mockAuthData = new AuthenticationData();
+
+    @Before
+    public void setUp(){
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(smartlingAuthorizationCodeAccessTokenProvider.getRestTemplate()).thenReturn(mockRestTemplate);
+        Mockito.when(mockResourceDetails.getClientId()).thenReturn("testClient");
+        Mockito.when(mockResourceDetails.getClientSecret()).thenReturn("testSecret");
+        Mockito.when(mockResourceDetails.getAccessTokenUri()).thenReturn("http://test.com/accessToken");
+        Mockito.when(mockResourceDetails.getRefreshUri()).thenReturn("http://test.com/accessToken/refresh");
+        Mockito.when(mockRestTemplate.postForObject(anyString(), anyMap(), any())).thenReturn(mockResp);
+
+
+        mockAuthData.setAccessToken("testAccessToken");
+        mockAuthData.setExpiresIn(480);
+        mockAuthData.setRefreshToken("testRefreshToken");
+        mockAuthData.setRefreshExpiresIn(21700);
+
+        Mockito.when(mockAccessTokenRequest.getExistingToken()).thenReturn(null);
+        Mockito.when(mockResp.getData()).thenReturn(mockAuthData);
+    }
+
+    @Test
+    public void testRefreshTokenMethodCalledIfNoExistingToken(){
+
+        OAuth2AccessToken accessToken = smartlingAuthorizationCodeAccessTokenProvider.obtainAccessToken(mockResourceDetails, mockAccessTokenRequest);
+        Mockito.verify(smartlingAuthorizationCodeAccessTokenProvider, Mockito.times(0)).refreshAccessToken(isA(OAuth2ProtectedResourceDetails.class), isA(OAuth2RefreshToken.class), isA(AccessTokenRequest.class));
+        Assert.assertEquals(mockAuthData.getAccessToken(), accessToken.getValue());
+        Assert.assertEquals(mockAuthData.getRefreshToken(), accessToken.getRefreshToken().getValue());
+    }
+
+    @Test
+    public void testRefreshTokenMethodNotCalledIfNoRefreshToken(){
+
+        DefaultOAuth2AccessToken accessToken = new DefaultOAuth2AccessToken("testAccessToken");
+        accessToken.setRefreshToken(null);
+        Mockito.when(mockAccessTokenRequest.getExistingToken()).thenReturn(accessToken);
+        smartlingAuthorizationCodeAccessTokenProvider.obtainAccessToken(mockResourceDetails, mockAccessTokenRequest);
+        Mockito.verify(smartlingAuthorizationCodeAccessTokenProvider, Mockito.times(0)).refreshAccessToken(isA(OAuth2ProtectedResourceDetails.class), isA(OAuth2RefreshToken.class), isA(AccessTokenRequest.class));
+    }
+
+    @Test
+    public void testTokenIsRefreshedIfRefreshTokenIsPresent(){
+
+        OAuth2AccessToken accessToken = smartlingAuthorizationCodeAccessTokenProvider.obtainAccessToken(mockResourceDetails, mockAccessTokenRequest);
+        Mockito.verify(smartlingAuthorizationCodeAccessTokenProvider, Mockito.times(0)).refreshAccessToken(isA(OAuth2ProtectedResourceDetails.class), isA(OAuth2RefreshToken.class), isA(AccessTokenRequest.class));
+        Mockito.when(mockAccessTokenRequest.getExistingToken()).thenReturn(accessToken);
+        smartlingAuthorizationCodeAccessTokenProvider.obtainAccessToken(mockResourceDetails, mockAccessTokenRequest);
+        Mockito.verify(smartlingAuthorizationCodeAccessTokenProvider, Mockito.times(1)).refreshAccessToken(isA(OAuth2ProtectedResourceDetails.class), isA(OAuth2RefreshToken.class), isA(AccessTokenRequest.class));
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProviderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/smartling/SmartlingAuthorizationCodeAccessTokenProviderTest.java
@@ -61,7 +61,7 @@ public class SmartlingAuthorizationCodeAccessTokenProviderTest {
     }
 
     @Test
-    public void testRefreshTokenMethodCalledIfNoExistingToken(){
+    public void testRefreshTokenMethodNotCalledIfNoExistingToken(){
 
         OAuth2AccessToken accessToken = smartlingAuthorizationCodeAccessTokenProvider.obtainAccessToken(mockResourceDetails, mockAccessTokenRequest);
         Mockito.verify(smartlingAuthorizationCodeAccessTokenProvider, Mockito.times(0)).refreshAccessToken(isA(OAuth2ProtectedResourceDetails.class), isA(OAuth2RefreshToken.class), isA(AccessTokenRequest.class));


### PR DESCRIPTION
The Spring OAuth2RestTemplate getAccessToken() method calls the AccessTokenProvider obtainAccessToken method if the token is null or if the token is expired, see https://github.com/spring-projects/spring-security-oauth/blob/2.3.8.RELEASE/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/OAuth2RestTemplate.java#L221

The current code doesn't attempt to refresh the access token and instead calls the Smartling access token uri for a new token, I've added a check to see if an existing token with a refresh token exists and if so call the refresh access token flow to refresh the expired token.