### PR TITLE
Add fallback repository option for extract-diff

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
@@ -82,6 +82,14 @@ public class CommandHelper {
     }
 
     /**
+     * Get all repositories
+     * @return
+     */
+    public List<Repository> getAllRepositories() {
+            return repositoryClient.getRepositories(null);
+    }
+
+    /**
      * Get list of {@link com.box.l10n.mojito.cli.filefinder.FileMatch} from
      * source directory
      *

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extraction-diffs/source1_source1/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extraction-diffs/source1_source1/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,6 @@
+{
+  "currentFilterConfigIdOverride" : null,
+  "currentFilterOptions" : [ "sometestoption=value1" ],
+  "addedTextunits" : [ ],
+  "removedTextunits" : [ ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extraction-diffs/source3_source1/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extraction-diffs/source3_source1/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,20 @@
+{
+  "currentFilterConfigIdOverride" : null,
+  "currentFilterOptions" : [ "sometestoption=value1" ],
+  "addedTextunits" : [ {
+    "name" : "1 day update --- 1_day_duration",
+    "source" : "1 day update",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  } ],
+  "removedTextunits" : [ {
+    "name" : "1 day --- 1_day_duration",
+    "source" : "1 day",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  } ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extractions/source1/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extractions/source1/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,83 @@
+{
+  "name" : "source1",
+  "textunits" : [ {
+    "name" : "100 character description: --- 100_character_description_",
+    "source" : "100 character description:",
+    "comments" : null,
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:2" ]
+  }, {
+    "name" : "15 min --- 15_min_duration",
+    "source" : "15 min",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:4" ]
+  }, {
+    "name" : "1 day --- 1_day_duration",
+    "source" : "1 day",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  }, {
+    "name" : "1 hour --- 1_hour_duration",
+    "source" : "1 hour",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  }, {
+    "name" : "1 month --- 1_month_duration",
+    "source" : "1 month",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:10" ]
+  }, {
+    "name" : "There is {number} car --- car _zero",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "zero",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _one",
+    "source" : "There is {number} car",
+    "comments" : "Test plural",
+    "pluralForm" : "one",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _two",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "two",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _few",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "few",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _many",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "many",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _other",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "other",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  } ],
+  "filterConfigIdOverride" : null,
+  "filterOptions" : [ "sometestoption=value1" ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extractions/source3/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/expected/extractions/source3/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,83 @@
+{
+  "name" : "source3",
+  "textunits" : [ {
+    "name" : "100 character description: --- 100_character_description_",
+    "source" : "100 character description:",
+    "comments" : null,
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:2" ]
+  }, {
+    "name" : "15 min --- 15_min_duration",
+    "source" : "15 min",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:4" ]
+  }, {
+    "name" : "1 day update --- 1_day_duration",
+    "source" : "1 day update",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  }, {
+    "name" : "1 hour --- 1_hour_duration",
+    "source" : "1 hour",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  }, {
+    "name" : "1 month --- 1_month_duration",
+    "source" : "1 month",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:10" ]
+  }, {
+    "name" : "There is {number} car --- car _zero",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "zero",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _one",
+    "source" : "There is {number} car",
+    "comments" : "Test plural",
+    "pluralForm" : "one",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _two",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "two",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _few",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "few",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _many",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "many",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  }, {
+    "name" : "There is {number} car --- car _other",
+    "source" : "There are {number} cars",
+    "comments" : "Test plural",
+    "pluralForm" : "other",
+    "pluralFormOther" : "There is {number} car --- car _other",
+    "usages" : [ "file.js:20" ]
+  } ],
+  "filterConfigIdOverride" : null,
+  "filterOptions" : [ "sometestoption=value1" ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/input/source3/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionDiffCommandTest_IO/testRepositoryFallback/input/source3/LC_MESSAGES/messages.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day update"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""


### PR DESCRIPTION
Add fallback --push-to-fallback option to the extract-diff CLI command to support easier repo renaming and migrations.