### PR TITLE
Added RunChecks cli command with spell & comment/context checker

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -89,6 +89,12 @@
             <version>4.5.2.201704071617-r</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.gitlab.dumonts</groupId>
+            <artifactId>hunspell</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/Command.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/Command.java
@@ -3,9 +3,12 @@ package com.box.l10n.mojito.cli.command;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.text.MessageFormat;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for Commands, provides basic support for usage display.
@@ -116,4 +119,5 @@ public abstract class Command {
     public void setOriginalArgs(List<String> originalArgs) {
         this.originalArgs = originalArgs;
     }
+
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
@@ -1,0 +1,258 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.command.checks.AbstractCliChecker;
+import com.box.l10n.mojito.cli.command.checks.CliCheckResult;
+import com.box.l10n.mojito.cli.command.checks.CliCheckerExecutor;
+import com.box.l10n.mojito.cli.command.checks.CliCheckerOptions;
+import com.box.l10n.mojito.cli.command.checks.CliCheckerType;
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffPaths;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffService;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionPaths;
+import com.box.l10n.mojito.cli.command.extraction.MissingExtractionDirectoryExcpetion;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.phabricator.DifferentialRevision;
+import com.box.l10n.mojito.phabricator.PhabricatorMessageBuilder;
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+import com.google.common.collect.ImmutableMap;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Command to execute checks against any new source strings
+ */
+@Component
+@Scope("prototype")
+@Parameters(commandNames = {"extraction-check"}, commandDescription = "Execute checks against new source strings")
+public class ExtractionCheckCommand extends Command {
+
+    static Logger logger = LoggerFactory.getLogger(ExtractionDiffCommand.class);
+
+    @Autowired
+    ExtractionDiffService extractionDiffService;
+
+    @Autowired
+    ConsoleWriter consoleWriter;
+
+    @Autowired(required = false)
+    PhabricatorMessageBuilder phabricatorMessageBuilder;
+
+    @Autowired(required = false)
+    DifferentialRevision differentialRevision;
+
+    @Parameter(names = {"--checker-list", "-cl"}, arity = 1, required = true, description = "List of checks to be run against new source strings")
+    List<String> checkerList;
+
+    @Parameter(names = {"--hard-fail", "-hf"}, arity = 1, required = false, description = "List of checks that will cause a hard failure, use ALL if all checks should be hard failures")
+    List<String> hardFailList = new ArrayList<>();
+
+    @Parameter(names = {"--parameter-regexes", "-pr"}, arity = 1, required = false, description = "Regex types used to identify parameters in source strings")
+    List<String> parameterRegexList = new ArrayList<>();
+
+    @Parameter(names = {"--dictionary-file", "-df"}, arity = 1, required = false, description = "Path to the dictionary file to be used by the spelling check. The file must be in .dic format")
+    String dictionaryFilePath = null;
+
+    @Parameter(names = {"--dictionary-affix-file", "-daff"}, arity = 1, required = false, description = "Path to the dictionary affix file to be used by the spelling check. The file must be in .aff format")
+    String dictionaryAffixFilePath = null;
+
+    @Parameter(names = {"--dictionary-additions-file", "-daf"}, arity = 1, required = false, description = "Path to the dictionary additions file used for the spelling check. The file format is a new spelling per line.")
+    String dictionaryAdditionsFilePath = "";
+
+    @Parameter(names = {"--glossary-file", "-gf"}, arity = 1, required = false, description = "Path to the glossary file used for the glossary check. The file is a json formatted file containing an array of glossary term objects, each object contains the 'term' and a 'severity' which is 'MAJOR' or 'MINOR'.")
+    String glossaryFilePath = "";
+
+    @Parameter(names = {"--name", "-n"}, arity = 1, required = false, description = ExtractionDiffCommand.EXCTRACTION_DIFF_NAME_DESCRIPTION)
+    String extractionDiffName = null;
+
+    @Parameter(names = {"--objectid", "-oid"}, arity = 1, required = false, description = "Phabricator object id, required if adding a comment with check failures to Phabricator.")
+    String phabObjectId = null;
+
+    @Parameter(names = {"--phab-message-template", "-pmt"}, arity = 1, required = false, description = "Optional message template to customize the Phabricator notification message. eg. '{baseMessage}. Check [[https://build.org/1234|build]].' ")
+    String messageTemplate = "{baseMessage}";
+
+    @Parameter(names = {"--current", "-c"}, arity = 1, required = true, description = ExtractionDiffCommand.CURRENT_EXTRACTION_NAME_DESCRIPTION)
+    String currentExtractionName;
+
+    @Parameter(names = {"--base", "-b"}, arity = 1, required = true, description = ExtractionDiffCommand.BASE_EXTRACTION_NAME_DESCRIPTION)
+    String baseExtractionName;
+
+    @Parameter(names = {"--output-directory", "-o"}, arity = 1, required = false, description = ExtractionDiffCommand.OUTPUT_DIRECTORY_DESCRIPTION)
+    String outputDirectoryParam = ExtractionDiffPaths.DEFAULT_OUTPUT_DIRECTORY;
+
+    @Parameter(names = {"--input-directory", "-i"}, arity = 1, required = false, description = ExtractionDiffCommand.INPUT_DIRECTORY_DESCRIPTION)
+    String inputDirectoryParam = ExtractionPaths.DEFAULT_OUTPUT_DIRECTORY;
+
+    @Override
+    protected void execute() throws CommandException {
+
+        checkPhabricatorPreconditions();
+        ExtractionPaths baseExtractionPaths = new ExtractionPaths(inputDirectoryParam, baseExtractionName);
+        ExtractionPaths currentExtractionPaths = new ExtractionPaths(inputDirectoryParam, currentExtractionName);
+        ExtractionDiffPaths extractionDiffPaths = ExtractionDiffPaths.builder()
+                .outputDirectory(outputDirectoryParam)
+                .diffExtractionName(extractionDiffName)
+                .baseExtractorPaths(baseExtractionPaths)
+                .currentExtractorPaths(currentExtractionPaths)
+                .build();
+
+        List<AssetExtractionDiff> assetExtractionDiffs;
+
+        try {
+            if (extractionDiffService.hasAddedTextUnits(extractionDiffPaths)) {
+                assetExtractionDiffs = extractionDiffService.findAssetExtractionDiffsWithAddedTextUnits(extractionDiffPaths);
+                CliCheckerExecutor cliCheckerExecutor = getCliCheckerExecutor();
+                List<CliCheckResult> cliCheckerResults = executeChecks(cliCheckerExecutor, assetExtractionDiffs);
+                checkForHardFail(cliCheckerResults);
+                if(!cliCheckerResults.isEmpty()) {
+                    List<CliCheckResult> failures = getCheckerFailures(cliCheckerResults).collect(Collectors.toList());
+                    outputFailuresToCommandLine(failures);
+                    if (phabObjectId != null) {
+                        addCommentToPhabricatorRevision(failures);
+                    }
+                }
+            } else {
+                consoleWriter.newLine().a("No new strings in diff to be checked.").println();
+            }
+        } catch (MissingExtractionDirectoryExcpetion missingExtractionDirectoryException) {
+            throw new CommandException("Can't compute extraction diffs", missingExtractionDirectoryException);
+        }
+        consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Checks completed").println(2);
+    }
+
+    private void addCommentToPhabricatorRevision(List<CliCheckResult> cliCheckerFailures) {
+        consoleWriter.fg(Ansi.Color.YELLOW).newLine().a("Adding comment to Phabricator revision " + phabObjectId).println();
+        differentialRevision.addComment(phabObjectId, getPhabricatorMessage(buildPhabricatorComment(cliCheckerFailures)));
+    }
+
+    private void checkForHardFail(List<CliCheckResult> results) {
+        if(getCheckerHardFailures(results).count() > 0) {
+            String hardFailureListString = "The following checks had hard failures:" + System.lineSeparator() +
+                    getCheckerHardFailures(results).map(failure -> failure.getCheckName() + " failures: " + System.lineSeparator() + failure.getNotificationText() +  System.lineSeparator())
+                        .collect(Collectors.joining(System.lineSeparator()));
+            logger.debug(hardFailureListString);
+            throw new CommandException(hardFailureListString);
+        }
+    }
+
+    private List<CliCheckResult> executeChecks(CliCheckerExecutor cliCheckerExecutor, List<AssetExtractionDiff> assetExtractionDiffs) {
+        consoleWriter.newLine().a("Running checks against new strings").println();
+        return cliCheckerExecutor.executeChecks(assetExtractionDiffs).stream()
+                .filter(result -> !result.isSuccessful())
+                .collect(Collectors.toList());
+    }
+
+    private Stream<CliCheckResult> getCheckerFailures(List<CliCheckResult> results) {
+        return results.stream().filter(result -> !result.isSuccessful());
+    }
+
+    private Stream<CliCheckResult> getCheckerHardFailures(List<CliCheckResult> results) {
+        return getCheckerFailures(results).filter(CliCheckResult::isHardFail);
+    }
+
+    String getPhabricatorMessage(String notificationText) {
+
+        ImmutableMap<String, Object> messageParamMap = ImmutableMap.<String, Object>builder()
+                .put("icon", PhabricatorIcon.WARNING.toString())
+                .put("header", "**i18n source string checks failed**")
+                .put("notificationText", notificationText)
+                .build();
+        String message = "{icon} {header}" + System.lineSeparator() + System.lineSeparator() + "{notificationText}";
+        return phabricatorMessageBuilder.getFormattedPhabricatorMessage(messageTemplate, "baseMessage", phabricatorMessageBuilder.getBaseMessage(messageParamMap, message));
+    }
+
+    private String buildPhabricatorComment(List<CliCheckResult> failedCheck) {
+        String notification = failedCheck.stream().map(check -> "//**" + check.getCheckName() + "**//" + System.lineSeparator()).collect(Collectors.joining(System.lineSeparator()));
+        return "**Failed checks:**" + addDoubleNewLine() + notification + addDoubleNewLine() + "**Please correct the above issues in a new commit.**";
+    }
+
+    private String addDoubleNewLine() {
+        return System.lineSeparator() + System.lineSeparator();
+    }
+
+    private void checkPhabricatorPreconditions() {
+        if (phabObjectId != null) {
+            PhabricatorPreconditions.checkNotNull(differentialRevision);
+        }
+    }
+
+    private CliCheckerExecutor getCliCheckerExecutor() {
+        return new CliCheckerExecutor(generateCheckerList(generateCheckerOptions()));
+    }
+
+    private void outputFailuresToCommandLine(List<CliCheckResult> failedCheckNames) {
+        consoleWriter.fg(Ansi.Color.YELLOW).newLine().a("Failed checks: ").println();
+        failedCheckNames.stream().forEach(check -> {
+            consoleWriter.fg(Ansi.Color.YELLOW).newLine().a(check.getCheckName()).println();
+            consoleWriter.fg(Ansi.Color.YELLOW).newLine().a(check.getNotificationText().replaceAll("\\*", "\t*")).println();
+        });
+    }
+
+    private CliCheckerOptions generateCheckerOptions() {
+        Set<PlaceholderRegularExpressions> regexSet = generateParameterRegexSet();
+        Set<CliCheckerType> hardFailureSet = getClassNamesOfHardFailures();
+        return new CliCheckerOptions(regexSet, hardFailureSet, dictionaryAdditionsFilePath, glossaryFilePath, dictionaryFilePath, dictionaryAffixFilePath);
+    }
+
+    private Set<CliCheckerType> getClassNamesOfHardFailures() {
+        if(hardFailList.stream().anyMatch(checkName -> "ALL".equalsIgnoreCase(checkName))) {
+            return Stream.of(CliCheckerType.values()).collect(Collectors.toSet());
+        } else {
+            return hardFailList.stream().map(check -> {
+                try {
+                    return CliCheckerType.valueOf(check);
+                } catch (IllegalArgumentException e) {
+                    throw new CommandException("Unknown check name in hard fail list '" + check + "'");
+                }
+            }).collect(Collectors.toSet());
+        }
+    }
+
+    private Set<PlaceholderRegularExpressions> generateParameterRegexSet() {
+        return parameterRegexList.stream().map(regexName -> {
+            try {
+                return PlaceholderRegularExpressions.valueOf(regexName);
+            } catch (IllegalArgumentException e) {
+                throw new CommandException("Unknown parameter regex name " + regexName);
+            }
+        }).collect(Collectors.toSet());
+    }
+
+    private List<AbstractCliChecker> generateCheckerList(CliCheckerOptions checkerOptions) {
+        List<AbstractCliChecker> checkers = new ArrayList<>();
+        for (String s : checkerList) {
+            try {
+                AbstractCliChecker checker = CliCheckerType.valueOf(s).getCliChecker();
+                checker.setCliCheckerOptions(checkerOptions);
+                checkers.add(checker);
+            } catch (IllegalArgumentException e) {
+                throw new CommandException("Unknown check '" + s + "'");
+            }
+        }
+
+        return checkers;
+    }
+
+    private Optional<CliCheckerType> findByName(String checkName) {
+        CliCheckerType cliCheckerType = null;
+        try {
+            cliCheckerType = CliCheckerType.valueOf(checkName);
+        } catch (IllegalArgumentException e){
+            logger.debug("Unknown checker type " + checkName);
+        }
+
+        return Optional.ofNullable(cliCheckerType);
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorIcon.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorIcon.java
@@ -1,0 +1,21 @@
+package com.box.l10n.mojito.cli.command;
+
+enum PhabricatorIcon {
+    INFO("\u2139\uFE0F"),
+    WARNING("\u26A0\uFE0F"),
+    STOP("\uD83D\uDED1");
+    String str;
+
+    PhabricatorIcon(String str) {
+        this.str = str;
+    }
+
+    public String getStr() {
+        return str;
+    }
+
+    @Override
+    public String toString() {
+        return str;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
@@ -1,0 +1,54 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public abstract class AbstractCliChecker {
+
+    protected CliCheckerOptions cliCheckerOptions;
+
+    public static AbstractCliChecker createInstanceForClassName(String className) throws CliCheckerInstantiationException {
+        try {
+            Class<?> clazz = Class.forName(className);
+            return (AbstractCliChecker) clazz.newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new CliCheckerInstantiationException("Cannot create an instance of CliChecker using reflection", e);
+        }
+    }
+
+    public abstract CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs);
+
+    public boolean isHardFail() {
+        return cliCheckerOptions.getHardFailureSet().contains(getCliCheckerType());
+    }
+
+    public void setCliCheckerOptions(CliCheckerOptions options) {
+        this.cliCheckerOptions = options;
+    }
+
+    protected List<AssetExtractorTextUnit> getAddedTextUnits(List<AssetExtractionDiff> assetExtractionDiffs) {
+        return assetExtractionDiffs.stream().map(AssetExtractionDiff::getAddedTextunits).flatMap(List::stream).collect(Collectors.toList());
+    }
+
+    protected CliCheckResult createCliCheckerResult() {
+        return new CliCheckResult(isHardFail(), getCliCheckerType().name());
+    }
+
+    protected CliCheckerType getCliCheckerType() {
+        return CliCheckerType.findByClass(this.getClass());
+    }
+
+    protected List<String> getSourceStringsFromDiff(List<AssetExtractionDiff> assetExtractionDiffs) {
+        return getAddedTextUnits(assetExtractionDiffs).stream().map(AssetExtractorTextUnit::getSource).collect(Collectors.toList());
+    }
+
+    protected List<Pattern> getRegexPatterns() {
+        return cliCheckerOptions.getParameterRegexSet().stream().map(regex -> Pattern.compile(regex.getRegex())).collect(Collectors.toList());
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractPlaceholderDescriptionCheck.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractPlaceholderDescriptionCheck.java
@@ -1,0 +1,21 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+import java.util.Set;
+
+public abstract class AbstractPlaceholderDescriptionCheck {
+
+    public abstract Set<String> checkCommentForDescriptions(String source, String comment);
+
+    public Optional<String> getFailureText(String placeholder) {
+        String failureText = null;
+        if (StringUtils.isNumeric(placeholder)) {
+            failureText = "Missing description for placeholder number '" + placeholder + "' in comment.";
+        } else if (!placeholder.trim().isEmpty()) {
+            failureText ="Missing description for placeholder with name '" + placeholder + "' in comment.";
+        }
+        return Optional.ofNullable(failureText);
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckResult.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckResult.java
@@ -1,0 +1,44 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+public class CliCheckResult {
+
+    private final boolean hardFail;
+    private final String checkName;
+    private boolean successful = true;
+    private String notificationText = "";
+
+    public CliCheckResult(boolean hardFail, String checkName) {
+        this.hardFail = hardFail;
+        this.checkName = checkName;
+    }
+
+    public CliCheckResult(boolean successful, boolean hardFail, String checkName) {
+        this.successful = successful;
+        this.hardFail = hardFail;
+        this.checkName = checkName;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public String getNotificationText() {
+        return notificationText;
+    }
+
+    public boolean isHardFail() {
+        return hardFail;
+    }
+
+    public String getCheckName() {
+        return checkName;
+    }
+
+    public void setSuccessful(boolean successful) {
+        this.successful = successful;
+    }
+
+    public void setNotificationText(String notificationText) {
+        this.notificationText = notificationText;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerExecutor.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerExecutor.java
@@ -1,0 +1,21 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CliCheckerExecutor {
+
+    private final List<AbstractCliChecker> cliCheckerList;
+
+    public CliCheckerExecutor(List<AbstractCliChecker> cliCheckerList) {
+        this.cliCheckerList = cliCheckerList;
+    }
+
+    public List<CliCheckResult> executeChecks(List<AssetExtractionDiff> assetExtractionDiffs) {
+        return cliCheckerList.stream()
+                .map(check -> check.run(assetExtractionDiffs))
+                .collect(Collectors.toList());
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerInstantiationException.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerInstantiationException.java
@@ -1,0 +1,8 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+public class CliCheckerInstantiationException extends RuntimeException {
+
+    public CliCheckerInstantiationException(String message, Exception e){
+        super(message, e);
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerOptions.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerOptions.java
@@ -1,0 +1,56 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.phabricator.DifferentialDiff;
+import com.box.l10n.mojito.phabricator.DifferentialRevision;
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+
+import java.util.Set;
+
+public class CliCheckerOptions {
+
+    private final Set<PlaceholderRegularExpressions> parameterRegexSet;
+    private final Set<CliCheckerType> hardFailureSet;
+    private final String dictionaryAdditionsFilePath;
+    private final String glossaryFilePath;
+    private String dictionaryFilePath;
+    private String dictionaryAffixFilePath;
+
+    public CliCheckerOptions(Set<PlaceholderRegularExpressions> parameterRegexSet, Set<CliCheckerType> hardFailureSet, String dictionaryAdditionsFilePath, String glossaryFilePath) {
+        this.parameterRegexSet = parameterRegexSet;
+        this.hardFailureSet = hardFailureSet;
+        this.dictionaryAdditionsFilePath = dictionaryAdditionsFilePath;
+        this.glossaryFilePath = glossaryFilePath;
+    }
+
+    public CliCheckerOptions(Set<PlaceholderRegularExpressions> parameterRegexSet, Set<CliCheckerType> hardFailureSet, String dictionaryAdditionsFilePath,
+                             String glossaryFilePath, String dictionaryFilePath, String dictionaryAffixFilePath) {
+        this(parameterRegexSet, hardFailureSet, dictionaryAdditionsFilePath, glossaryFilePath);
+        this.dictionaryFilePath = dictionaryFilePath;
+        this.dictionaryAffixFilePath = dictionaryAffixFilePath;
+    }
+    
+    public Set<PlaceholderRegularExpressions> getParameterRegexSet() {
+        return parameterRegexSet;
+    }
+
+    public Set<CliCheckerType> getHardFailureSet() {
+        return hardFailureSet;
+    }
+
+    public String getDictionaryAdditionsFilePath() {
+        return dictionaryAdditionsFilePath;
+    }
+
+    public String getGlossaryFilePath() {
+        return glossaryFilePath;
+    }
+
+    public String getDictionaryFilePath() {
+        return dictionaryFilePath;
+    }
+
+    public String getDictionaryAffixFilePath() {
+        return dictionaryAffixFilePath;
+    }
+
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerType.java
@@ -1,0 +1,42 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.CommandException;
+
+public enum CliCheckerType {
+
+    SPELL_CHECKER(SpellCliChecker.class),
+    CONTEXT_COMMENT_CHECKER(ContextAndCommentCliChecker.class);
+
+    Class<? extends AbstractCliChecker> type;
+
+    CliCheckerType(Class<? extends AbstractCliChecker> type) {
+        this.type = type;
+    }
+
+    public AbstractCliChecker getCliChecker() {
+        AbstractCliChecker checker;
+
+        try {
+            checker = type.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new CommandException("Can't create CliChecker", e);
+        }
+
+        return checker;
+    }
+
+    public static CliCheckerType findByClass(Class<? extends AbstractCliChecker> clazz) {
+        CliCheckerType[] cliCheckerTypes = CliCheckerType.values();
+        for(CliCheckerType cliCheckerType : cliCheckerTypes) {
+            if (cliCheckerType.getType() == clazz) {
+                return cliCheckerType;
+            }
+        }
+        throw new CommandException("Unknown checker class type " + clazz.getName());
+    }
+
+    private Class<? extends AbstractCliChecker> getType() {
+        return type;
+    }
+
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
@@ -1,0 +1,112 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * {@link AbstractCliChecker} that verifies the comment and context parameters are provided and
+ * are not identical.
+ *
+ * @author mallen
+ */
+public class ContextAndCommentCliChecker extends AbstractCliChecker {
+
+    static Logger logger = LoggerFactory.getLogger(ContextAndCommentCliChecker.class);
+
+    static class ContextAndCommentCliCheckerResult {
+        String sourceString;
+        String failureMessage;
+        boolean failed;
+
+        public ContextAndCommentCliCheckerResult(boolean failed, String sourceString, String failureMessage) {
+            this.sourceString = sourceString;
+            this.failureMessage = failureMessage;
+            this.failed = failed;
+        }
+
+        public ContextAndCommentCliCheckerResult(boolean failed) {
+            this.failed = failed;
+        }
+
+        public String getSourceString() {
+            return sourceString;
+        }
+
+        public String getFailureMessage() {
+            return failureMessage;
+        }
+
+        public boolean isFailed() {
+            return failed;
+        }
+    }
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        CliCheckResult cliCheckResult = createCliCheckerResult();
+        List<ContextAndCommentCliCheckerResult> results = runChecks(assetExtractionDiffs);
+        if(results.stream().anyMatch(ContextAndCommentCliCheckerResult::isFailed)){
+            cliCheckResult.setSuccessful(false);
+            cliCheckResult.setNotificationText("Context and comment check found failures:" + System.lineSeparator() +
+                    results.stream().filter(ContextAndCommentCliCheckerResult::isFailed)
+                        .map(result -> "* Source string '" + result.getSourceString() + "' failed check with error: "
+                            + result.getFailureMessage())
+                        .collect(Collectors.joining(System.lineSeparator())) + System.lineSeparator());
+        }
+        return cliCheckResult;
+    }
+
+    private List<ContextAndCommentCliCheckerResult> runChecks(List<AssetExtractionDiff> assetExtractionDiffs) {
+        return getAddedTextUnits(assetExtractionDiffs).stream()
+            .map(assetExtractorTextUnit -> getContextAndCommentCliCheckerResult(assetExtractorTextUnit, checkTextUnit(assetExtractorTextUnit)))
+                .collect(Collectors.toList());
+    }
+
+    private ContextAndCommentCliCheckerResult getContextAndCommentCliCheckerResult(AssetExtractorTextUnit assetExtractorTextUnit, String failureText) {
+        ContextAndCommentCliCheckerResult result;
+        if(failureText != null) {
+            logger.debug("'{}' source string failed check with error: {}", assetExtractorTextUnit.getSource(), failureText);
+            result = new ContextAndCommentCliCheckerResult(true, assetExtractorTextUnit.getSource(), failureText);
+        } else {
+            result = new ContextAndCommentCliCheckerResult(false);
+        }
+        return result;
+    }
+
+    private String checkTextUnit(AssetExtractorTextUnit assetExtractorTextUnit) {
+        String failureText = null;
+        String[] splitNameArray = assetExtractorTextUnit.getName().split("---");
+        String context = null;
+        if (splitNameArray.length > 1) {
+            context = splitNameArray[1];
+        }
+        String comment = assetExtractorTextUnit.getComments();
+
+        if (!isBlank(context) && !isBlank(comment)) {
+            if(context.trim().equalsIgnoreCase(comment.trim())) {
+                failureText = "Context & comment strings should not be identical.";
+            }
+        } else if (isBlank(context) && isBlank(comment)) {
+            failureText = "Context and comment strings are both empty.";
+        } else if (isBlank(context)) {
+            failureText = "Context string is empty.";
+        } else if (isBlank(comment)) {
+            failureText = "Comment string is empty.";
+        }
+
+        return failureText;
+    }
+
+    private boolean isBlank(String string) {
+        return StringUtils.isBlank(string);
+    }
+
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
@@ -1,0 +1,248 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.CommandException;
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+import dumonts.hunspell.Hunspell;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * {@link AbstractCliChecker} that uses hunspell native libraries to spell check words in source strings.
+ * <br>
+ * <br>
+ * <b>NOTE:</b> The hunspell libraries must be available on your system separately for this check to execute successfully.
+ *
+ * @author mallen
+ */
+public class SpellCliChecker extends AbstractCliChecker {
+
+    static Logger logger = LoggerFactory.getLogger(SpellCliChecker.class);
+
+    private Hunspell hunspell;
+
+    static class SpellCliCheckerResult {
+
+        String source;
+        Map<String, List<String>> suggestionMap;
+        boolean isSuccessful;
+
+        public SpellCliCheckerResult(String source, Map<String, List<String>> suggestionMap) {
+            this.source = source;
+            this.suggestionMap = suggestionMap;
+            this.isSuccessful = true;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public Map<String, List<String>> getSuggestionMap() {
+            return suggestionMap;
+        }
+
+        public boolean isSuccessful() {
+            return isSuccessful;
+        }
+
+        public void setSuccessful(boolean successful) {
+            this.isSuccessful = successful;
+        }
+    }
+
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        checkDictionaryFiles();
+        hunspell = getHunspellInstance();
+        List<String> sourceStrings = getSourceStringsFromDiff(assetExtractionDiffs);
+        loadAdditionalWordsToDictionary(cliCheckerOptions.getDictionaryAdditionsFilePath());
+        Map<String, Map<String, List<String>>> failureMap = spellCheck(sourceStrings);
+        CliCheckResult cliCheckResult = createCliCheckerResult();
+        if(!failureMap.isEmpty()) {
+            cliCheckResult.setSuccessful(false);
+            cliCheckResult.setNotificationText(buildNotificationText(failureMap));
+        }
+
+        return cliCheckResult;
+    }
+
+    protected Hunspell getHunspellInstance(){
+        if (hunspell == null) {
+            hunspell = new Hunspell(Paths.get(cliCheckerOptions.getDictionaryFilePath()), Paths.get(cliCheckerOptions.getDictionaryAffixFilePath()));
+        }
+        return hunspell;
+    }
+
+    private void checkDictionaryFiles() {
+        if(StringUtils.isBlank(cliCheckerOptions.getDictionaryFilePath())) {
+            throw new CommandException("The dictionary file path parameter cannot be empty when using the spell checker.");
+        } else if (StringUtils.isBlank(cliCheckerOptions.getDictionaryAffixFilePath())) {
+            throw new CommandException("The dictionary affix file path parameter cannot be empty when using the spell checker.");
+        } else if (!Files.exists(Paths.get(cliCheckerOptions.getDictionaryFilePath()))) {
+            throw new CommandException(cliCheckerOptions.getDictionaryFilePath() + " does not exist.");
+        } else if (!Files.exists(Paths.get(cliCheckerOptions.getDictionaryAffixFilePath()))) {
+            throw new CommandException(cliCheckerOptions.getDictionaryAffixFilePath() + " does not exist.");
+        }
+    }
+
+    private Map<String, Map<String, List<String>>> spellCheck(List<String> sourceStrings) {
+
+        return sourceStrings.stream()
+                .map(sourceString -> getSpellCliCheckerResult(sourceString))
+                .filter(result -> !result.isSuccessful())
+                .collect(Collectors.toMap(SpellCliCheckerResult::getSource, SpellCliCheckerResult::getSuggestionMap));
+
+    }
+
+    private SpellCliCheckerResult getSpellCliCheckerResult(String sourceString) {
+        SpellCliCheckerResult result = new SpellCliCheckerResult(sourceString, spellCheckSourceString(Arrays.asList(removePlaceholdersFromString(sourceString).split("\\W+"))));
+        if(!result.getSuggestionMap().isEmpty()) {
+            result.setSuccessful(false);
+        }
+        return result;
+    }
+
+    private String removePlaceholdersFromString(String sourceString) {
+        String stringWithoutPlaceholders = sourceString;
+        for(PlaceholderRegularExpressions regex : cliCheckerOptions.getParameterRegexSet()) {
+            stringWithoutPlaceholders = removePlaceholders(stringWithoutPlaceholders, regex);
+        }
+        return stringWithoutPlaceholders;
+    }
+
+    private String removePlaceholders(String stringWithoutPlaceholders, PlaceholderRegularExpressions regex) {
+        if(regex.equals(PlaceholderRegularExpressions.SINGLE_BRACE_REGEX) || regex.equals(PlaceholderRegularExpressions.DOUBLE_BRACE_REGEX)) {
+            stringWithoutPlaceholders = removeBracketedPlaceholders(stringWithoutPlaceholders);
+        }else {
+            stringWithoutPlaceholders = stringWithoutPlaceholders.replaceAll(regex.getRegex(), "");
+        }
+        return stringWithoutPlaceholders;
+    }
+
+    private String removeBracketedPlaceholders(String stringWithoutPlaceholders) {
+        int index = stringWithoutPlaceholders.indexOf("{");
+        while(index != -1 && stringWithoutPlaceholders.contains("}")) {
+            int associatedClosingBraceIndex = getEndOfPlaceholderIndex(stringWithoutPlaceholders, index);
+            String tmp = stringWithoutPlaceholders.substring(index, associatedClosingBraceIndex + 1 < stringWithoutPlaceholders.length()? associatedClosingBraceIndex + 1 : associatedClosingBraceIndex).replaceAll("\\{", "\\\\{").replaceAll("\\}", "\\\\}");
+            stringWithoutPlaceholders = stringWithoutPlaceholders.replaceAll(tmp, "");
+            index = stringWithoutPlaceholders.indexOf("{");
+        }
+        return stringWithoutPlaceholders;
+    }
+
+    private int getEndOfPlaceholderIndex(String str, int startIndex){
+        ArrayDeque<Character> stack = new ArrayDeque<>();
+        int indexCount = startIndex;
+        for (Character c : str.substring(startIndex).toCharArray()) {
+            if (c.equals('{')) {
+                stack.push(c);
+                indexCount++;
+                continue;
+            } else if (c.equals('}')) {
+                if(stack.isEmpty()){
+                    throw new CommandException("Invalid number of opening brackets in string.");
+                }
+                stack.pop();
+                if(stack.isEmpty()) {
+                    return indexCount;
+                }
+            }
+            indexCount++;
+        }
+        if(!stack.isEmpty()) {
+            throw new CommandException("Invalid number of closing brackets in string.");
+        }
+        return -1;
+    }
+
+    private void loadAdditionalWordsToDictionary(String additionalWordsFilePath) {
+
+        if (additionalWordsFilePath != null && !additionalWordsFilePath.isEmpty()) {
+            try {
+                Files.readAllLines(Paths.get(additionalWordsFilePath)).stream().forEach(word -> {
+                    String w = word.trim();
+                    logger.debug("Adding {} to dictionary", w);
+                    hunspell.add(w);
+                });
+            } catch (IOException e) {
+                logger.error("Error adding additional words to dictionary: {}", e);
+                throw new CommandException("Error adding additional words to dictionary: " + e.getMessage());
+            }
+        }
+    }
+
+    private Map<String, List<String>> spellCheckSourceString(List<String> words) {
+        Map<String, List<String>> failureMap = new HashMap<>();
+        Set<String> checked = new HashSet<>();
+        for (String word : words) {
+            if (!checked.contains(word) && !hunspell.spell(word)) {
+                List<String> suggestions = hunspell.suggest(word);
+                logger.debug("{} is spelt incorrectly. Suggested correct spellings are {}", word, suggestions);
+                failureMap.put(word, suggestions);
+                checked.add(word);
+            }
+        }
+        return failureMap;
+    }
+
+    private String buildNotificationText(Map<String, Map<String, List<String>>> failureMap) {
+        StringBuilder notificationText = new StringBuilder();
+        notificationText.append(failureMap.keySet().stream()
+                .map(sourceString -> buildFailureText(failureMap, sourceString))
+                .collect(Collectors.joining(System.lineSeparator())));
+        notificationText.append(System.lineSeparator());
+        addDictionaryUpdateInformation(notificationText);
+
+        return notificationText.toString();
+    }
+
+    private void addDictionaryUpdateInformation(StringBuilder notificationText) {
+        if(cliCheckerOptions.getDictionaryAdditionsFilePath() != null && !cliCheckerOptions.getDictionaryAdditionsFilePath().isEmpty()) {
+            notificationText.append("If a word is correctly spelt please add your spelling to " +
+                    cliCheckerOptions.getDictionaryAdditionsFilePath() +
+                    " to avoid future false negatives.");
+        }
+    }
+
+    private String buildFailureText(Map<String, Map<String, List<String>>> failureMap, String sourceString) {
+        return failureMap.get(sourceString).keySet().stream()
+                .map(misspelling -> {
+                    StringBuilder builder = new StringBuilder();
+                    builder.append("The string '" + sourceString + "' contains misspelled words:" + System.lineSeparator());
+                    List<String> suggestions = failureMap.get(sourceString).get(misspelling);
+                    builder.append(" * '" + misspelling + "' ");
+                    if(!suggestions.isEmpty()){
+                        builder.append("- Did you mean ");
+                        builder.append(suggestions.stream().collect(Collectors.collectingAndThen(Collectors.toList(), joinCommaSeparated(", ", " or "))));
+                        builder.append("?");
+                    }
+                    return builder.toString();
+                })
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private static Function<List<String>, String> joinCommaSeparated(String delimiter, String finalDelimiter) {
+        return result -> {
+            int last = result.size() - 1;
+            if(last < 1) {
+                return String.join(delimiter, result);
+            }
+            return String.join(finalDelimiter, String.join(delimiter, result.subList(0, last)), result.get(last));
+        };
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extraction/ExtractionDiffService.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extraction/ExtractionDiffService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Service to compute difference between local extractions
@@ -87,6 +88,19 @@ public class ExtractionDiffService {
                 .reduce(extractionDiffStatistics, (c1, c2) -> c1.withAdded(c1.getAdded() + c2.getAdded()).withRemoved(c1.getRemoved() + c2.getRemoved()));
 
         return extractionDiffStatistics;
+    }
+
+    public List<AssetExtractionDiff> findAssetExtractionDiffsWithAddedTextUnits(ExtractionDiffPaths extractionDiffPaths) throws MissingExtractionDirectoryExcpetion {
+
+        ExtractionPaths baseExtractionPaths = extractionDiffPaths.getBaseExtractorPaths();
+        ExtractionPaths currentExtractionPaths = extractionDiffPaths.getCurrentExtractorPaths();
+
+        checkExtractionDirectoryExists(baseExtractionPaths);
+        checkExtractionDirectoryExists(currentExtractionPaths);
+
+        return extractionDiffPaths.findAllAssetExtractionDiffPaths().map(path -> objectMapper.readValueUnchecked(path.toFile(), AssetExtractionDiff.class))
+                .filter(assetExtractionDiff -> !assetExtractionDiff.getAddedTextunits().isEmpty())
+                .collect(Collectors.toList());
     }
 
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
@@ -1,0 +1,165 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import dumonts.hunspell.Hunspell;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ExtractionCheckCommandTest extends CLITestBase {
+
+    @Test
+    public void runSuccessfulChecks() throws Exception {
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source1").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source1");
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source2");
+
+        getL10nJCommander().run("extract-diff",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1");
+
+        getL10nJCommander().run("extraction-check",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1",
+                "-cl", "CONTEXT_COMMENT_CHECKER");
+
+        Assert.assertTrue(outputCapture.toString().contains("Running checks against new strings"));
+        Assert.assertTrue(outputCapture.toString().contains("Checks completed"));
+        Assert.assertFalse(outputCapture.toString().contains("failed") || outputCapture.toString().contains("Failed"));
+    }
+
+    @Test
+    public void runHardFailChecks() throws Exception {
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source1").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source1");
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source2");
+
+        getL10nJCommander().run("extract-diff",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1");
+
+        getL10nJCommander().run("extraction-check",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1",
+                "-cl", "CONTEXT_COMMENT_CHECKER",
+                "-hf", "CONTEXT_COMMENT_CHECKER");
+
+        Assert.assertTrue(outputCapture.toString().contains("Running checks against new strings"));
+        Assert.assertTrue(outputCapture.toString().contains("The following checks had hard failures:" + System.lineSeparator()));
+        Assert.assertTrue(outputCapture.toString().contains("CONTEXT_COMMENT_CHECKER"));
+        Assert.assertTrue(outputCapture.toString().contains("Context and comment check found failures:"));
+        Assert.assertTrue(outputCapture.toString().contains("* Source string 'This is a new source string missing a context' failed check with error: Context string is empty."));
+    }
+
+    @Test
+    public void runSoftFailChecks() throws Exception {
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source1").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source1");
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source2");
+
+        getL10nJCommander().run("extract-diff",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1");
+
+        getL10nJCommander().run("extraction-check",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1",
+                "-cl", "CONTEXT_COMMENT_CHECKER");
+
+        Assert.assertTrue(outputCapture.toString().contains("Running checks against new strings"));
+        Assert.assertTrue(outputCapture.toString().contains("Failed checks: "));
+        Assert.assertTrue(outputCapture.toString().contains("CONTEXT_COMMENT_CHECKER"));
+        Assert.assertTrue(outputCapture.toString().contains("Checks completed"));
+    }
+
+    @Test
+    public void runCheckWithInvalidCheckName() {
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source1").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source1");
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source2");
+
+        getL10nJCommander().run("extract-diff",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1");
+
+        getL10nJCommander().run("extraction-check",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1",
+                "-cl", "INVALID_CHECK_NAME");
+
+        Assert.assertTrue(outputCapture.toString().contains("Unknown check 'INVALID_CHECK_NAME'"));
+    }
+
+    @Test
+    public void runHardFailChecksWithInvalidCheckName() throws Exception {
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source1").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source1");
+
+        getL10nJCommander().run("extract",
+                "-s", getInputResourcesTestDir("source2").getAbsolutePath(),
+                "-o", getTargetTestDir("extractions").getAbsolutePath(),
+                "-n", "source2");
+
+        getL10nJCommander().run("extract-diff",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1");
+
+        getL10nJCommander().run("extraction-check",
+                "-i", getTargetTestDir("extractions").getAbsolutePath(),
+                "-o", getTargetTestDir("extraction-diffs").getAbsolutePath(),
+                "-c", "source2",
+                "-b", "source1",
+                "-cl", "CONTEXT_COMMENT_CHECKER",
+                "-hf", "INVALID_NAME");
+
+        Assert.assertTrue(outputCapture.toString().contains("Unknown check name in hard fail list 'INVALID_NAME'"));
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PhabricatorExtractionDiffNotificationCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PhabricatorExtractionDiffNotificationCommandTest.java
@@ -4,6 +4,7 @@ import com.box.l10n.mojito.cli.CLITestBase;
 import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffService;
 import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffStatistics;
 import com.box.l10n.mojito.phabricator.DifferentialRevision;
+import com.box.l10n.mojito.phabricator.PhabricatorMessageBuilder;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,24 +20,28 @@ public class PhabricatorExtractionDiffNotificationCommandTest extends CLITestBas
     @Test
     public void getMessageInfo() {
         PhabricatorExtractionDiffNotificationCommand phabricatorExtractionDiffNotificationCommand = new PhabricatorExtractionDiffNotificationCommand();
+        phabricatorExtractionDiffNotificationCommand.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         assertEquals("ℹ️ 0 strings removed and 1 string added (from 10 to 11)", phabricatorExtractionDiffNotificationCommand.getMessage(ExtractionDiffStatistics.builder().added(1).removed(0).base(10).current(11).build()));
     }
 
     @Test
     public void getMessageWarning() {
         PhabricatorExtractionDiffNotificationCommand phabricatorExtractionDiffNotificationCommand = new PhabricatorExtractionDiffNotificationCommand();
+        phabricatorExtractionDiffNotificationCommand.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         assertEquals("⚠️ 10 strings removed and 8 strings added (from 20 to 18)", phabricatorExtractionDiffNotificationCommand.getMessage(ExtractionDiffStatistics.builder().added(8).removed(10).base(20).current(18).build()));
     }
 
     @Test
     public void getMessageError() {
         PhabricatorExtractionDiffNotificationCommand phabricatorExtractionDiffNotificationCommand = new PhabricatorExtractionDiffNotificationCommand();
+        phabricatorExtractionDiffNotificationCommand.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         assertEquals("🛑 200 strings removed and 0 strings added (from 500 to 300)", phabricatorExtractionDiffNotificationCommand.getMessage(ExtractionDiffStatistics.builder().added(0).removed(200).base(500).current(300).build()));
     }
 
     @Test
     public void withTemplate() {
         PhabricatorExtractionDiffNotificationCommand phabricatorExtractionDiffNotificationCommand = new PhabricatorExtractionDiffNotificationCommand();
+        phabricatorExtractionDiffNotificationCommand.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         phabricatorExtractionDiffNotificationCommand.messageTemplate = "{baseMessage}. Check [[https://build.org/1234|build]].";
         assertEquals("🛑 200 strings removed and 0 strings added (from 500 to 300). Check [[https://build.org/1234|build]].",
                 phabricatorExtractionDiffNotificationCommand.getMessage(
@@ -46,6 +51,7 @@ public class PhabricatorExtractionDiffNotificationCommandTest extends CLITestBas
     @Test
     public void shouldSendNotification() {
         PhabricatorExtractionDiffNotificationCommand phabricatorExtractionDiffNotificationCommand = new PhabricatorExtractionDiffNotificationCommand();
+        phabricatorExtractionDiffNotificationCommand.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         assertTrue(phabricatorExtractionDiffNotificationCommand.shouldSendNotification(
                 ExtractionDiffStatistics.builder().added(0).removed(200).base(500).current(300).build()));
     }
@@ -53,6 +59,7 @@ public class PhabricatorExtractionDiffNotificationCommandTest extends CLITestBas
     @Test
     public void shouldNotSendNotification() {
         PhabricatorExtractionDiffNotificationCommand phabricatorExtractionDiffNotificationCommand = new PhabricatorExtractionDiffNotificationCommand();
+        phabricatorExtractionDiffNotificationCommand.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         assertFalse(phabricatorExtractionDiffNotificationCommand.shouldSendNotification(
                 ExtractionDiffStatistics.builder().added(0).removed(0).base(500).current(300).build()));
     }
@@ -82,6 +89,7 @@ public class PhabricatorExtractionDiffNotificationCommandTest extends CLITestBas
         PhabricatorExtractionDiffNotificationCommand command = l10nJCommander.getCommand(PhabricatorExtractionDiffNotificationCommand.class);
         DifferentialRevision mock = Mockito.mock(DifferentialRevision.class);
         command.differentialRevision = mock;
+        command.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
 
         l10nJCommander.run("phab-extraction-diff-notif",
                 "-i", getTargetTestDir("extractions").getAbsolutePath(),
@@ -103,6 +111,7 @@ public class PhabricatorExtractionDiffNotificationCommandTest extends CLITestBas
         PhabricatorExtractionDiffNotificationCommand command = l10nJCommander.getCommand(PhabricatorExtractionDiffNotificationCommand.class);
         DifferentialRevision mock = Mockito.mock(DifferentialRevision.class);
         command.differentialRevision = mock;
+        command.phabricatorMessageBuilder = new PhabricatorMessageBuilder();
         command.extractionDiffService = Mockito.mock(ExtractionDiffService.class);
         Mockito.when(command.extractionDiffService.computeExtractionDiffStatistics(any())).thenReturn(ExtractionDiffStatistics.builder().build());
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliCheckerTest.java
@@ -1,0 +1,171 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.checks.CliCheckResult;
+import com.box.l10n.mojito.cli.command.checks.CliCheckerOptions;
+import com.box.l10n.mojito.cli.command.checks.CliCheckerType;
+import com.box.l10n.mojito.cli.command.checks.ContextAndCommentCliChecker;
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
+
+public class ContextAndCommentCliCheckerTest {
+
+    private ContextAndCommentCliChecker contextAndCommentCliChecker;
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        contextAndCommentCliChecker = new ContextAndCommentCliChecker();
+        contextAndCommentCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(), "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+    }
+
+    @Test
+    public void testContextAndCommentPreset() {
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testCommentIsEmpty() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments(null);
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Context and comment check found failures:" + System.lineSeparator() +
+                "* Source string 'A source string with no errors.' failed check with error: Comment string is empty."
+                + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testContextIsEmpty() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Context and comment check found failures:" + System.lineSeparator() +
+                "* Source string 'A source string with no errors.' failed check with error: Context string is empty."
+                + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testBothCommentAndContextAreEmpty() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments(null);
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Context and comment check found failures:" + System.lineSeparator() +
+                "* Source string 'A source string with no errors.' failed check with error: Context and comment strings are both empty."
+                + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testIdenticalContextAndCommentStrings() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some id --- Identical string");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments("Identical string");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Context and comment check found failures:" + System.lineSeparator() +
+                "* Source string 'A source string with no errors.' failed check with error: Context & comment strings should not be identical."
+                + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testHardFailure() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments(null);
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        contextAndCommentCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(CliCheckerType.CONTEXT_COMMENT_CHECKER), "", ""));
+
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.isHardFail());
+    }
+
+    @Test
+    public void testStringsOnlyContainingWhitespace() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- ");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setComments(" ");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Context and comment check found failures:" + System.lineSeparator() +
+                "* Source string 'A source string with no errors.' failed check with error: Context and comment strings are both empty."
+                + System.lineSeparator(), result.getNotificationText());
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
@@ -1,0 +1,384 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.beust.jcommander.internal.Lists;
+import com.box.l10n.mojito.cli.command.CommandException;
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.io.Files;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import dumonts.hunspell.Hunspell;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX;
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PRINTF_LIKE_VARIABLE_TYPE_REGEX;
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SpellCliCheckerTest {
+
+    @Mock
+    private Hunspell hunspellMock;
+
+    @Spy
+    private SpellCliChecker spellCliChecker = new SpellCliChecker();
+
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        doReturn(CliCheckerType.SPELL_CHECKER).when(spellCliChecker).getCliCheckerType();
+        doReturn(hunspellMock).when(spellCliChecker).getHunspellInstance();
+        when(hunspellMock.spell(isA(String.class))).thenReturn(true);
+        when(hunspellMock.spell("strng")).thenReturn(false);
+        when(hunspellMock.spell("erors")).thenReturn(false);
+        when(hunspellMock.spell("falures")).thenReturn(false);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(),
+                "", "", "target/test-classes/dictionaries/empty.dic", "target/test-classes/dictionaries/empty.aff"));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+    }
+
+    @Test
+    public void testHardFailureIsSet() throws Exception {
+        Set<CliCheckerType> hardFailureSet = new HashSet<>();
+        hardFailureSet.add(CliCheckerType.SPELL_CHECKER);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(PLACEHOLDER_NO_SPECIFIER_REGEX), hardFailureSet, "", "", "target/test-classes/dictionaries/empty.dic", "target/test-classes/dictionaries/empty.aff"));
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isHardFail());
+    }
+
+    @Test
+    public void testStringWithNoErrors() throws Exception {
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testStringWithErrors() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source strng with some erors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        when(hunspellMock.spell("strng")).thenReturn(false);
+        when(hunspellMock.spell("erors")).thenReturn(false);
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertFalse(result.getNotificationText().isEmpty());
+        assertTrue(result.getNotificationText().contains("* 'erors'"));
+        assertTrue(result.getNotificationText().contains("* 'strng'"));
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testAddingStringsToDictionary() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source strng with some erors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        createTempDictionaryAdditionsFile("strng" + System.lineSeparator() + "erors");
+        when(hunspellMock.spell("strng")).thenReturn(true);
+        when(hunspellMock.spell("erors")).thenReturn(true);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(PLACEHOLDER_NO_SPECIFIER_REGEX), Sets.newHashSet(),
+                "target/tests/resources/dictAddition.txt", "", "target/test-classes/dictionaries/empty.dic", "target/test-classes/dictionaries/empty.aff"));
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        verify(hunspellMock, times(1)).add("strng");
+        verify(hunspellMock, times(1)).add("erors");
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testParametersAreNotSpellChecked() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with {image_name} errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        verify(hunspellMock, times(0)).spell("image_name");
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testEmptyCurlyBracketsDoesNotCauseSubsequentPlaceholdersToBeIncludedInCheck() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("Something went wrong {} saving the carousel images {imag_name} on our side. Please try again.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testAddingStringsToDictionaryAppendsSuggestedUpdateOnFailure() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source strng with some erors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        createTempDictionaryAdditionsFile("");
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(PLACEHOLDER_NO_SPECIFIER_REGEX), Sets.newHashSet(),
+                "target/tests/resources/dictAddition.txt", "", "target/test-classes/dictionaries/empty.dic", "target/test-classes/dictionaries/empty.aff"));
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertFalse(result.getNotificationText().isEmpty());
+        assertTrue(result.getNotificationText().contains("* 'erors'"));
+        assertTrue(result.getNotificationText().contains("* 'strng'"));
+        assertTrue(result.getNotificationText().contains("If a word is correctly spelt please add your spelling to target/tests/resources/dictAddition.txt to avoid future false negatives."));
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testMultipleStringsWithMisspellings() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source strng with some erors.");
+        addedTUs.add(assetExtractorTextUnit);
+        AssetExtractorTextUnit anotherTextUnit = new AssetExtractorTextUnit();
+        anotherTextUnit.setSource("Another string with falures");
+        addedTUs.add(anotherTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertFalse(result.getNotificationText().isEmpty());
+        assertTrue(result.getNotificationText().contains("* 'erors'"));
+        assertTrue(result.getNotificationText().contains("* 'strng'"));
+        assertTrue(result.getNotificationText().contains("* 'falures'"));
+    }
+
+    @Test
+    public void testNestedICUPlaceholderIsExcludedFromSpellcheck() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("You have {pagesCount, plral, one {# pazge.} othr {# pages.}}");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testMultipleNestedICUPlaceholderIsExcludedFromSpellcheck() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("You have {pagesCount, plral, one {# pazge.} othr {# pages.}} {anotherCount, plral, one {# count } othr { # cnt }}");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test(expected = CommandException.class)
+    public void testInvalidNumberClosingBracketsForPlaceholder() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("You have {pagesCount, plral, one {# pazge.} othr {# pages.}} {anotherCount, plral, one {# count } othr { # cnt }");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        spellCliChecker.run(assetExtractionDiffs);
+    }
+
+    @Test
+    public void testMultipleIdenticalErrorsInStringAreReportedOnlyOnce() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with identicl identicl identicl errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        when(hunspellMock.spell("identicl")).thenReturn(false);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertTrue(result.getNotificationText().contains("* 'identicl'"));
+        assertEquals(1, result.getNotificationText().chars().filter(c -> c == '*').count());
+    }
+
+    @Test
+    public void testMultipleConfiguredPlaceholderRegexesAreNotSpellChecked() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with a {numbr} of %(diferent)s errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX), Sets.newHashSet(),
+                "", "", "target/test-classes/dictionaries/empty.dic", "target/test-classes/dictionaries/empty.aff"));
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test(expected = CommandException.class)
+    public void testExceptionThrownIfNoDictionaryFileProvided() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with a {numbr} of %(diferent)s errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX), Sets.newHashSet(),
+                "", "", null, "target/test-classes/dictionaries/empty.aff"));
+        spellCliChecker.run(assetExtractionDiffs);
+    }
+
+    @Test(expected = CommandException.class)
+    public void testExceptionThrownIfNoDictAffixFileProvided() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with a {numbr} of %(diferent)s errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX), Sets.newHashSet(),
+                "", "", "target/test-classes/dictionaries/empty.dic", null));
+        spellCliChecker.run(assetExtractionDiffs);
+    }
+
+    @Test(expected = CommandException.class)
+    public void testExceptionThrownIfDictFileDoesNotExist() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with a {numbr} of %(diferent)s errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX), Sets.newHashSet(),
+                "", "", "fake_dir/dictionaries/empty.dic", "target/test-classes/dictionaries/empty.aff"));
+        spellCliChecker.run(assetExtractionDiffs);
+    }
+
+    @Test(expected = CommandException.class)
+    public void testExceptionThrownIfDictAffixFileDoesNotExist() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with a {numbr} of %(diferent)s errors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        spellCliChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX), Sets.newHashSet(),
+                "", "", "target/test-classes/dictionaries/empty.dic", "fake_dir/dictionaries/empty.aff"));
+        spellCliChecker.run(assetExtractionDiffs);
+    }
+
+    @Test
+    public void testSuggestedSpellingsAreIncludedInNotificationMessgage() {
+        when(hunspellMock.suggest("erors")).thenReturn(Lists.newArrayList("errors"));
+        when(hunspellMock.suggest("strng")).thenReturn(Lists.newArrayList("string", "strong"));
+        when(hunspellMock.suggest("sorce")).thenReturn(Lists.newArrayList("source", "sorcerer", "sorcery"));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A sorce strng with some erors.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        when(hunspellMock.spell("strng")).thenReturn(false);
+        when(hunspellMock.spell("erors")).thenReturn(false);
+        when(hunspellMock.spell("sorce")).thenReturn(false);
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertFalse(result.getNotificationText().isEmpty());
+        assertTrue(result.getNotificationText().contains("* 'erors'"));
+        assertTrue(result.getNotificationText().contains("* 'strng'"));
+        assertTrue(result.getNotificationText().contains("* 'sorce'"));
+        assertTrue(result.getNotificationText().contains("Did you mean errors?"));
+        assertTrue(result.getNotificationText().contains("Did you mean string or strong?"));
+        assertTrue(result.getNotificationText().contains("Did you mean source, sorcerer or sorcery?"));
+        assertFalse(result.isHardFail());
+    }
+
+    private void createTempDictionaryAdditionsFile(String contents) throws IOException {
+        File dictAdditions = new File("target/tests/resources/");
+        dictAdditions.mkdirs();
+        dictAdditions = new File("target/tests/resources/dictAddition.txt");
+        dictAdditions.createNewFile();
+        Files.write(Paths.get("target/tests/resources/dictAddition.txt"), contents);
+    }
+
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInvalidCheckName/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInvalidCheckName/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInvalidCheckName/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInvalidCheckName/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+
+#. New source string
+#: file.js:21
+msgctxt "new_source"
+msgid "This is a new source string"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecks/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecks/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecks/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecks/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,64 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+
+#. New source string comment
+#: file.js:21
+msgctxt ""
+msgid "This is a new source string missing a context"
+msgstr ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecksWithInvalidCheckName/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecksWithInvalidCheckName/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecksWithInvalidCheckName/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runHardFailChecksWithInvalidCheckName/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,64 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+
+#. New source string with spelling failure
+#: file.js:21
+msgctxt "new_source_invalid_spelling"
+msgid "This is a new sorce string with spelling failure"
+msgstr ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSoftFailChecks/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSoftFailChecks/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSoftFailChecks/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSoftFailChecks/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,63 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+
+#: file.js:21
+msgctxt "Missing comment source string"
+msgid "This is a new source string missing a context"
+msgstr ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSuccessfulChecks/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSuccessfulChecks/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSuccessfulChecks/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runSuccessfulChecks/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] ""
+msgstr[1] ""
+
+#. New source string
+#: file.js:21
+msgctxt "new_source"
+msgid "This is a new source string"
+msgstr ""

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/PhabricatorConfiguration.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/PhabricatorConfiguration.java
@@ -36,4 +36,9 @@ public class PhabricatorConfiguration {
     Phabricator phabricator() {
         return new Phabricator(differentialDiff(), harbormaster(), differentialRevision());
     }
+
+    @Bean
+    PhabricatorMessageBuilder phabricatorMessageBuilder() {
+        return new PhabricatorMessageBuilder();
+    }
 }

--- a/common/src/main/java/com/box/l10n/mojito/phabricator/PhabricatorMessageBuilder.java
+++ b/common/src/main/java/com/box/l10n/mojito/phabricator/PhabricatorMessageBuilder.java
@@ -1,0 +1,17 @@
+package com.box.l10n.mojito.phabricator;
+
+import com.google.common.collect.ImmutableMap;
+import com.ibm.icu.text.MessageFormat;
+
+public class PhabricatorMessageBuilder {
+
+    public String getFormattedPhabricatorMessage(String messageTemplate, String messageKey, String message){
+        MessageFormat messageFormatForTemplate = new MessageFormat(messageTemplate);
+        return messageFormatForTemplate.format(ImmutableMap.of(messageKey, message));
+    }
+
+    public String getBaseMessage(ImmutableMap<String, Object> arguments, String message) {
+        MessageFormat messageFormat = new MessageFormat(message);
+        return messageFormat.format(arguments);
+    }
+}

--- a/common/src/main/java/com/box/l10n/mojito/regex/PlaceholderRegularExpressions.java
+++ b/common/src/main/java/com/box/l10n/mojito/regex/PlaceholderRegularExpressions.java
@@ -1,0 +1,52 @@
+package com.box.l10n.mojito.regex;
+
+public enum PlaceholderRegularExpressions {
+
+    /**
+     * Modified regex from Formatter#formatSpecifier = "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])";
+     * (%[argument_index$][flags][width][.precision][t]conversion)
+     * @return
+     */
+    PRINTF_LIKE_REGEX("%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n|@)"),
+
+    /**
+     * Regex checks for strings in the format %([variable_name])[conversion flags][type]
+     */
+    PRINTF_LIKE_VARIABLE_TYPE_REGEX("%([{|(])+([a-zA-Z0-9_])+([}|)])+([-#+ 0,\\.(\\<]+)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|c|d|e|E|f|F|g|G|i|o|p|r|s|u|x|X)"),
+
+    /**
+     * Checks for placeholders like %1, %2
+     */
+    SIMPLE_PRINTF_REGEX("%\\d+"),
+
+    /**
+     * Checks for placeholders within single braces e.g. {placeholder}
+     */
+    SINGLE_BRACE_REGEX("\\{(.|\\n)*?(?=\\})\\}"),
+
+    /**
+     * Checks for placeholders within double braces e.g. {{placeholder}}
+     */
+    DOUBLE_BRACE_REGEX("\\{\\{(.|\\n)*?(?=\\}\\})\\}\\}"),
+
+    /**
+     * Checks for placeholders as % followed by a type e.g. %s, %d
+     */
+    PLACEHOLDER_NO_SPECIFIER_REGEX("%[d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n]"),
+
+    /**
+     * Ignores percentage symbols after a bracket as a token.
+     */
+    PLACEHOLDER_IGNORE_PERCENTAGE_AFTER_BRACKETS("(?<![}|)])%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n|@)");
+
+    private String regex;
+
+    PlaceholderRegularExpressions(String regex) {
+        this.regex = regex;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>jupiter-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- TODO(spring2) remove -->

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeAddParameterSpecifierIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeAddParameterSpecifierIntegrityChecker.java
@@ -3,6 +3,8 @@ package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX;
+
 /**
  * Integrity checker that modifies any placeholders with format '%[type]' in the source & target strings to use
  * a placeholder with parameter specifier '%1$[type]' before executing the {@link PrintfLikeIntegrityChecker} checks.
@@ -12,8 +14,7 @@ import java.util.regex.Pattern;
  */
 public class PrintfLikeAddParameterSpecifierIntegrityChecker extends PrintfLikeIntegrityChecker {
 
-    private static final String PLACEHOLDER_NO_SPECIFIER_REGEX = "%[d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n]";
-    private Pattern pattern = Pattern.compile(PLACEHOLDER_NO_SPECIFIER_REGEX);
+    private Pattern pattern = Pattern.compile(PLACEHOLDER_NO_SPECIFIER_REGEX.getRegex());
 
     @Override
     public void check(String sourceContent, String targetContent) throws PrintfLikeIntegrityCheckerException {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeIgnorePercentageAfterBracketsIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeIgnorePercentageAfterBracketsIntegrityChecker.java
@@ -4,6 +4,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_IGNORE_PERCENTAGE_AFTER_BRACKETS;
+
 /**
  * '%' symbol preceded by a '}' or ')' are ignored as variable tokens. This can be useful
  * for avoiding false negatives when handling translations that contain percentages inside
@@ -15,7 +17,7 @@ public class PrintfLikeIgnorePercentageAfterBracketsIntegrityChecker extends Reg
 
     @Override
     public String getRegex() {
-        return "(?<![}|)])%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n|@)";
+        return PLACEHOLDER_IGNORE_PERCENTAGE_AFTER_BRACKETS.getRegex();
     }
 
     @Override

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeIntegrityChecker.java
@@ -1,7 +1,9 @@
 package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
 
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PRINTF_LIKE_REGEX;
+
 /**
- * Checks that there are the same c-printf like placeholders 
+ * Checks that there are the same c-printf like placeholders
  * in the source and target content, order is not important.
  *
  * @author wyau
@@ -10,17 +12,17 @@ public class PrintfLikeIntegrityChecker extends RegexIntegrityChecker {
 
     /**
      * Modified regex from Formatter#formatSpecifier = "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])";
-     * (%[argument_index$][flags][width][.precision][t]conversion) 
-     * @return 
+     * (%[argument_index$][flags][width][.precision][t]conversion)
+     * @return
      */
     @Override
     public String getRegex() {
-        return "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n|@)";
+        return PRINTF_LIKE_REGEX.getRegex();
     }
 
     @Override
     public void check(String sourceContent, String targetContent) throws PrintfLikeIntegrityCheckerException {
-        
+
         try {
             super.check(sourceContent, targetContent);
         } catch (RegexCheckerException rce) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeVariableTypeIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/PrintfLikeVariableTypeIntegrityChecker.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
 
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PRINTF_LIKE_VARIABLE_TYPE_REGEX;
+
 /**
  * Validates that a variable format type is not modified in the target string,
  * only validates variables contained within brackets e.g. %([variable_name])[flags][width][.precision][t]conversion)
@@ -13,7 +15,7 @@ public class PrintfLikeVariableTypeIntegrityChecker extends RegexIntegrityChecke
         /**
          * Regex checks for strings in the format %([variable_name])[conversion flags][type]
          */
-        return "%([{|(])+([a-zA-Z0-9_])+([}|)])+([-#+ 0,\\.(\\<]+)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|c|d|e|E|f|F|g|G|i|o|p|r|s|u|x|X)";
+        return PRINTF_LIKE_VARIABLE_TYPE_REGEX.getRegex();
     }
 
     @Override

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/SimplePrintfLikeIntegrityChecker.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/SimplePrintfLikeIntegrityChecker.java
@@ -1,21 +1,23 @@
 package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
 
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SIMPLE_PRINTF_REGEX;
+
 /**
  * Checks that there are the same placeholders like %1, %2, etc
  * in the source and target content, order is not important.
- * 
+ *
  * @author jyi
  */
 public class SimplePrintfLikeIntegrityChecker extends RegexIntegrityChecker {
-    
+
     @Override
     public String getRegex() {
-        return "%\\d+";
+        return SIMPLE_PRINTF_REGEX.getRegex();
     }
 
     @Override
     public void check(String sourceContent, String targetContent) throws PrintfLikeIntegrityCheckerException {
-        
+
         try {
             super.check(sourceContent, targetContent);
         } catch (RegexCheckerException rce) {


### PR DESCRIPTION
Adds a cli command that runs checks on newly added source strings from a list on checkers. The command soft fails on check failures by default but can be configured to hard fail for specific failures. A phabricator diff id can be added as an optional command parameter, if provided a comment will be added to the relevant diff with any failures found in the soft failure scenario.

The following checkers are included in this PR:

**SPELL_CHECKER** checks for spelling errors within the added source strings, on failure it provides suggestions on correct spellings for the misspelt word.

**CONTEXT_COMMENT_CHECKER** verifies that both a context and comment have been provided with the source string and that they are not identical to each other.