### PR TITLE
Fix Branch & Screenshots UI pages issuing 2x concurrent backend queries

### DIFF
--- a/webapp/src/main/resources/public/js/app.js
+++ b/webapp/src/main/resources/public/js/app.js
@@ -202,6 +202,7 @@ function onEnterBranches() {
 function onEnterScreenshots() {
     setTimeout(() => {
         ScreenshotsRepositoryActions.getAllRepositories();
+        ScreenshotsPageActions.performSearch();
     }, 1);
 }
 

--- a/webapp/src/main/resources/public/js/stores/branches/BranchesHistoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/branches/BranchesHistoryStore.js
@@ -125,8 +125,6 @@ class BranchesHistoryStore {
         }
 
         BranchesDataSource.enableHistoryUpdate();
-
-        BranchesPageActions.getBranches();
     }
 }
 

--- a/webapp/src/main/resources/public/js/stores/screenshots/ScreenshotsHistoryStore.js
+++ b/webapp/src/main/resources/public/js/stores/screenshots/ScreenshotsHistoryStore.js
@@ -171,8 +171,6 @@ class ScreenshotsHistoryStore {
         ScreenshotsPageActions.changeSelectedScreenshotIdx(selectedScreenshotIdx);
 
         ScreenshotsHistoryActions.enableHistoryUpdate();
-
-        ScreenshotsPageActions.performSearch();
     }
 }
 


### PR DESCRIPTION
Both the branches and screenshots issue two backend queries for data when either:

A. We directly navigate to a /branches page or a /statistics page with URL params
or 
B. We navigate to one of the page types above using the browser's history buttons.

(To note, this doesn't occur when navigating between tabs/headers through the buttons of the Mojito WebUI.)

The fix was to remove backend querying from History stores initialization and move querying for the screenshots UI to the route path logic to eliminate double backend concurrent requests
