### PR TITLE
Restrict image upload to specific formats

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -282,19 +282,24 @@ public class ThirdPartyService {
         if (!thirdPartyImageToTextUnits.isEmpty()) {
             logger.debug("There are text units to be mapped, upload image: {}", image.getName());
 
-            ThirdPartyTMSImage thirdPartyTMSImage = thirdPartyTMS.uploadImage(projectId, image.getName(), image.getContent());
+            try {
+                ThirdPartyTMSImage thirdPartyTMSImage = thirdPartyTMS.uploadImage(projectId, image.getName(), image.getContent());
 
-            ThirdPartyScreenshot thirdPartyScreenshot = new ThirdPartyScreenshot();
-            thirdPartyScreenshot.setScreenshot(screenshot);
-            thirdPartyScreenshot.setThirdPartyId(thirdPartyTMSImage.getId());
+                ThirdPartyScreenshot thirdPartyScreenshot = new ThirdPartyScreenshot();
+                thirdPartyScreenshot.setScreenshot(screenshot);
+                thirdPartyScreenshot.setThirdPartyId(thirdPartyTMSImage.getId());
 
-            logger.debug("Save screenshot mapping");
-            thirdPartyScreenshotRepository.save(thirdPartyScreenshot);
+                logger.debug("Save screenshot mapping");
+                thirdPartyScreenshotRepository.save(thirdPartyScreenshot);
 
-            logger.debug("Set the image id on the mappings");
-            thirdPartyImageToTextUnits.stream().forEach(t -> t.setImageId(thirdPartyScreenshot.getThirdPartyId()));
+                logger.debug("Set the image id on the mappings");
+                thirdPartyImageToTextUnits.stream().forEach(t -> t.setImageId(thirdPartyScreenshot.getThirdPartyId()));
 
-            thirdPartyTMS.createImageToTextUnitMappings(projectId, thirdPartyImageToTextUnits);
+                thirdPartyTMS.createImageToTextUnitMappings(projectId, thirdPartyImageToTextUnits);
+            } catch (UnsupportedImageFormatException e) {
+                logger.warn(e.getMessage());
+            }
+
         } else {
             logger.debug("No text units to be mapped so we don't upload the image (might be late to perform the mapping and/or it" +
                     "is not usefull to send the image)");

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/UnsupportedImageFormatException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/UnsupportedImageFormatException.java
@@ -1,0 +1,8 @@
+package com.box.l10n.mojito.service.thirdparty;
+
+public class UnsupportedImageFormatException extends RuntimeException {
+
+    public UnsupportedImageFormatException(String message) {
+        super(message);
+    }
+}

--- a/webapp/src/main/resources/public/js/stores/branches/BranchesScreenshotUploadModalStore.js
+++ b/webapp/src/main/resources/public/js/stores/branches/BranchesScreenshotUploadModalStore.js
@@ -10,6 +10,7 @@ class BranchesScreenshotUploadModalStore {
         this.setDefaultState();
         this.bindActions(BranchesScreenshotUploadActions);
         this.registerAsync(BranchesScreenshotUploadDataSource);
+        this.supportedImageExtensionsSet = new Set([".png", ".gif", ".tiff", ".jpg",".jpeg"])
     }
 
     setDefaultState() {
@@ -40,10 +41,14 @@ class BranchesScreenshotUploadModalStore {
     }
 
     uploadScreenshotImage() {
-        let generatedUuid = v4() + this.fileToUpload.name;
-        this.screenshotSrc = 'api/images/' + generatedUuid;
-        this.uploadInProgress = true;
-        this.getInstance().performUploadScreenshotImage(generatedUuid);
+        if (this.isImageExtensionSupported(this.fileToUpload.name)) {
+            let generatedUuid = v4() + this.fileToUpload.name;
+            this.screenshotSrc = 'api/images/' + generatedUuid;
+            this.uploadInProgress = true;
+            this.getInstance().performUploadScreenshotImage(generatedUuid);
+        } else {
+            this.errorMessage =  this.fileToUpload.name + " is not in .png, .gif, .tiff, .jpg or .jpeg format."
+        }
     }
 
     uploadScreenshotImageSuccess() {
@@ -86,6 +91,11 @@ class BranchesScreenshotUploadModalStore {
 
     changeImageForUpload(imageForUpload) {
         this.imageForUpload = imageForUpload;
+    }
+
+    isImageExtensionSupported(name) {
+        let fileExtension = this.fileToUpload.name.substring(this.fileToUpload.name.lastIndexOf(".")).toLowerCase();
+        return this.supportedImageExtensionsSet.has(fileExtension);
     }
 
     loadImage() {


### PR DESCRIPTION
Restrict files that are uploaded to have the following extensions:

- .png
- .jpg
- .jpeg
- .gif

Any other extensions will be rejected on the frontend, also added backend handling to skip uploading to ThirdParty if an unsupported extension is present.