### PR TITLE
Added MessageFormatDoubleBracesIntegrityChecker with unit tests

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
@@ -8,6 +8,7 @@ package com.box.l10n.mojito.rest.entity;
 public enum IntegrityCheckerType {
 
     MESSAGE_FORMAT,
+    MESSAGE_FORMAT_DOUBLE_BRACES,
     PRINTF_LIKE,
     PRINTF_LIKE_IGNORE_PERCENTAGE_AFTER_BRACKETS,
     PRINTF_LIKE_VARIABLE_TYPE,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerType.java
@@ -8,6 +8,7 @@ package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
 public enum IntegrityCheckerType {
 
     MESSAGE_FORMAT(MessageFormatIntegrityChecker.class.getName()),
+    MESSAGE_FORMAT_DOUBLE_BRACES(MessageFormatDoubleBracesIntegrityChecker.class.getName()),
     PRINTF_LIKE(PrintfLikeIntegrityChecker.class.getName()),
     SIMPLE_PRINTF_LIKE(SimplePrintfLikeIntegrityChecker.class.getName()),
     PRINTF_LIKE_IGNORE_PERCENTAGE_AFTER_BRACKETS(PrintfLikeIgnorePercentageAfterBracketsIntegrityChecker.class.getName()),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/MessageFormatDoubleBracesIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/MessageFormatDoubleBracesIntegrityChecker.java
@@ -1,0 +1,45 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import java.util.ArrayDeque;
+
+/**
+ * Checks the validity of the message format when double braces are used as placeholders in the target content.
+ *
+ * Verifies correct number of brackets in string then replaces double braces with a single brace and
+ * runs the {@link MessageFormatIntegrityChecker} checks.
+ */
+public class MessageFormatDoubleBracesIntegrityChecker extends MessageFormatIntegrityChecker {
+
+    private static final String LEFT_DOUBLE_BRACES_REGEX = "\\{\\{.*?";
+    private static final String RIGHT_DOUBLE_BRACES_REGEX = "\\}\\}.*?";
+
+    @Override
+    public void check(String source, String content) throws MessageFormatIntegrityCheckerException {
+        verifyEqualNumberOfBraces(source);
+        verifyEqualNumberOfBraces(content);
+        super.check(replaceDoubleBracesWithSingle(source), replaceDoubleBracesWithSingle(content));
+    }
+
+    private void verifyEqualNumberOfBraces(String str) throws MessageFormatIntegrityCheckerException {
+        ArrayDeque<Character> stack = new ArrayDeque<>();
+        for (Character c : str.toCharArray()) {
+            if (c.equals('{')) {
+                stack.push(c);
+                continue;
+            } else if (c.equals('}')) {
+                if (stack.isEmpty()) {
+                    throw new MessageFormatIntegrityCheckerException("Invalid pattern, closing bracket found with no associated opening bracket.");
+                }
+                stack.pop();
+            }
+        }
+        if (!stack.isEmpty()) {
+            throw new MessageFormatIntegrityCheckerException("Invalid pattern, there is more left than right braces in string.");
+        }
+    }
+
+    private String replaceDoubleBracesWithSingle(String str) {
+        return str.replaceAll(LEFT_DOUBLE_BRACES_REGEX, "{")
+                .replaceAll(RIGHT_DOUBLE_BRACES_REGEX, "}");
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/MessageFormatDoubleBracesIntegrityCheckerTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/MessageFormatDoubleBracesIntegrityCheckerTest.java
@@ -1,0 +1,124 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class MessageFormatDoubleBracesIntegrityCheckerTest {
+
+    @Test
+    public void testCompilationCheckWorks() throws IntegrityCheckException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{numFiles, plural, one{# There is one file} other{There are # files}}}";
+        String target = "{{numFiles, plural, one{Il y a un fichier} other{Il y a # fichiers}}}";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testCompilationCheckWorksWithMoreForms() throws IntegrityCheckException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{numFiles, plural, one{{# There is one file}} other{{There are # files}}}}";
+        String target = "{{numFiles, plural, zero{{Il n'y a pas de fichier}} one{{Il y a un fichier}} other{{Il y a # fichiers}}}}";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testCompilationCheckFailsIfMissingRightBracket() throws IntegrityCheckException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{numFiles, plural, one{{# There is one file}} other{{There are # files}}}}";
+        String target = "{{numFiles, plural, one{{Il y a un fichier}} other{{Il y a # fichiers}}}";
+
+        try {
+            checker.check(source, target);
+            fail("MessageFormatIntegrityCheckerException must be thrown");
+        } catch (MessageFormatIntegrityCheckerException e) {
+            assertEquals("Invalid pattern, there is more left than right braces in string.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCompilationCheckFailsIfMissingLeftBracket() throws IntegrityCheckException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{numFiles, plural, one{{# There is one file}} other{{There are # files}}}}";
+        String target = "{numFiles, plural, one{{Il y a un fichier}} other{{Il y a # fichiers}}}}";
+
+        try {
+            checker.check(source, target);
+            fail("MessageFormatIntegrityCheckerException must be thrown");
+        } catch (MessageFormatIntegrityCheckerException e) {
+            assertEquals("Invalid pattern, closing bracket found with no associated opening bracket.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCompilationCheckFailsIfPluralElementGetsTranslated() throws IntegrityCheckException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{numFiles, plural, one{{# There is one file}} other{{There are # files}}}}";
+        String target = "{{numFiles, plural, un{{Il y a un fichier}} autre{{Il y a # fichiers}}}}";
+
+        try {
+            checker.check(source, target);
+            fail("Exception must be thrown");
+        } catch (MessageFormatIntegrityCheckerException e) {
+            assertEquals("Invalid pattern", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNumberOfPlaceholder() throws MessageFormatIntegrityCheckerException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "At {{1,time}} on {{1,date}}, there was {{2}} on planet {{0,number,integer}}.";
+        String target = "At {{1,time}} on {{1,date}}, there was {{2}} on planet {{0,number,integer}}.";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testWrongNumberOfPlaceholder() throws MessageFormatIntegrityCheckerException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "At {{1,time}} on {{1,date}}, there was {{2}} on planet {{0,number,integer}}.";
+        String target = "At on {{1,date}}, there was {{2}} on planet {{0,number,integer}}.";
+
+        try {
+            checker.check(source, target);
+            fail("Exception must be thrown");
+        } catch (MessageFormatIntegrityCheckerException e) {
+            assertEquals("Number of top level placeholders in source (4) and target (3) is different", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDoubleAndSingleBracketsInUse() throws MessageFormatIntegrityCheckerException {
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{username}} likes skydiving with {other_user}";
+        String target = "{{username}} aime le saut en parachute avec {other_user}";
+
+        checker.check(source, target);
+    }
+
+    @Test
+    public void testNamedParametersChanged() throws MessageFormatIntegrityCheckerException {
+
+        MessageFormatDoubleBracesIntegrityChecker checker = new MessageFormatDoubleBracesIntegrityChecker();
+        String source = "{{username}} likes skydiving";
+        String target = "{{utilisateur}} aime le saut en parachute";
+
+        try {
+            checker.check(source, target);
+            fail("Exception must be thrown");
+        } catch (MessageFormatIntegrityCheckerException e) {
+            assertEquals("Different placeholder name in source and target", e.getMessage());
+        }
+    }
+
+
+}


### PR DESCRIPTION
Integrity checker that verifies strings where double curly brackets are used as placeholder tokens, it extends the existing MessageFormatIntegrityChecker class that validates strings against the icu4j MessageFormat.

First the checker validates that there is an equal number of left and right brackets in the source and content strings, then it replaces double curly brackets with single brackets before executing the MessageFormatIntegrityChecker checks.