### PR TITLE
Update error message if screenshot upload failure is due to unauthorized response

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/react/ReactSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/react/ReactSecurityConfig.java
@@ -15,6 +15,8 @@ public class ReactSecurityConfig {
 
     Map<String, OAuth2> oAuth2;
 
+    boolean handleRedirectAsErrorOnImageUpload;
+
     @Autowired
     public ReactSecurityConfig(SecurityConfig securityConfig) {
         Preconditions.checkNotNull(securityConfig);
@@ -23,6 +25,15 @@ public class ReactSecurityConfig {
                 e -> e.getKey(),
                 e -> new OAuth2(e.getValue())
         ));
+        this.handleRedirectAsErrorOnImageUpload = securityConfig.isHandleRedirectAsErrorOnImageUpload();
+    }
+
+    public boolean isHandleRedirectAsErrorOnImageUpload() {
+        return handleRedirectAsErrorOnImageUpload;
+    }
+
+    public void setHandleRedirectAsErrorOnImageUpload(boolean handleRedirectAsErrorOnImageUpload) {
+        this.handleRedirectAsErrorOnImageUpload = handleRedirectAsErrorOnImageUpload;
     }
 
     public String getUnauthRedirectTo() {

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/security/UserWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/security/UserWS.java
@@ -59,6 +59,16 @@ public class UserWS {
     }
 
     /**
+     * Endpoint to verify if the user session is active
+     *
+     * @return a 200 response if the user session is active.
+     */
+    @RequestMapping(value = "/api/users/session", method = RequestMethod.GET)
+    public ResponseEntity isSessionActive(){
+        return ResponseEntity.ok().build();
+    }
+
+    /**
      * Creates a {@link User}
      *
      * @param user

--- a/webapp/src/main/java/com/box/l10n/mojito/security/SecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/SecurityConfig.java
@@ -35,6 +35,8 @@ public class SecurityConfig {
 
     Map<String, OAuth2> oAuth2 = new HashMap<>();
 
+    boolean handleRedirectAsErrorOnImageUpload;
+
     public List<AuthenticationType> getAuthenticationType() {
         return authenticationType;
     }
@@ -57,6 +59,14 @@ public class SecurityConfig {
 
     public void setoAuth2(Map<String, OAuth2> oAuth2) {
         this.oAuth2 = oAuth2;
+    }
+
+    public boolean isHandleRedirectAsErrorOnImageUpload() {
+        return handleRedirectAsErrorOnImageUpload;
+    }
+
+    public void setHandleRedirectAsErrorOnImageUpload(boolean handleRedirectAsErrorOnImageUpload) {
+        this.handleRedirectAsErrorOnImageUpload = handleRedirectAsErrorOnImageUpload;
     }
 
     /**

--- a/webapp/src/main/resources/public/js/app.js
+++ b/webapp/src/main/resources/public/js/app.js
@@ -140,6 +140,10 @@ function startApp(messages) {
             let pathNameStrippedLeadingSlash = location.pathname.substr(1 + APP_CONFIG.contextPath.length, location.pathname.length);
             let currentLocation = pathNameStrippedLeadingSlash + window.location.search;
 
+            if (currentLocation === "") {
+                currentLocation = "workbench"
+            }
+
             if (APP_CONFIG.security.unauthRedirectTo) {
                 // if we don't log through login page we just reload the current location
                 // that needs to be improved eg. when navigating within the workbench if an api calls fails it will

--- a/webapp/src/main/resources/public/js/components/App.js
+++ b/webapp/src/main/resources/public/js/components/App.js
@@ -1,7 +1,32 @@
 import React from "react";
 import Header from "./header/Header";
+import BaseClient from "../sdk/BaseClient";
 
 class App extends React.Component {
+
+    componentDidMount() {
+        window.addEventListener("focus", this.onFocus)
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("focus", this.onFocus)
+    }
+
+    onFocus = () => {
+        this.isSessionExpired();
+    }
+
+    isSessionExpired() {
+        fetch(window.location.origin + '/api/users/session', {
+            credentials: 'include',
+            redirect: "manual"
+        }).then(response => {
+            if (response.status !== 200) {
+                BaseClient.authenticateHandler();
+            }
+        });
+    }
+
     render() {
         return (
 

--- a/webapp/src/main/resources/public/js/sdk/BaseClient.js
+++ b/webapp/src/main/resources/public/js/sdk/BaseClient.js
@@ -105,6 +105,7 @@ class BaseClient {
     }
 
     putBinaryData(url, data) {
+        const redirectMethod = APP_CONFIG.security.handleRedirectAsErrorOnImageUpload === true ? "manual" : "follow"
         return fetch(url, {
             method: 'put',
             compress: false, // workaround for node-fetch, see this file header
@@ -113,8 +114,13 @@ class BaseClient {
             headers: {
                 'X-CSRF-TOKEN': this.getCSRF()
             },
-            follow: 0
+            follow: 0,
+            redirect: redirectMethod
         }).then(response => {
+            if (APP_CONFIG.security.handleRedirectAsErrorOnImageUpload === true && response.status === 0) {
+                // Workaround for OAuth redirect for auth on image upload causing silent TOO_MANY_REDIRECTS failure
+                BaseClient.authenticateHandler();
+            }
             this.handleUnauthenticatedResponse(response);
         });
     }

--- a/webapp/src/main/resources/public/js/stores/branches/BranchesScreenshotUploadModalStore.js
+++ b/webapp/src/main/resources/public/js/stores/branches/BranchesScreenshotUploadModalStore.js
@@ -50,9 +50,12 @@ class BranchesScreenshotUploadModalStore {
         this.getInstance().performUploadScreenshot();
     }
 
-    uploadScreenshotImageError() {
+    uploadScreenshotImageError(error) {
         this.uploadInProgress = false;
         this.errorMessage = "Couldn't upload image";
+        if (error.response && (error.response.status === 401 || error.response.status === 0)) {
+            this.errorMessage = "Authentication has expired. Please reauthenticate and try again."
+        }
     }
 
     uploadScreenshotSuccess() {


### PR DESCRIPTION
Updates the error message observed on screenshot upload failure to indicate that the upload has failed as user authentication has expired.

Updated the putBinaryData function to treat a redirect response as an error as when OAuth is being used for login the initial image upload fails as the response is an OAuth redirect to re-authorize. This isn't treated as an error by the frontend but triggers multiple redirects under the hood which eventually fail with a TOO_MANY_REDIRECTS error, this causes the error to be displayed but doesn't trigger the handleUnAuthenticatedRequests flow.