### PR TITLE
Provide template options for Phabricator notification

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageBuilderPhabricator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationMessageBuilderPhabricator.java
@@ -1,6 +1,8 @@
 package com.box.l10n.mojito.service.branch.notification.phabricator;
 
 import com.box.l10n.mojito.service.branch.BranchUrlBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.text.MessageFormat;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +24,12 @@ public class BranchNotificationMessageBuilderPhabricator {
     @Autowired
     BranchUrlBuilder branchUrlBuilder;
 
+    @Value("${l10n.branchNotification.phabricator.notification.message.new.format:{message}{link}\n\n{strings}}")
+    String getNewNotificationMsgFormat;
+
+    @Value("${l10n.branchNotification.phabricator.notification.message.updated.format:{message}{link}\n\n{strings}}")
+    String getUpdatedNotificationMsgFormat;
+
     @Value("${l10n.branchNotification.phabricator.notification.message.new:We received your strings! " +
             "Please **add screenshots** as soon as possible and **wait for translations** before releasing. }")
     String newNotificationMsg;
@@ -40,23 +48,32 @@ public class BranchNotificationMessageBuilderPhabricator {
     String screenshotsMissingMsg;
 
     public String getNewMessage(String branchName, List<String> sourceStrings) {
-        return newNotificationMsg +
-                getLinkGoToMojito(branchName) + "\n\n" +
-                getFormattedSourceStrings(sourceStrings);
+        MessageFormat messageFormat = new MessageFormat(getNewNotificationMsgFormat);
+        ImmutableMap<String, Object> messageParamMap = ImmutableMap.<String, Object>builder()
+                .put("message", newNotificationMsg)
+                .put("link", getLinkGoToMojito(branchName))
+                .put("strings", getFormattedSourceStrings(sourceStrings))
+                .build();
+        return messageFormat.format(messageParamMap);
     }
+
 
     public String getUpdatedMessage(String branchName, List<String> sourceStrings) {
 
         String msg = null;
 
+        MessageFormat messageFormat = new MessageFormat(getUpdatedNotificationMsgFormat);
+        ImmutableMap<String, Object> messageParamMap;
         if (sourceStrings.isEmpty()) {
-            msg = noMoreStringsMsg;
+            messageParamMap = ImmutableMap.<String, Object>builder().put("message", noMoreStringsMsg).build();
         } else {
-            msg = updatedNotificationMsg +
-                    getLinkGoToMojito(branchName) + "\n\n" +
-                    getFormattedSourceStrings(sourceStrings);
+            messageParamMap = ImmutableMap.<String, Object>builder()
+                    .put("message", updatedNotificationMsg)
+                    .put("link", getLinkGoToMojito(branchName))
+                    .put("strings", getFormattedSourceStrings(sourceStrings))
+                    .build();
         }
-        return msg;
+        return messageFormat.format(messageParamMap);
     }
 
     public String getNoMoreStringsMessage() { return noMoreStringsMsg; }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationCustomMessageWithFormatPhabricatorTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/phabricator/BranchNotificationCustomMessageWithFormatPhabricatorTest.java
@@ -1,0 +1,48 @@
+package com.box.l10n.mojito.service.branch.notification.phabricator;
+
+import com.box.l10n.mojito.service.branch.BranchUrlBuilder;
+import com.box.l10n.mojito.utils.ServerConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {
+        BranchNotificationMessageBuilderPhabricator.class,
+        BranchNotificationCustomMessageWithFormatPhabricatorTest.class,
+        BranchUrlBuilder.class,
+        ServerConfig.class},
+        properties = {
+                "l10n.branchNotification.phabricator.notification.message.new.format={message}",
+                "l10n.branchNotification.phabricator.notification.message.updated.format={message} {link}",
+                "l10n.branchNotification.phabricator.notification.message.new=Custom message text for new messages stating the time that screenshots need to be uploaded ",
+                "l10n.branchNotification.phabricator.notification.message.updated=Test custom message for update messages stating the screenshot upload deadline ",
+                "l10n.branchNotification.phabricator.notification.message.noMoreStrings=Test custom message for no more strings ",
+                "l10n.branchNotification.phabricator.notification.message.translationsReady=Test custom message for translated strings ready",
+                "l10n.branchNotification.phabricator.notification.message.screenshotsMissing=Test custom message for screenshots missing"})
+public class BranchNotificationCustomMessageWithFormatPhabricatorTest {
+
+    @Autowired
+    BranchNotificationMessageBuilderPhabricator branchNotificationMessageBuilderPhabricator;
+
+    @Test
+    public void getCustomNewMessageWithFormat() {
+        String newMessage = branchNotificationMessageBuilderPhabricator.getNewMessage("branchTest", Arrays.asList("string1", "string2"));
+        assertEquals("Custom message text for new messages stating the time that screenshots need to be uploaded ", newMessage);
+    }
+
+    @Test
+    public void getCustomUpdatedMessageWithFormat() {
+        String updatedMessage = branchNotificationMessageBuilderPhabricator.getUpdatedMessage("branchTest", Arrays.asList("string1", "string2"));
+        assertEquals("Test custom message for update messages stating the screenshot upload deadline " +
+                " [→ Go to Mojito](http://localhost:8080/branches?searchText=branchTest&deleted=false&onlyMyBranches=false)"
+                , updatedMessage);
+    }
+
+}


### PR DESCRIPTION
Adds templating options to Phabricator new & updated notification messages.Message format items are message, link and strings and can be set using the `l10n.branchNotifications.phabricator.notification.message.new.format` and `l10n.branchNotifications.phabricator.notification.message.updated.format` properties