### PR TITLE
Smartling untranslated strings fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ release.properties
 /docs/.jekyll-cache/
 /docs/_site/
 /.java-version
+/node_modules/

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -20,15 +20,10 @@ import com.box.l10n.mojito.service.tm.search.UsedFilter;
 import com.box.l10n.mojito.smartling.AssetPathAndTextUnitNameKeys;
 import com.box.l10n.mojito.smartling.SmartlingClient;
 import com.box.l10n.mojito.smartling.SmartlingClientException;
-import com.box.l10n.mojito.smartling.SmartlingJsonKeys;
 import com.box.l10n.mojito.smartling.request.Binding;
 import com.box.l10n.mojito.smartling.request.Bindings;
-import com.box.l10n.mojito.smartling.response.ContextUpload;
 import com.box.l10n.mojito.smartling.response.File;
-import com.box.l10n.mojito.smartling.response.Key;
 import com.box.l10n.mojito.smartling.response.StringInfo;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -48,7 +43,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -311,7 +305,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
         SmartlingOptions options = SmartlingOptions.parseList(optionList);
 
         if (options.isJsonSync()) {
-            thirdPartyTMSSmartlingWithJson.pull(repository, projectId, pluralSeparator, localeMapping, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
+            thirdPartyTMSSmartlingWithJson.pull(repository, projectId, localeMapping);
             return;
         }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitDTO.java
@@ -117,6 +117,10 @@ public class TextUnitDTO {
         return tmTextUnitVariantId != null;
     }
 
+    public boolean hasEmptyTranslation() {
+        return target == null || target.isEmpty();
+    }
+
     public Long getLastSuccessfulAssetExtractionId() {
         return lastSuccessfulAssetExtractionId;
     }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJsonTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJsonTest.java
@@ -4,24 +4,32 @@ import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.AssetContent;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.assetcontent.AssetContentService;
 import com.box.l10n.mojito.service.repository.RepositoryService;
+import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingJsonConverter;
 import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingOptions;
 import com.box.l10n.mojito.service.tm.importer.TextUnitBatchImporterService;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.smartling.SmartlingClient;
+import com.box.l10n.mojito.smartling.SmartlingJsonKeys;
 import com.box.l10n.mojito.smartling.SmartlingTestConfig;
+import com.box.l10n.mojito.smartling.response.File;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,10 +37,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
 
 public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
 
@@ -49,6 +60,9 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
 
     @Autowired(required = false)
     ThirdPartyTMSSmartlingWithJson thirdPartyTMSSmartlingWithJson;
+
+    @Mock
+    ThirdPartyTMSSmartlingWithJson thirdPartyTMSSmartlingWithJsonMock;
 
     @Autowired(required = false)
     ThirdPartyService thirdPartyService;
@@ -68,8 +82,14 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
     @Autowired
     TextUnitBatchImporterService textUnitBatchImporterService;
 
+    @Mock
+    TextUnitBatchImporterService textUnitBatchImporterServiceMock;
+
     @Autowired
     TextUnitSearcher textUnitSearcher;
+
+
+    SmartlingJsonConverter smartlingJsonConverter = new SmartlingJsonConverter(ObjectMapper.withIndentedOutput(), new SmartlingJsonKeys());
 
     @Test
     public void testJsonWithICUMessagFormats() throws Exception {
@@ -127,7 +147,7 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
 
         waitForCondition("eventually we should be able to pull", () -> {
             logger.debug("Pulling...");
-            thirdPartyTMSSmartlingWithJson.pull(repository, testConfig.projectId, null, ImmutableMap.of(), null, null, smartlingOptions);
+            thirdPartyTMSSmartlingWithJson.pull(repository, testConfig.projectId, ImmutableMap.of());
             return true;
         }, 3, 1000);
 
@@ -150,6 +170,168 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
                 );
 
         thirdPartyService.mapMojitoAndThirdPartyTextUnits(repository, testConfig.getProjectId(), null, Arrays.asList("json-sync=true"));
+    }
+
+    @Test
+    public void testGetTranslatedUnits() {
+        TextUnitDTO translatedTextUnitDto = new TextUnitDTO();
+        translatedTextUnitDto.setTmTextUnitId(1L);
+        translatedTextUnitDto.setAssetPath("assetPath");
+        translatedTextUnitDto.setName("name-1");
+        translatedTextUnitDto.setTarget("target-1");
+        translatedTextUnitDto.setComment("comment-1");
+
+        TextUnitDTO untranslatedTextUnitDto = new TextUnitDTO();
+        untranslatedTextUnitDto.setTmTextUnitId(2L);
+        untranslatedTextUnitDto.setAssetPath("assetPath");
+        untranslatedTextUnitDto.setName("name-2");
+        untranslatedTextUnitDto.setTarget("");
+        untranslatedTextUnitDto.setComment("comment-2");
+
+        TextUnitDTO untranslatedTextUnitDtoWithOriginalString = new TextUnitDTO();
+        untranslatedTextUnitDtoWithOriginalString.setTmTextUnitId(2L);
+        untranslatedTextUnitDtoWithOriginalString.setAssetPath("assetPath");
+        untranslatedTextUnitDtoWithOriginalString.setName("name-2");
+        untranslatedTextUnitDtoWithOriginalString.setTarget("target-2");
+        untranslatedTextUnitDtoWithOriginalString.setComment("comment-2");
+
+        ImmutableList<TextUnitDTO> textUnitDTOS = ImmutableList.of(translatedTextUnitDto, untranslatedTextUnitDto);
+        ImmutableList<TextUnitDTO> textUnitDTOSWithOriginalStrings = ImmutableList.of(translatedTextUnitDto, untranslatedTextUnitDtoWithOriginalString);
+
+        ThirdPartyTMSSmartlingWithJson thirdPartyTMSSmartlingWithJson = new ThirdPartyTMSSmartlingWithJson(null, null, null, null, null);
+
+        ImmutableList<TextUnitDTO> result = thirdPartyTMSSmartlingWithJson.getTranslatedUnits(textUnitDTOS, textUnitDTOSWithOriginalStrings);
+
+        // Only expecting the first text unit to be returned
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(translatedTextUnitDto.getTmTextUnitId(), result.get(0).getTmTextUnitId());
+    }
+
+    @Test
+    public void testPullWithUntranslatedUnits() throws Exception {
+        String repositoryName = testIdWatcher.getEntityName("repository");
+        Repository repository = repositoryService.createRepository(repositoryName);
+        RepositoryLocale repositoryLocaleFrFR = repositoryService.addRepositoryLocale(repository, "fr-FR");
+        File smartlingFile = new File();
+        String projectId = "testProject";
+        String smartlingLocale = "fr-FR";
+        ImmutableMap<String, String> localeMapping = ImmutableMap.of();
+
+        String smartlingJsonResponse = "" +
+                "{\n" +
+                "  \"smartling\" : {\n" +
+                "    \"translate_paths\" : {\n" +
+                "      \"path\" : \"*/string\",\n" +
+                "      \"instruction\" : \"*/note\",\n" +
+                "      \"key\" : \"*/key\"\n" +
+                "    },\n" +
+                "    \"string_format\" : \"icu\",\n" +
+                "    \"variants_enabled\" : \"true\"\n" +
+                "  },\n" +
+                "  \"strings\" : [\n" +
+                "  {\n" +
+                "    \"key\" : \"connectAccountButton\",\n" +
+                "    \"tmTextUnitId\" : 1,\n" +
+                "    \"assetPath\" : \"en.properties\",\n" +
+                "    \"name\" : \"connectAccount.connectAccountButton\",\n" +
+                "    \"string\" : \"Associer le compte\",\n" +
+                "    \"note\" : \" connect account note\"\n" +
+                "  },\n" +
+                "\n" +
+                "  {\n" +
+                "    \"key\" : \"connectAccount.connectInstruction\",\n" +
+                "    \"tmTextUnitId\" : 2,\n" +
+                "    \"assetPath\" : \"en.properties\",\n" +
+                "    \"name\" : \"connectAccount.connectInstruction\",\n" +
+                // Untranslated string returned as an empty string
+                "    \"string\" : \"\",\n" +
+                "    \"note\" : \" connect instruction note\"\n" +
+                "  }" +
+                "]}";
+
+        String smartlingJsonResponseWithOriginalString = "" +
+                "{\n" +
+                "  \"smartling\" : {\n" +
+                "    \"translate_paths\" : {\n" +
+                "      \"path\" : \"*/string\",\n" +
+                "      \"instruction\" : \"*/note\",\n" +
+                "      \"key\" : \"*/key\"\n" +
+                "    },\n" +
+                "    \"string_format\" : \"icu\",\n" +
+                "    \"variants_enabled\" : \"true\"\n" +
+                "  },\n" +
+                "  \"strings\" : [\n" +
+                "  {\n" +
+                "    \"key\" : \"connectAccountButton\",\n" +
+                "    \"tmTextUnitId\" : 1,\n" +
+                "    \"assetPath\" : \"en.properties\",\n" +
+                "    \"name\" : \"connectAccount.connectAccountButton\",\n" +
+                "    \"string\" : \"Associer le compte\",\n" +
+                "    \"note\" : \" connect account note\"\n" +
+                "  },\n" +
+                "\n" +
+                "  {\n" +
+                "    \"key\" : \"connectAccount.connectInstruction\",\n" +
+                "    \"tmTextUnitId\" : 2,\n" +
+                "    \"assetPath\" : \"en.properties\",\n" +
+                "    \"name\" : \"connectAccount.connectInstruction\",\n" +
+                // Untranslated string returned as the original string:
+                "    \"string\" : \"Connect your account.\",\n" +
+                "    \"note\" : \" connect instruction note\"\n" +
+                "  }" +
+                "]}";
+
+        Mockito.doCallRealMethod()
+                .when(thirdPartyTMSSmartlingWithJsonMock)
+                .pull(repository, projectId, localeMapping);
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.hasEmptyTranslations(any()))
+                .thenCallRealMethod();
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getTranslatedUnits(any(), any()))
+                .thenCallRealMethod();
+
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getRepositoryFilesFromProject(repository, projectId))
+                .thenReturn(ImmutableList.of(smartlingFile));
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getRepositoryLocaleWithoutRootStream(repository))
+                .thenReturn(Stream.of(repositoryLocaleFrFR));
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getSmartlingLocale(localeMapping, repositoryLocaleFrFR))
+                .thenReturn(smartlingLocale);
+
+        thirdPartyTMSSmartlingWithJsonMock.smartlingJsonConverter = smartlingJsonConverter;
+        thirdPartyTMSSmartlingWithJsonMock.textUnitBatchImporterService = textUnitBatchImporterServiceMock;
+
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getLocalizedFileContent(projectId, smartlingFile, smartlingLocale, false))
+                .thenReturn(smartlingJsonResponseWithOriginalString);
+
+        // For the first pass, mock a fully translated response
+        thirdPartyTMSSmartlingWithJsonMock.pull(repository, projectId, localeMapping);
+
+        ArgumentCaptor<ImmutableList<TextUnitDTO>> dtoListCaptor = ArgumentCaptor.forClass(ImmutableList.class);
+        Mockito.verify(textUnitBatchImporterServiceMock, times(1))
+                .importTextUnits(dtoListCaptor.capture(), anyBoolean(), anyBoolean());
+        ImmutableList<TextUnitDTO> translatedUnits = dtoListCaptor.getValue();
+
+        // Expecting two fully translated units
+        Assert.assertEquals(2, translatedUnits.size());
+
+
+        // For the second pass, mock a partially translated response on the initial call
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getRepositoryLocaleWithoutRootStream(repository))
+                .thenReturn(Stream.of(repositoryLocaleFrFR));
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getLocalizedFileContent(projectId, smartlingFile, smartlingLocale, false))
+                .thenReturn(smartlingJsonResponse);
+        Mockito.when(thirdPartyTMSSmartlingWithJsonMock.getLocalizedFileContent(projectId, smartlingFile, smartlingLocale, true))
+                .thenReturn(smartlingJsonResponseWithOriginalString);
+
+        thirdPartyTMSSmartlingWithJsonMock.pull(repository, projectId, localeMapping);
+
+        dtoListCaptor = ArgumentCaptor.forClass(ImmutableList.class);
+        Mockito.verify(textUnitBatchImporterServiceMock, times(2))
+                .importTextUnits(dtoListCaptor.capture(), anyBoolean(), anyBoolean());
+        translatedUnits = dtoListCaptor.getValue();
+
+        // Expecting two fully translated units
+        Assert.assertEquals(1, translatedUnits.size());
+
     }
 
     List<TextUnitDTO> getRepositoryTextUnits(Repository repository) {


### PR DESCRIPTION
Fix issue where untranslated strings would be imported into Mojito and be
marked as rejected. Solved by disambiguating between actual empty
translated strings and untranslated strings by making an additional call
to Smartling to export the untranslated strings in a different format and
filtering out any untranslated strings before import.