### PR TITLE
Disable the screenshot upload button and update button text while upload is in progress

### DIFF
--- a/webapp/src/main/resources/public/js/components/branches/BranchesScreenshotUploadModal.js
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesScreenshotUploadModal.js
@@ -8,6 +8,7 @@ class BranchesScreenshotUploadModal extends React.Component {
     static propTypes = {
         "show": PropTypes.bool.isRequired,
         "uploadDisabled": PropTypes.bool.isRequired,
+        "uploadInProgress": PropTypes.bool.isRequired,
         "onUpload": PropTypes.func.isRequired,
         "onCancel": PropTypes.func.isRequired,
         "onSelectedFileChange": PropTypes.func.isRequired,
@@ -43,8 +44,9 @@ class BranchesScreenshotUploadModal extends React.Component {
                 </Modal.Body>
                 <Modal.Footer>
                     <Button onClick={this.props.onUpload} bsStyle="primary"
-                            disabled={this.props.imageForUpload === null}>
-                        <FormattedMessage id="branches.screenshotUploadModal.upload"/>
+                            disabled={this.props.imageForUpload === null || this.props.uploadInProgress}>
+                        {!this.props.uploadInProgress && <FormattedMessage id="branches.screenshotUploadModal.upload"/>}
+                        {this.props.uploadInProgress && <FormattedMessage id="upload.screenshot.processing"/>}
                     </Button>
                     <Button onClick={this.props.onCancel}>
                         <FormattedMessage id="label.cancel"/>

--- a/webapp/src/main/resources/public/js/stores/branches/BranchesScreenshotUploadModalStore.js
+++ b/webapp/src/main/resources/public/js/stores/branches/BranchesScreenshotUploadModalStore.js
@@ -16,6 +16,8 @@ class BranchesScreenshotUploadModalStore {
         this.show = false;
         this.uploadDisabled = true;
 
+        this.uploadInProgress = false;
+
         this.fileToUpload = null;
 
         // Data URL
@@ -40,6 +42,7 @@ class BranchesScreenshotUploadModalStore {
     uploadScreenshotImage() {
         let generatedUuid = v4() + this.fileToUpload.name;
         this.screenshotSrc = 'api/images/' + generatedUuid;
+        this.uploadInProgress = true;
         this.getInstance().performUploadScreenshotImage(generatedUuid);
     }
 
@@ -48,6 +51,7 @@ class BranchesScreenshotUploadModalStore {
     }
 
     uploadScreenshotImageError() {
+        this.uploadInProgress = false;
         this.errorMessage = "Couldn't upload image";
     }
 


### PR DESCRIPTION
Disables the screenshot upload button while an upload is in progress to prevent repeated upload requests of the same image, button text is changed to "Uploading Screenshot..." while an upload is in progress.