### PR TITLE
Change fallback logic to reduce DB calls

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionDiffCommand.java
@@ -167,13 +167,13 @@ public class ExtractionDiffCommand extends Command {
             throw new CommandException(msobe.getMessage());
         }
 
-        pushToRepository = getValidRepositoryName();
         if (pushToRepository != null) {
             boolean hasAddedTextUnits = extractionDiffService.hasAddedTextUnits(extractionDiffPaths);
 
             if (!hasAddedTextUnits) {
                 consoleWriter.a("The diff is empty, don't push to repository: ").fg(Ansi.Color.CYAN).a(pushToRepository).println();
             } else {
+                pushToRepository = getValidRepositoryName();
                 consoleWriter.a("Push asset diffs to repository: ").fg(Ansi.Color.CYAN).a(pushToRepository).println(2);
                 pushToRepository(extractionDiffPaths);
             }


### PR DESCRIPTION
Avoid DB calls if no text units have been added in the latest diff extraction.