### PR TITLE
Added S3 image storage & retrieval implementation

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/images/ImageWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/images/ImageWS.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.rest.images;
 import com.box.l10n.mojito.entity.Image;
 import com.box.l10n.mojito.service.image.ImageService;
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
@@ -41,20 +42,13 @@ public class ImageWS {
 
         String imageName = getImageNameFromRequest(httpServletRequest);
 
-        Image image = imageService.getImage(imageName);
-
-        ResponseEntity responseEntity = null;
-
-        if (image != null) {
-            responseEntity = ResponseEntity
-                    .ok()
-                    .contentType(getMediaTypeFromImageName(imageName))
-                    .body(image.getContent());
-        } else {
-            responseEntity = ResponseEntity.notFound().build();
-        }
+        Optional<Image> image = imageService.getImage(imageName);
         
-        return responseEntity;
+        return image.map(i -> ResponseEntity
+                        .ok()
+                        .contentType(getMediaTypeFromImageName(imageName))
+                        .body(image.get().getContent()))
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @RequestMapping(value = "/api/images/**", method = RequestMethod.PUT)

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/DatabaseImageService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/DatabaseImageService.java
@@ -1,0 +1,47 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.entity.Image;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service to uploadImage and serve images.
+ *
+ * @author jeanaurambault
+ */
+public class DatabaseImageService implements ImageService {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(ImageService.class);
+
+    ImageRepository imageRepository;
+
+    public DatabaseImageService(ImageRepository imageRepository) {
+        this.imageRepository = imageRepository;
+    }
+
+    public Optional<Image> getImage(String name) {
+        logger.debug("Get image with name: {}", name);
+        return imageRepository.findByName(name);
+    }
+
+    public void uploadImage(String name, byte[] content) {
+
+        logger.debug("Upload image with name: {}", name);
+
+        Image image = imageRepository.findByName(name).orElseGet(() -> {
+                Image img = new Image();
+                img.setName(name);
+                return img;
+        });
+
+        image.setContent(content);
+
+        imageRepository.save(image);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/ImageRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/ImageRepository.java
@@ -6,11 +6,13 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.Optional;
+
 /**
  * @author jaurambault
  */
 @RepositoryRestResource(exported = false)
 public interface ImageRepository extends JpaRepository<Image, Long>, JpaSpecificationExecutor<Image> {
     
-    Image findByName(@Param("name") String name);
+    Optional<Image> findByName(@Param("name") String name);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/ImageService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/ImageService.java
@@ -1,48 +1,14 @@
 package com.box.l10n.mojito.service.image;
 
+
 import com.box.l10n.mojito.entity.Image;
-import org.slf4j.Logger;
-import static org.slf4j.LoggerFactory.getLogger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
-/**
- * Service to uploadImage and serve images.
- *
- * @author jeanaurambault
- */
-@Component
-public class ImageService {
+import java.util.Optional;
 
-    /**
-     * logger
-     */
-    static Logger logger = getLogger(ImageService.class);
-    
-    @Autowired
-    ImageRepository imageRepository;
+public interface ImageService {
 
-    public Image getImage(String name) {
-        logger.debug("Get image with name: {}", name);
-        Image image = imageRepository.findByName(name);
-        return image;
-    }
+    Optional<Image> getImage(String name);
 
-    public void uploadImage(String name, byte[] content) {
+    void uploadImage(String name, byte[] content);
 
-        logger.debug("Upload image with name: {}", name);
-        Image image;
-        Image prevVersion = imageRepository.findByName(name);
-
-        if (prevVersion != null) {
-            prevVersion.setContent(content);
-            image = prevVersion;
-        } else {
-            image = new Image();
-            image.setName(name);
-            image.setContent(content);
-        }
-
-        imageRepository.save(image);
-    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/ImageServiceConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/ImageServiceConfiguration.java
@@ -1,0 +1,70 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class ImageServiceConfiguration {
+
+    @ConditionalOnProperty(value = "l10n.image-service.storage.type", havingValue = "s3Fallback")
+    static class S3FallbackImageServiceConfiguration {
+
+        @Autowired
+        ImageRepository imageRepository;
+
+        @Autowired
+        S3BlobStorage s3BlobStorage;
+
+        @Bean @Qualifier("databaseImageService")
+        public DatabaseImageService databaseImageService() {
+            return new DatabaseImageService(imageRepository);
+        }
+
+        @Bean @Qualifier("s3ImageService")
+        public S3ImageService s3ImageService(S3BlobStorage s3BlobStorage, @Value("${l10n.image-service.storage.s3.prefix:image}") String s3PathPrefix) {
+            return new S3ImageService(s3BlobStorage, s3PathPrefix);
+        }
+
+        @Bean
+        public S3UploadImageAsyncTask s3UploadImageAsyncTask(S3ImageService s3ImageService) {
+            return new S3UploadImageAsyncTask(s3ImageService);
+        }
+
+        @Bean @Primary
+        public ImageService s3ImageFallback(@Qualifier("s3ImageService") S3ImageService s3ImageService,
+                                            @Qualifier("databaseImageService") DatabaseImageService databaseImageService,
+                                            S3UploadImageAsyncTask s3UploadImageAsyncTask) {
+            return new S3FallbackImageService(s3ImageService, databaseImageService, s3UploadImageAsyncTask);
+        }
+    }
+
+    @ConditionalOnProperty(value = "l10n.image-service.storage.type", havingValue = "s3")
+    static class S3ImageServiceConfiguration {
+
+        @Autowired
+        S3BlobStorage s3BlobStorage;
+
+        @Bean
+        public ImageService s3ImageService(S3BlobStorage s3BlobStorage, @Value("${l10n.image-service.storage.s3.prefix:image}") String s3PathPrefix) {
+            return new S3ImageService(s3BlobStorage, s3PathPrefix);
+        }
+    }
+
+    @ConditionalOnProperty(value = "l10n.image-service.storage.type", havingValue = "database", matchIfMissing = true)
+    static class DatabaseImageServiceConfiguration {
+
+        @Autowired
+        ImageRepository imageRepository;
+
+        @Bean
+        public ImageService databaseImageService() {
+            return new DatabaseImageService(imageRepository);
+        }
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/S3FallbackImageService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/S3FallbackImageService.java
@@ -1,0 +1,53 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.entity.Image;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service that retrieves images from an S3 bucket and falls back to the Mojito DB for retrieval if
+ * an image is not available in the S3 bucket.
+ *
+ * If a requested image cannot be found in S3 an attempt will be made to retrieve from the Mojito DB, if the image is
+ * found in the DB then an async task will be executed to upload the image to S3.
+ *
+ * @author maallen
+ */
+public class S3FallbackImageService implements ImageService {
+
+    static Logger logger = getLogger(S3FallbackImageService.class);
+
+    S3ImageService s3ImageService;
+
+    DatabaseImageService databaseImageService;
+
+    S3UploadImageAsyncTask s3UploadImageAsyncTask;
+
+    public S3FallbackImageService(S3ImageService s3ImageService, DatabaseImageService databaseImageService,
+                                  S3UploadImageAsyncTask s3UploadImageAsyncTask) {
+        this.s3ImageService = s3ImageService;
+        this.databaseImageService = databaseImageService;
+        this.s3UploadImageAsyncTask = s3UploadImageAsyncTask;
+    }
+
+    @Override
+    public Optional<Image> getImage(String name) {
+        logger.debug("Attempt image retrieval from S3 with name: {}", name);
+        Image image = s3ImageService.getImage(name).orElseGet(() ->
+                databaseImageService.getImage(name).map(img -> {
+                    logger.debug("Found image {} in database, triggering async upload to S3", img.getName());
+                    s3UploadImageAsyncTask.uploadImageToS3(img.getName(), img.getContent());
+                    return img;
+                }).orElse(null));
+        return Optional.ofNullable(image);
+    }
+
+    @Override
+    public void uploadImage(String name, byte[] content) {
+        s3ImageService.uploadImage(name, content);
+    }
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/S3ImageService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/S3ImageService.java
@@ -1,0 +1,54 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.entity.Image;
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorage;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Service to upload and retrieve images from S3.
+ *
+ * Configured {@link S3BlobStorage} and {@link com.amazonaws.services.s3.AmazonS3} client instances are required to
+ * upload and retrieve images from S3.
+ *
+ * @author maallen
+ */
+public class S3ImageService implements ImageService {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(S3ImageService.class);
+
+    S3BlobStorage s3BlobStorage;
+
+    String s3PathPrefix;
+
+    public S3ImageService(S3BlobStorage s3BlobStorage, String s3PathPrefix) {
+        this.s3BlobStorage = s3BlobStorage;
+        this.s3PathPrefix = s3PathPrefix;
+    }
+
+    public Optional<Image> getImage(String name) {
+        logger.debug("Get image from S3 with name: {}", name);
+
+        return s3BlobStorage.getBytes(getS3Path(name)).map(bytes -> {
+            Image image = new Image();
+            image.setName(name);
+            image.setContent(bytes);
+            return image;
+        });
+    }
+
+    public void uploadImage(String name, byte[] content) {
+        logger.debug("Upload image to S3 with name: {}", name);
+        s3BlobStorage.put(getS3Path(name), content);
+    }
+
+    private String getS3Path(String name) {
+        return s3PathPrefix + "/" + name;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/image/S3UploadImageAsyncTask.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/image/S3UploadImageAsyncTask.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorage;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Async task to upload an image to S3.
+ *
+ * @author maallen
+ */
+public class S3UploadImageAsyncTask {
+
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(S3UploadImageAsyncTask.class);
+
+    S3ImageService s3ImageService;
+
+    public S3UploadImageAsyncTask(S3ImageService s3ImageService) {
+        this.s3ImageService = s3ImageService;
+    }
+
+    @Async
+    public void uploadImageToS3(String name, byte[] content){
+        logger.debug("Uploading image {} to S3", name);
+        s3ImageService.uploadImage(name, content);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -329,7 +329,7 @@ public class ThirdPartyService {
 
         Optional<Image> image = Optional.ofNullable(screenshot.getSrc())
                 .map(src -> src.replaceAll("^api/images/", ""))
-                .map(name -> imageService.getImage(name));
+                .flatMap(name -> imageService.getImage(name));
 
         return image;
     }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/image/DatabaseImageServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/image/DatabaseImageServiceTest.java
@@ -1,0 +1,82 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.entity.Image;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DatabaseImageServiceTest {
+
+    @Mock
+    ImageRepository imageRepository;
+
+    DatabaseImageService databaseImageService;
+
+    @Captor
+    ArgumentCaptor<Image> imageCaptor;
+
+    Image image;
+
+    byte[] imageBytes = new byte[]{1,2,3,4,5};
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        image = new Image();
+        image.setName("test");
+        image.setContent(imageBytes);
+        when(imageRepository.findByName("test")).thenReturn(Optional.of(image));
+        databaseImageService = new DatabaseImageService(imageRepository);
+    }
+
+    @Test
+    public void testGetImageFromDB() {
+        Optional<Image> image = databaseImageService.getImage("test");
+        assertTrue(image.isPresent());
+        assertEquals("test", image.get().getName());
+        assertEquals(imageBytes, image.get().getContent());
+    }
+
+    @Test
+    public void testImageNotAvailableInDB() {
+        when(imageRepository.findByName("imageNotFound")).thenReturn(Optional.empty());
+        Optional<Image> image = databaseImageService.getImage("imageNotFound");
+        assertFalse(image.isPresent());
+    }
+
+    @Test
+    public void testUploadImageToDB() {
+        byte[] content = new byte[] {6, 7, 8, 9, 10};
+        databaseImageService.uploadImage("otherImage", content);
+        verify(imageRepository, times(1)).findByName("otherImage");
+        verify(imageRepository, times(1)).save(imageCaptor.capture());
+        Image imageCaptorValue = imageCaptor.getValue();
+        assertEquals("otherImage", imageCaptorValue.getName());
+        assertEquals(content, imageCaptorValue.getContent());
+    }
+
+    @Test
+    public void testUploadNewVersionOfExistingImageInDB() {
+        byte[] content = new byte[] {6, 7, 8, 9, 10};
+        databaseImageService.uploadImage("test", content);
+        verify(imageRepository, times(1)).findByName("test");
+        verify(imageRepository, times(1)).save(imageCaptor.capture());
+        Image imageCaptorValue = imageCaptor.getValue();
+        assertEquals("test", imageCaptorValue.getName());
+        assertEquals(content, imageCaptorValue.getContent());
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/image/S3FallbackImageServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/image/S3FallbackImageServiceTest.java
@@ -1,0 +1,149 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.entity.Image;
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {
+        S3FallbackImageServiceTest.class,
+        ImageServiceConfiguration.class,
+        S3FallbackImageService.class
+}, properties = {
+        "l10n.image-service.storage.type=s3Fallback",
+        "l10n.blob-storage.type=s3",
+        "l10n.aws.s3.enabled=true"
+})
+public class S3FallbackImageServiceTest {
+
+    @Configuration
+    static class S3FallbackImageServiceTestConfiguration {
+
+        @MockBean
+        ImageRepository imageRepository;
+
+        @MockBean
+        S3BlobStorage s3BlobStorage;
+
+        @Bean("databaseImageService")
+        public DatabaseImageService databaseImageService() {
+            return Mockito.spy(new DatabaseImageService(imageRepository));
+        }
+
+        @Bean("s3ImageService")
+        public S3ImageService s3ImageService(S3BlobStorage s3BlobStorage, @Value("${l10n.image-service.storage.s3.prefix:image}") String s3PathPrefix) {
+            return Mockito.spy(new S3ImageService(s3BlobStorage, s3PathPrefix));
+        }
+
+        @Bean
+        public S3UploadImageAsyncTask s3UploadImageAsyncTask(S3ImageService s3ImageService) {
+            return Mockito.spy(new S3UploadImageAsyncTask(s3ImageService));
+        }
+
+        @Bean @Primary
+        public ImageService s3ImageFallback(@Qualifier("s3ImageService") S3ImageService s3ImageService,
+                                            @Qualifier("databaseImageService") DatabaseImageService databaseImageService,
+                                            S3UploadImageAsyncTask s3UploadImageAsyncTask) {
+            return new S3FallbackImageService(s3ImageService, databaseImageService, s3UploadImageAsyncTask);
+        }
+    }
+
+    @MockBean
+    S3BlobStorage s3BlobStorageMock;
+
+    @MockBean
+    ImageRepository imageRepositoryMock;
+
+    @SpyBean
+    S3UploadImageAsyncTask s3UploadImageAsyncTaskSpy;
+
+    @SpyBean
+    S3ImageService s3ImageService;
+
+    @Autowired
+    S3FallbackImageService s3FallbackImageService;
+
+    byte[] imageBytes = new byte[]{1,2,3,4,5};
+
+    Optional<byte[]> imageContent;
+
+    @Before
+    public void setup() {
+        imageContent = Optional.of(imageBytes);
+    }
+
+    @Test
+    public void testGetImageFromS3() {
+        when(s3BlobStorageMock.getBytes(anyString())).thenReturn(imageContent);
+        Optional<Image> image = s3FallbackImageService.getImage("testName");
+        assertEquals("testName", image.get().getName());
+        assertEquals(imageBytes, image.get().getContent());
+        verify(s3ImageService, times(1)).getImage("testName");
+        verify(s3BlobStorageMock, times(1)).getBytes("image/testName");
+        verifyNoInteractions(imageRepositoryMock, s3UploadImageAsyncTaskSpy);
+    }
+
+    @Test
+    public void testUploadImageToS3() {
+        s3FallbackImageService.uploadImage("testImage", imageBytes);
+        verify(s3BlobStorageMock, times(1)).put("image/testImage", imageBytes);
+        verifyNoInteractions(imageRepositoryMock, s3UploadImageAsyncTaskSpy);
+    }
+
+    @Test
+    public void testDatabaseCheckedForImageIfNotInS3() {
+        when(s3BlobStorageMock.getBytes(anyString())).thenReturn(Optional.empty());
+        when(imageRepositoryMock.findByName("test")).thenReturn(Optional.empty());
+        Optional<Image> image = s3FallbackImageService.getImage("test");
+        assertFalse(image.isPresent());
+        verify(s3ImageService, times(1)).getImage("test");
+        verify(s3BlobStorageMock, times(1)).getBytes("image/test");
+        verify(imageRepositoryMock, times(1)).findByName("test");
+        verifyNoInteractions(s3UploadImageAsyncTaskSpy);
+    }
+
+    @Test
+    public void testImageUploadedToS3IfFoundInDB() {
+        Image image = new Image();
+        image.setName("test");
+        image.setContent(imageBytes);
+        when(s3BlobStorageMock.getBytes(anyString())).thenReturn(Optional.empty());
+        when(imageRepositoryMock.findByName("test")).thenReturn(Optional.of(image));
+        Optional<Image> retrievedImage = s3FallbackImageService.getImage("test");
+        assertTrue(retrievedImage.isPresent());
+        assertEquals("test", image.getName());
+        assertEquals(imageBytes, retrievedImage.get().getContent());
+        verify(s3ImageService, times(1)).getImage("test");
+        verify(s3BlobStorageMock, times(1)).getBytes("image/test");
+        verify(imageRepositoryMock, times(1)).findByName("test");
+        verify(s3UploadImageAsyncTaskSpy, times(1)).uploadImageToS3("test", retrievedImage.get().getContent());
+        verify(s3BlobStorageMock, timeout(3000).times(1)).put("image/test", retrievedImage.get().getContent());
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/image/S3ImageServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/image/S3ImageServiceTest.java
@@ -1,0 +1,59 @@
+package com.box.l10n.mojito.service.image;
+
+import com.box.l10n.mojito.entity.Image;
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorage;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class S3ImageServiceTest {
+
+    @Mock
+    S3BlobStorage s3BlobStorageMock;
+
+    S3ImageService s3ImageService;
+
+    byte[] imageContent = new byte[]{1, 2, 3, 4, 5};
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        s3ImageService = new S3ImageService(s3BlobStorageMock, "image");
+    }
+
+    @Test
+    public void testGetImageFromS3() {
+        when(s3BlobStorageMock.getBytes(anyString())).thenReturn(Optional.of(imageContent));
+        Optional<Image> image = s3ImageService.getImage("testImage");
+        verify(s3BlobStorageMock, times(1)).getBytes("image/testImage");
+        assertEquals("testImage", image.get().getName());
+        assertEquals(imageContent, image.get().getContent());
+    }
+
+    @Test
+    public void testImageNotAvailableInS3() {
+        when(s3BlobStorageMock.getBytes(anyString())).thenReturn(Optional.empty());
+        Optional<Image> image = s3ImageService.getImage("testImage");
+        verify(s3BlobStorageMock, times(1)).getBytes("image/testImage");
+        assertFalse(image.isPresent());
+    }
+
+    @Test
+    public void testUploadImageToS3() {
+        s3ImageService.uploadImage("testImage", imageContent);
+        verify(s3BlobStorageMock, times(1)).put("image/testImage", imageContent);
+    }
+
+
+}


### PR DESCRIPTION
Adds functionality to store and retrieve images from Amazon S3 storage. 

The S3 image service is enabled via the *l10n.image-service.storage.type* configuration parameter being set to s3 or s3Fallback, the service also requires that configuration is provided for an S3BlobStorage and an AmazonS3 client. The s3Fallback option will check the Mojito database for any requested images that can't be found in S3, if the image is found in the database then an asynchronous task will be triggered to upload the image to S3.

The existing database blob storage solution will be used if the *l10n.image-service.storage.type* parameter is missing or has a "database" value.

The prefix that images are stored in S3 under can be configured via the *l10n.image-service.storage.s3.prefix* parameter, if this is not provided it will default to "image" as the prefix.
