### PR TITLE
Move log to translation_needed block on integrity check failure to avoid excessive logging

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/TextUnitWS.java
@@ -361,7 +361,7 @@ public class TextUnitWS {
             tmTextUnitIntegrityCheckService.checkTMTextUnitIntegrity(textUnitCheckBody.getTmTextUnitId(), textUnitCheckBody.getContent());
             result.setCheckResult(true);
         } catch (IntegrityCheckException e) {
-            logger.info("Integrity check failed for text unit id {}, content {}: {}", textUnitCheckBody.getTmTextUnitId(), textUnitCheckBody.getContent(), e.getMessage());
+            logger.info("Integrity check failed for text unit id {}, content {}: {}", textUnitCheckBody.getTmTextUnitId(), textUnitCheckBody.getContent(), e);
             result.setCheckResult(false);
             result.setFailureDetail(e.getMessage());
         }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
@@ -245,15 +245,14 @@ public class TextUnitBatchImporterService {
                     textUnitChecker.check(currentTextUnit.getSource(), textUnitForBatchImport.getContent());
                 } catch (IntegrityCheckException ice) {
 
-                    logger.info("Integrity check failed for string with source {}, content {}: {}", currentTextUnit.getSource(),
-                            textUnitForBatchImport.getContent(), ice.getMessage());
-
                     boolean hasSameTarget = textUnitForBatchImport.getContent().equals(currentTextUnit.getTarget());
 
                     if (hasSameTarget && keepStatusIfCheckFailedAndSameTarget) {
                         textUnitForBatchImport.setIncludedInLocalizedFile(currentTextUnit.isIncludedInLocalizedFile());
                         textUnitForBatchImport.setStatus(currentTextUnit.getStatus());
                     } else {
+                        logger.info("Integrity check failed for string with source {}, content {}: {}", currentTextUnit.getSource(),
+                                textUnitForBatchImport.getContent(), ice);
                         textUnitForBatchImport.setIncludedInLocalizedFile(false);
                         textUnitForBatchImport.setStatus(Status.TRANSLATION_NEEDED);
                     }


### PR DESCRIPTION
Moving the log on integrity checker exception to log only when an exception has occurred and the text unit status is changed to translation_needed to avoid excessive logging when the text unit status is to be kept the same.