### PR TITLE
Setting default encoding in  RawDocument to UTF-8

### DIFF
--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsv/expected/demo_fr-CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsv/expected/demo_fr-CA.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+100_character_description_,100 character description:,Description de 100 caractères :,
 15_min_duration,15 min,15 min,File lock dialog duration
 1_day_duration,1 day,1 jour,File lock dialog duration
 1_hour_duration,1 hour,1 heure,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsv/expected/demo_fr-FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsv/expected/demo_fr-FR.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+100_character_description_,100 character description:,Description de 100 caractères :,
 15_min_duration,15 min,15 min,File lock dialog duration
 1_day_duration,1 day,1 jour,File lock dialog duration
 1_hour_duration,1 hour,1 heure,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsv/expected/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsv/expected/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,100文字の説明:,
+100_character_description_,100 character description:,100文字の説明:,
 15_min_duration,15 min,15分,File lock dialog duration
 1_day_duration,1 day,1日,File lock dialog duration
 1_hour_duration,1 hour,1時間,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJson/expected/demo_fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJson/expected/demo_fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJson/expected/demo_fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJson/expected/demo_fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJson/expected/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJson/expected/demo_ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonDefaultFormatJs/expected/fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonDefaultFormatJs/expected/fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonDefaultFormatJs/expected/fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonDefaultFormatJs/expected/fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonDefaultFormatJs/expected/ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonDefaultFormatJs/expected/ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonI18NextParser/expected/locales/fr-CA/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonI18NextParser/expected/locales/fr-CA/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonI18NextParser/expected/locales/fr-FR/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonI18NextParser/expected/locales/fr-FR/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonI18NextParser/expected/locales/ja-JP/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonI18NextParser/expected/locales/ja-JP/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonNobasename/expected/fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonNobasename/expected/fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonNobasename/expected/fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonNobasename/expected/fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonNobasename/expected/ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonNobasename/expected/ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonWithNote/expected/demo_fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonWithNote/expected/demo_fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonWithNote/expected/demo_fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonWithNote/expected/demo_fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonWithNote/expected/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonWithNote/expected/demo_ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target/demo_fr-CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target/demo_fr-CA.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+100_character_description_,100 character description:,Description de 100 caractères :,
 15_min_duration,15 min,15 min,File lock dialog duration
 1_day_duration,1 day,1 jour,File lock dialog duration
 1_hour_duration,1 hour,1 heure,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target/demo_fr-FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target/demo_fr-FR.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,
+100_character_description_,100 character description:,Description de 100 caractères :,
 15_min_duration,15 min,15 min,File lock dialog duration
 1_day_duration,1 day,1 jour,File lock dialog duration
 1_hour_duration,1 hour,1 heure,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,100文字の説明:,
+100_character_description_,100 character description:,100文字の説明:,
 15_min_duration,15 min,15分,File lock dialog duration
 1_day_duration,1 day,1日,File lock dialog duration
 1_hour_duration,1 hour,1時間,File lock dialog duration

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target_modified/demo_fr-CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target_modified/demo_fr-CA.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,,
+100_character_description_,100 character description:,Description de 100 caractères :,,
 15_min_duration,15 min,15 min,File lock dialog duration,
 1_hour_duration,1 hour,1 heure,File lock dialog duration,
 1_month_duration,1 month,1 mois,File lock dialog duration,

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target_modified/demo_fr-FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target_modified/demo_fr-FR.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,Description de 100 caractères :,,
+100_character_description_,100 character description:,Description de 100 caractères :,,
 15_min_duration,15 min,15 min,File lock dialog duration,
 1_hour_duration,1 hour,1 heure,File lock dialog duration,
 1_month_duration,1 month,1 mois,File lock dialog duration,

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target_modified/demo_ja-JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsv/expected/target_modified/demo_ja-JP.csv
@@ -1,4 +1,4 @@
-﻿100_character_description_,100 character description:,100文字の説明:,,
+100_character_description_,100 character description:,100文字の説明:,,
 15_min_duration,15 min,15分,File lock dialog duration,
 1_hour_duration,1 hour,1時間,File lock dialog duration,
 1_month_duration,1 month,1か月,File lock dialog duration,

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target/demo_fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target/demo_fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target/demo_fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target/demo_fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target/demo_ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target_modified/demo_fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target_modified/demo_fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target_modified/demo_fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target_modified/demo_fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target_modified/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJson/expected/target_modified/demo_ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target/fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target/fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target/fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target/fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target/ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target/ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target_modified/fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target_modified/fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target_modified/fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target_modified/fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target_modified/ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonDefaultFormatJs/expected/target_modified/ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "defaultMessage": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target/_locales/fr_CA/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target/_locales/fr_CA/messages.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "message": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target/_locales/fr_FR/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target/_locales/fr_FR/messages.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "message": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target/_locales/ja_JP/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target/_locales/ja_JP/messages.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "message": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_CA/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_CA/messages.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "message": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_FR/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target_modified/_locales/fr_FR/messages.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "message": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target_modified/_locales/ja_JP/messages.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonFromChromeExtension/expected/target_modified/_locales/ja_JP/messages.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "message": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target/locales/fr-CA/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target/locales/fr-CA/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target/locales/fr-FR/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target/locales/fr-FR/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target/locales/ja-JP/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target/locales/ja-JP/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target_modified/locales/fr-CA/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target_modified/locales/fr-CA/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target_modified/locales/fr-FR/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target_modified/locales/fr-FR/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target_modified/locales/ja-JP/demo.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonI18NextParser/expected/target_modified/locales/ja-JP/demo.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target/fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target/fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target/fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target/fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target/ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target/ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target_modified/fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target_modified/fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target_modified/fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target_modified/fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "Description de 100 caractères :",
   // File lock dialog duration
   "15_min_duration": "15 min",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target_modified/ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonNobasename/expected/target_modified/ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": "100文字の説明:",
   // File lock dialog duration
   "15_min_duration": "15分",

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target/demo_fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target/demo_fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target/demo_fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target/demo_fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target/demo_ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "100文字の説明:"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target_modified/demo_fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target_modified/demo_fr-CA.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target_modified/demo_fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target_modified/demo_fr-FR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "Description de 100 caractères :"
   },

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target_modified/demo_ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonWithNote/expected/target_modified/demo_ja-JP.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "100_character_description_": {
     "string": "100文字の説明:"
   },

--- a/common/src/main/java/com/box/l10n/mojito/okapi/RawDocument.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/RawDocument.java
@@ -3,10 +3,12 @@ package com.box.l10n.mojito.okapi;
 import net.sf.okapi.common.LocaleId;
 import org.springframework.util.ReflectionUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -24,7 +26,7 @@ public class RawDocument extends net.sf.okapi.common.resource.RawDocument {
     }
 
     public RawDocument(CharSequence inputCharSequence, LocaleId sourceLocale, LocaleId targetLocale) {
-        super(inputCharSequence, sourceLocale, targetLocale);
+        super(new ByteArrayInputStream(inputCharSequence.toString().getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8.name().toLowerCase(), sourceLocale, targetLocale);
 
         Field inputURIField = ReflectionUtils.findField(RawDocument.class, "inputURI");
         ReflectionUtils.makeAccessible(inputURIField);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckStep.java
@@ -4,6 +4,7 @@ import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.TMTextUnitVariantComment;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
+import com.google.common.io.CharStreams;
 import net.sf.okapi.common.Event;
 import net.sf.okapi.common.LocaleId;
 import net.sf.okapi.common.pipeline.BasePipelineStep;
@@ -17,10 +18,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author aloison
@@ -70,7 +74,12 @@ public class IntegrityCheckStep extends BasePipelineStep {
     protected Event handleStartDocument(Event event) {
         logger.debug("Check integrity of document");
 
-        String documentContent = rawDocument.getInputCharSequence().toString();
+        String documentContent = null;
+        try {
+            documentContent = CharStreams.toString(rawDocument.getReader());
+        } catch (IOException e) {
+            logger.error("Error reading document content", e);
+        }
 
         // TODO(P1): do not hardcode the type here
         List<DocumentIntegrityChecker> documentIntegrityCheckers = integrityCheckerFactory.getDocumentCheckers("xliff");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -2515,7 +2515,7 @@ public class TMServiceTest extends ServiceTestBase {
                 + "  // Greeting from Main UI 3\n"
                 + "  \"hello3\": \"Hello 3\"\n"
                 + "}";
-        String expectedContent = "\uFEFF" + assetContent;
+        String expectedContent = assetContent;
 
         asset = assetService.createAssetWithContent(repo.getId(), "strings.json", assetContent);
         asset = assetRepository.findById(asset.getId()).orElse(null);
@@ -2573,7 +2573,7 @@ public class TMServiceTest extends ServiceTestBase {
                 "    \"note\": \"A description that shows the number of photos a user has.\"\n" +
                 "  }\n" +
                 "}";
-        String expectedContent = "\uFEFF" + assetContent;
+        String expectedContent = assetContent;
 
         asset = assetService.createAssetWithContent(repo.getId(), "strings.json", assetContent);
         asset = assetRepository.findById(asset.getId()).orElse(null);


### PR DESCRIPTION
Updated the okapi RawDocument to use a default encoding of UTF-8 as localized files were using UTF-16 as the default encoding which meant that a BOM was being added to the generated localized files.