### PR TITLE
Also remove textual fields with the specified value

### DIFF
--- a/common/src/test/java/com/box/l10n/mojito/json/JsonObjectRemoverByValueTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/json/JsonObjectRemoverByValueTest.java
@@ -25,6 +25,14 @@ class JsonObjectRemoverByValueTest {
     }
 
     @Test
+    void removeTextualFields() {
+        assertEquals("{ }", JsonObjectRemoverByValue.remove("{\n" +
+                "  \"value1\": \"##$UNTRANSLATED$##\",\n" +
+                "  \"value2\": \"##$UNTRANSLATED$##\"\n" +
+                "}", "##$UNTRANSLATED$##"));
+    }
+
+    @Test
     void removeInObject() {
         assertEquals("{\n" +
                 "  \"mykey2\" : {\n" +


### PR DESCRIPTION
Before it was only remove sub object that the value. This is to support removing untranslated from "flat" json map like

{
  "hello": "Hello",
  "bye": "Bye"
}