### PR TITLE
Add text unit statistics functionality

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/collect/ImmutableMapCollectors.java
+++ b/common/src/main/java/com/box/l10n/mojito/collect/ImmutableMapCollectors.java
@@ -3,10 +3,15 @@ package com.box.l10n.mojito.collect;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collector;
 
 public class ImmutableMapCollectors {
-    public static <K,V> Collector<Map.Entry<K, V>, ?, ImmutableMap<K, V>> MapEntriesToImmutableMap() {
+    public static <K,V> Collector<Map.Entry<K, V>, ?, ImmutableMap<K, V>> mapEntriesToImmutableMap() {
         return ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    public static <K,V> Collector<Map.Entry<K, V>, ?, ImmutableMap<K, V>> mapEntriesToImmutableMap(BinaryOperator<V> mergeFunction) {
+        return ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue, mergeFunction);
     }
 }

--- a/common/src/main/java/com/box/l10n/mojito/localtm/merger/MultiBranchStateMerger.java
+++ b/common/src/main/java/com/box/l10n/mojito/localtm/merger/MultiBranchStateMerger.java
@@ -109,7 +109,7 @@ public class MultiBranchStateMerger {
     ImmutableMap<String, BranchData> removeBranchByName(BranchStateTextUnit intoStateTextUnit, String branchName) {
         return intoStateTextUnit.getBranchNameToBranchDatas().entrySet().stream()
                 .filter(stringBranchDataEntry -> !branchName.equals(stringBranchDataEntry.getKey()))
-                .collect(ImmutableMapCollectors.MapEntriesToImmutableMap());
+                .collect(ImmutableMapCollectors.mapEntriesToImmutableMap());
     }
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnit.java
@@ -8,9 +8,11 @@ import org.springframework.data.annotation.CreatedBy;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -84,6 +86,9 @@ public class TMTextUnit extends SettableAuditableEntity {
     
     @Column(name = "plural_form_other", length = Integer.MAX_VALUE)
     protected String pluralFormOther;
+
+    @OneToOne(mappedBy = "tmTextUnit", fetch = FetchType.LAZY)
+    protected TMTextUnitStatistic tmTextUnitStatistic;
 
     public User getCreatedByUser() {
         return createdByUser;
@@ -172,5 +177,13 @@ public class TMTextUnit extends SettableAuditableEntity {
     public void setPluralFormOther(String pluralFormOther) {
         this.pluralFormOther = pluralFormOther;
     }
-    
+
+    public TMTextUnitStatistic getStatistic() {
+        return tmTextUnitStatistic;
+    }
+
+    public void setStatistic(TMTextUnitStatistic tmTextUnitStatistic) {
+        this.tmTextUnitStatistic = tmTextUnitStatistic;
+    }
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitStatistic.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/TMTextUnitStatistic.java
@@ -1,0 +1,73 @@
+package com.box.l10n.mojito.entity;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Type;
+import org.joda.time.DateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+/**
+ * @author garion
+ */
+@Entity
+@Table(
+        name = "tm_text_unit_statistic",
+        indexes = {
+                @Index(name = "UK__TM_TEXT_UNIT_STATISTIC__BRANCH_ID", columnList = "tm_text_unit_id", unique = true),
+        }
+)
+@BatchSize(size = 1000)
+public class TMTextUnitStatistic extends AuditableEntity {
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "tm_text_unit_id", foreignKey = @ForeignKey(name = "FK__TM_TEXT_UNIT_STATISTIC__BRANCH_ID"))
+    private TMTextUnit tmTextUnit;
+
+    @Column(name="last_day_usage_count")
+    private double lastDayUsageCount = 0;
+
+    @Column(name="last_period_usage_count")
+    private double lastPeriodUsageCount = 0;
+
+    @Column(name="last_seen_date")
+    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+    private DateTime lastSeenDate;
+
+    public TMTextUnit getTMTextUnit() {
+        return tmTextUnit;
+    }
+
+    public void setTMTextUnit(TMTextUnit tmTextUnit) {
+        this.tmTextUnit = tmTextUnit;
+    }
+
+    public double getLastDayUsageCount() {
+        return lastDayUsageCount;
+    }
+
+    public void setLastDayUsageCount(double lastDayUsageCount) {
+        this.lastDayUsageCount = lastDayUsageCount;
+    }
+
+    public double getLastPeriodUsageCount() {
+        return lastPeriodUsageCount;
+    }
+
+    public void setLastPeriodUsageCount(double lastPeriodUsageCount) {
+        this.lastPeriodUsageCount = lastPeriodUsageCount;
+    }
+
+    public DateTime getLastSeenDate() {
+        return lastSeenDate;
+    }
+
+    public void setLastSeenDate(DateTime lastSeenDate) {
+        this.lastSeenDate = lastSeenDate;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/ImportTextUnitStatisticsBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/ImportTextUnitStatisticsBody.java
@@ -1,0 +1,64 @@
+package com.box.l10n.mojito.rest.textunit;
+import org.joda.time.DateTime;
+
+public class ImportTextUnitStatisticsBody {
+    private String name;
+
+    private String content;
+
+    private String comment;
+
+    private Double lastDayEstimatedVolume;
+
+    private Double lastPeriodEstimatedVolume;
+
+    private DateTime lastSeenDate;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Double getLastDayEstimatedVolume() {
+        return lastDayEstimatedVolume;
+    }
+
+    public void setLastDayEstimatedVolume(Double lastDayEstimatedVolume) {
+        this.lastDayEstimatedVolume = lastDayEstimatedVolume;
+    }
+
+    public Double getLastPeriodEstimatedVolume() {
+        return lastPeriodEstimatedVolume;
+    }
+
+    public void setLastPeriodEstimatedVolume(Double lastPeriodEstimatedVolume) {
+        this.lastPeriodEstimatedVolume = lastPeriodEstimatedVolume;
+    }
+
+    public DateTime getLastSeenDate() {
+        return lastSeenDate;
+    }
+
+    public void setLastSeenDate(DateTime lastSeenDate) {
+        this.lastSeenDate = lastSeenDate;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetPathNotFoundException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/asset/AssetPathNotFoundException.java
@@ -1,0 +1,15 @@
+package com.box.l10n.mojito.service.asset;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ *
+ * @author garion
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class AssetPathNotFoundException extends IllegalArgumentException {
+    public AssetPathNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryNameNotFoundException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/repository/RepositoryNameNotFoundException.java
@@ -1,0 +1,15 @@
+package com.box.l10n.mojito.service.repository;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ *
+ * @author garion
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class RepositoryNameNotFoundException extends IllegalArgumentException{
+    public RepositoryNameNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitRepository.java
@@ -23,8 +23,11 @@ public interface TMTextUnitRepository extends JpaRepository<TMTextUnit, Long> {
     TMTextUnit findFirstByAssetAndName(Asset asset, String name);
 
     List<TMTextUnit> findByTm_id(Long tmId);
-        
+
     List<TMTextUnit> findByIdIn(Collection<Long> ids);
+
+    @Query("select tu from TMTextUnit tu left outer join fetch tu.tmTextUnitStatistic where tu.id IN ?1")
+    List<TMTextUnit> findByIdInAndEagerFetchStatistics(Collection<Long> ids);
 
     List<TMTextUnit> findByAsset(Asset asset);
     List<TMTextUnit> findByAssetId(Long assetId);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticRepository.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.service.tm;
+
+import com.box.l10n.mojito.entity.TMTextUnitStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+/**
+ * @author garion
+ */
+@RepositoryRestResource(exported = false)
+public interface TMTextUnitStatisticRepository  extends JpaRepository<TMTextUnitStatistic, Long> {
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticService.java
@@ -1,0 +1,213 @@
+package com.box.l10n.mojito.service.tm;
+
+import com.box.l10n.mojito.collect.ImmutableMapCollectors;
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.BaseEntity;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.TMTextUnit;
+import com.box.l10n.mojito.entity.TMTextUnitStatistic;
+import com.box.l10n.mojito.okapi.TextUnitUtils;
+import com.box.l10n.mojito.rest.textunit.ImportTextUnitStatisticsBody;
+import com.box.l10n.mojito.service.pollableTask.Pollable;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
+import com.box.l10n.mojito.service.pollableTask.PollableFutureTaskResult;
+import com.box.l10n.mojito.service.tm.search.StatusFilter;
+import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
+import com.box.l10n.mojito.service.tm.textunitdtocache.TextUnitDTOsCacheService;
+import com.box.l10n.mojito.service.tm.textunitdtocache.UpdateType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @author garion
+ */
+@Service
+public class TMTextUnitStatisticService {
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(TMTextUnitStatisticService.class);
+
+    @Autowired
+    MeterRegistry meterRegistry;
+
+    @Autowired
+    TextUnitBatchMatcher textUnitBatchMatcher;
+
+    @Autowired
+    TextUnitDTOsCacheService textUnitDTOsCacheService;
+
+    @Autowired
+    TMTextUnitRepository tmTextUnitRepository;
+
+    @Autowired
+    TMTextUnitStatisticRepository tmTextUnitStatisticRepository;
+
+    @Autowired
+    TextUnitUtils textUnitUtils;
+
+    int batchSize = 5000;
+
+    /**
+     * Imports statistics information for a target text unit by matching it using name, content and comment information.
+     * Existing statistic data is overwritten by incoming data.
+     *
+     * @param locale                the locale of the target text unit
+     * @param asset                 the asset of the target text unit
+     * @param textUnitStatistics    the statistics of the text unit
+     * @return                      a PollableFuture
+     */
+    @Pollable(async = true, message = "Start importing text unit statistics.")
+    public PollableFuture importStatistics(
+            Locale locale,
+            Asset asset,
+            List<ImportTextUnitStatisticsBody> textUnitStatistics) {
+        logger.debug("Import statistics for the text units for the given locale and asset.");
+
+        ImmutableMap<String, TextUnitDTO> textUnitDTOsByMD5 = textUnitDTOsCacheService.getTextUnitDTOsForAssetAndLocaleByMD5(
+                asset.getId(),
+                locale.getId(),
+                StatusFilter.ALL,
+                true,
+                UpdateType.ALWAYS);
+
+        ImmutableMap<String, List<TextUnitDTO>> textUnitDTOsByName = textUnitDTOsByMD5.values().stream()
+                .collect(Collectors.collectingAndThen(Collectors.groupingBy(TextUnitDTO::getName), ImmutableMap::copyOf));
+
+        ImmutableMap<ImportTextUnitStatisticsBody, ImmutableList<TextUnitDTO>> statisticToTextUnitDTOMap = textUnitStatistics.stream()
+                .map(textUnitStatistic -> new AbstractMap.SimpleEntry<>(
+                        textUnitStatistic, getMatchingTextUnitDTOs(textUnitStatistic, textUnitDTOsByMD5, textUnitDTOsByName, asset)
+                ))
+                .filter(entry -> entry.getValue() != null)
+                .collect(ImmutableMapCollectors.mapEntriesToImmutableMap(
+                        (textUnitDTOsFirst, textUnitDTOsLast) -> textUnitDTOsLast)
+                );
+
+        ImmutableList<Long> textUnitIds = statisticToTextUnitDTOMap.values().stream()
+                .flatMap(Collection::stream)
+                .map(TextUnitDTO::getTmTextUnitId)
+                .collect(ImmutableList.toImmutableList());
+
+        Map<ImportTextUnitStatisticsBody, List<TMTextUnit>> statisticsToTextUnitsMap = getStatisticsToTextUnitMap(statisticToTextUnitDTOMap, textUnitIds);
+        uploadStatistics(statisticsToTextUnitsMap);
+
+        return new PollableFutureTaskResult();
+    }
+
+    private ImmutableList<TextUnitDTO> getMatchingTextUnitDTOs(ImportTextUnitStatisticsBody textUnitStatistic, ImmutableMap<String, TextUnitDTO> textUnitDTOsByMD5, ImmutableMap<String, List<TextUnitDTO>> textUnitDTOsByName, Asset logAsset) {
+        String statisticTextUnitMD5 = getTextUnitMd5(textUnitStatistic);
+        TextUnitDTO foundTextUnitDTOByMD5 = textUnitDTOsByMD5.get(statisticTextUnitMD5);
+
+        if (foundTextUnitDTOByMD5 != null) {
+            return ImmutableList.of(foundTextUnitDTOByMD5);
+        }
+
+        // Only attempt a fallback match by name if the content or comment aren't available in the statistic object.
+        if (StringUtils.isEmpty(textUnitStatistic.getContent()) || StringUtils.isEmpty(textUnitStatistic.getComment())) {
+            List<TextUnitDTO> foundTextUnitDTOsByNameAndContent = textUnitDTOsByName.get(textUnitStatistic.getName());
+
+            if (foundTextUnitDTOsByNameAndContent != null && foundTextUnitDTOsByNameAndContent.size() > 0) {
+                return ImmutableList.copyOf(foundTextUnitDTOsByNameAndContent);
+            }
+        }
+
+        logUnmatchedStatistics(logAsset, textUnitStatistic);
+        return null;
+    }
+
+    private void logUnmatchedStatistics(Asset asset, ImportTextUnitStatisticsBody textUnitStatistic) {
+        String message = String.format(
+                "No equivalent text unit found, skip import statistics for text unit with name: %1$s for asset with id: %2$s & path: %3$s",
+                textUnitStatistic.getName(),
+                asset.getId(),
+                asset.getPath());
+
+        logger.warn(message);
+
+        Tags tags = Tags.of("assetId", String.valueOf(asset.getId()),
+                "assetPath", asset.getPath());
+
+        meterRegistry.summary("services.TMTextUnitStatisticService.ImportUnmatchedStatistics", tags);
+    }
+
+    private ImmutableMap<ImportTextUnitStatisticsBody, List<TMTextUnit>> getStatisticsToTextUnitMap(ImmutableMap<ImportTextUnitStatisticsBody, ImmutableList<TextUnitDTO>> statisticToTextUnitDTOMap, ImmutableList<Long> textUnitIds) {
+        List<TMTextUnit> textUnits = new ArrayList<>();
+        Iterables.partition(textUnitIds, batchSize).forEach(
+                textUnitIdBatch -> textUnits.addAll(tmTextUnitRepository.findByIdInAndEagerFetchStatistics(textUnitIdBatch))
+        );
+
+        ImmutableMap<Long, TMTextUnit> idTextUnitMap = textUnits.stream().collect(
+                ImmutableMap.toImmutableMap(BaseEntity::getId, Function.identity())
+        );
+
+        return statisticToTextUnitDTOMap.entrySet()
+                .stream()
+                .map(statisticToTextUnitDTOEntry -> {
+                    ImportTextUnitStatisticsBody statistics = statisticToTextUnitDTOEntry.getKey();
+                    ImmutableList<TextUnitDTO> textUnitDTOs = statisticToTextUnitDTOEntry.getValue();
+
+                    List<TMTextUnit> matchedTextUnits = textUnitDTOs.stream()
+                            .map(textUnitDTO -> idTextUnitMap.get(textUnitDTO.getTmTextUnitId()))
+                            .collect(Collectors.toList());
+
+                    return new AbstractMap.SimpleEntry<>(
+                            statistics,
+                            matchedTextUnits
+                            );
+                })
+                .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private void uploadStatistics(Map <ImportTextUnitStatisticsBody, List<TMTextUnit>> statisticsToTextUnitsMap) {
+        List<TMTextUnitStatistic> updatedStatistics = statisticsToTextUnitsMap.entrySet().stream()
+                .flatMap(statisticsToTextUnitEntry -> {
+                    ImportTextUnitStatisticsBody textUnitStatistic = statisticsToTextUnitEntry.getKey();
+                    List<TMTextUnit> tmTextUnits = statisticsToTextUnitEntry.getValue();
+
+                    return tmTextUnits.stream()
+                            .map(tmTextUnit -> {
+                                logger.debug("Add statistics for text unit with name: {}.", textUnitStatistic.getName());
+
+                                TMTextUnitStatistic statistic = tmTextUnit.getStatistic();
+
+                                if (statistic == null) {
+                                    statistic = new TMTextUnitStatistic();
+                                    statistic.setTMTextUnit(tmTextUnit);
+                                }
+
+                                statistic.setLastDayUsageCount(textUnitStatistic.getLastDayEstimatedVolume());
+                                statistic.setLastPeriodUsageCount(textUnitStatistic.getLastPeriodEstimatedVolume());
+                                statistic.setLastSeenDate(textUnitStatistic.getLastSeenDate());
+
+                                return statistic;
+                            });
+                })
+                .collect(Collectors.toList());
+
+        Iterables.partition(updatedStatistics, batchSize).forEach(
+                updatedStatisticsBatch -> tmTextUnitStatisticRepository.saveAll(updatedStatisticsBatch)
+        );
+    }
+
+    private String getTextUnitMd5(ImportTextUnitStatisticsBody textUnitStatistic) {
+        return textUnitUtils.computeTextUnitMD5(
+                textUnitStatistic.getName(), textUnitStatistic.getContent(), textUnitStatistic.getComment()
+        );
+    }
+}

--- a/webapp/src/main/resources/db/migration/V57__Add_TmTextUnitStatistic.sql
+++ b/webapp/src/main/resources/db/migration/V57__Add_TmTextUnitStatistic.sql
@@ -1,0 +1,16 @@
+-- New table to store text unit usage statistics.
+-- Note: v56 is a JAVA-based migration, found here: db/migration/V56__TUCVAddAssetIdUpdater.java
+
+CREATE TABLE tm_text_unit_statistic (
+    id bigint(20) NOT NULL AUTO_INCREMENT,
+    created_date datetime DEFAULT NULL,
+    last_modified_date datetime DEFAULT NULL,
+    last_day_usage_count double precision DEFAULT NULL,
+    last_period_usage_count double precision DEFAULT NULL,
+    last_seen_date datetime DEFAULT NULL,
+    tm_text_unit_id bigint NOT NULL,
+    primary key (id)
+);
+
+ALTER TABLE tm_text_unit_statistic ADD CONSTRAINT UK__TM_TEXT_UNIT_STATISTIC__BRANCH_ID UNIQUE (tm_text_unit_id);
+ALTER TABLE tm_text_unit_statistic ADD CONSTRAINT FK__TM_TEXT_UNIT_STATISTIC__BRANCH_ID FOREIGN KEY (tm_text_unit_id) REFERENCES tm_text_unit (id);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMTextUnitStatisticServiceTest.java
@@ -1,0 +1,293 @@
+package com.box.l10n.mojito.service.tm;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.TMTextUnit;
+import com.box.l10n.mojito.entity.TMTextUnitStatistic;
+import com.box.l10n.mojito.rest.textunit.ImportTextUnitStatisticsBody;
+import com.box.l10n.mojito.service.asset.AssetRepository;
+import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import com.box.l10n.mojito.service.repository.RepositoryService;
+import com.box.l10n.mojito.test.TestIdWatcher;
+import org.joda.time.DateTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author garion
+ */
+public class TMTextUnitStatisticServiceTest extends ServiceTestBase {
+
+    /**
+     * logger
+     */
+    static Logger logger = LoggerFactory.getLogger(TMTextUnitStatisticServiceTest.class);
+
+    @Autowired
+    TMService tmService;
+
+    @Autowired
+    RepositoryService repositoryService;
+
+    @Autowired
+    AssetRepository assetRepository;
+
+    @Autowired
+    AssetService assetService;
+
+    @Autowired
+    TMTextUnitStatisticRepository tmTextUnitStatisticRepository;
+
+    @Autowired
+    TMTextUnitStatisticService tmTextUnitStatisticService;
+
+    @Rule
+    public TestIdWatcher testIdWatcher = new TestIdWatcher();
+
+    Asset asset;
+    Long tmId;
+    Long assetId;
+    Long tmTextUnitId;
+    String tmTextUnitName = "content --- comment";
+    String tmTextContent = "content";
+    String tmTextComment = "comment";
+    Double lastDayEstimatedVolume = 3D;
+    Double lastPeriodEstimatedVolume = 42D;
+    DateTime lastSeenDate = new DateTime(2021, 11, 25, 0, 0);
+
+    private void createTestTextUnitData(Repository repository) {
+        logger.debug("Create data for test");
+
+        asset = assetService.createAssetWithContent(repository.getId(), "test-asset-path.xliff", "test asset content");
+
+        //make sure asset and its relationships are loaded
+        asset = assetRepository.findById(asset.getId()).orElse(null);
+
+        assetId = asset.getId();
+        tmId = repository.getTm().getId();
+
+        TMTextUnit addTMTextUnit = tmService.addTMTextUnit(tmId, assetId, tmTextUnitName, tmTextContent, tmTextComment);
+        tmTextUnitId = addTMTextUnit.getId();
+    }
+
+    private ImportTextUnitStatisticsBody getImportTextUnitStatisticsBody() {
+        ImportTextUnitStatisticsBody statistic = new ImportTextUnitStatisticsBody();
+        statistic.setName(tmTextUnitName);
+        statistic.setContent(tmTextContent);
+        statistic.setComment(tmTextComment);
+        statistic.setLastDayEstimatedVolume(lastDayEstimatedVolume);
+        statistic.setLastPeriodEstimatedVolume(lastPeriodEstimatedVolume);
+        statistic.setLastSeenDate(lastSeenDate);
+        return statistic;
+    }
+
+    @Test
+    public void importStatisticsByMD5Works() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+
+        assertNotNull(actualTMTextUnitStatistics);
+        TMTextUnitStatistic actualStatistic = actualTMTextUnitStatistics.stream().findFirst().orElse(null);
+        assertNotNull(actualStatistic);
+        assertEquals(statistic.getLastDayEstimatedVolume(), (Double) actualStatistic.getLastDayUsageCount());
+        assertEquals(statistic.getLastPeriodEstimatedVolume(), (Double) actualStatistic.getLastPeriodUsageCount());
+        assertEquals(statistic.getLastSeenDate(), actualStatistic.getLastSeenDate());
+    }
+
+    @Test
+    public void importDuplicateStatisticsWorks() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        textUnitStatistics.add(statistic);
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertNotNull(actualTMTextUnitStatistics);
+        assertEquals(1, actualTMTextUnitStatistics.size());
+        TMTextUnitStatistic actualStatistic = actualTMTextUnitStatistics.stream().findFirst().orElse(null);
+        assertNotNull(actualStatistic);
+        assertEquals(statistic.getLastDayEstimatedVolume(), (Double) actualStatistic.getLastDayUsageCount());
+        assertEquals(statistic.getLastPeriodEstimatedVolume(), (Double) actualStatistic.getLastPeriodUsageCount());
+        assertEquals(statistic.getLastSeenDate(), actualStatistic.getLastSeenDate());
+    }
+
+    @Test
+    public void importPartialStatisticForTextUnitsWithSameName() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        asset = assetService.createAssetWithContent(repository.getId(), "test-asset-path.xliff", "test asset content");
+        asset = assetRepository.findById(asset.getId()).orElse(null);
+
+        assetId = asset.getId();
+        tmId = repository.getTm().getId();
+
+        tmService.addTMTextUnit(tmId, assetId, tmTextUnitName, "content1", "comment1");
+        tmService.addTMTextUnit(tmId, assetId, tmTextUnitName, "content2", "comment2");
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        statistic.setContent(null);
+        statistic.setComment(null);
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertNotNull(actualTMTextUnitStatistics);
+        assertEquals(2, actualTMTextUnitStatistics.size());
+
+        for (TMTextUnitStatistic actualStatistic: actualTMTextUnitStatistics) {
+            assertNotNull(actualStatistic);
+            assertEquals(statistic.getLastDayEstimatedVolume(), (Double) actualStatistic.getLastDayUsageCount());
+            assertEquals(statistic.getLastPeriodEstimatedVolume(), (Double) actualStatistic.getLastPeriodUsageCount());
+            assertEquals(statistic.getLastSeenDate(), actualStatistic.getLastSeenDate());
+        }
+    }
+
+    @Test
+    public void importStatisticsMissingCommentWorks() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        statistic.setComment(null);
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertNotNull(actualTMTextUnitStatistics);
+        assertEquals(1, actualTMTextUnitStatistics.size());
+        TMTextUnitStatistic actualStatistic = actualTMTextUnitStatistics.stream().findFirst().orElse(null);
+        assertNotNull(actualStatistic);
+        assertEquals(statistic.getLastDayEstimatedVolume(), (Double) actualStatistic.getLastDayUsageCount());
+        assertEquals(statistic.getLastPeriodEstimatedVolume(), (Double) actualStatistic.getLastPeriodUsageCount());
+        assertEquals(statistic.getLastSeenDate(), actualStatistic.getLastSeenDate());
+    }
+
+    @Test
+    public void importStatisticsMissingContentWorks() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        statistic.setContent(null);
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertNotNull(actualTMTextUnitStatistics);
+        assertEquals(1, actualTMTextUnitStatistics.size());
+        TMTextUnitStatistic actualStatistic = actualTMTextUnitStatistics.stream().findFirst().orElse(null);
+        assertNotNull(actualStatistic);
+        assertEquals(statistic.getLastDayEstimatedVolume(), (Double) actualStatistic.getLastDayUsageCount());
+        assertEquals(statistic.getLastPeriodEstimatedVolume(), (Double) actualStatistic.getLastPeriodUsageCount());
+        assertEquals(statistic.getLastSeenDate(), actualStatistic.getLastSeenDate());
+    }
+
+    @Test
+    public void importStatisticsMismatchedNameFails() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        statistic.setName("mismatched_name");
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertEquals(0, actualTMTextUnitStatistics.size());
+    }
+
+    @Test
+    public void importStatisticsMismatchedContentFails() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        statistic.setContent("mismatched_content");
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertEquals(0, actualTMTextUnitStatistics.size());
+    }
+
+    @Test
+    public void importStatisticsMismatchedCommentFails() throws Exception {
+        Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+        createTestTextUnitData(repository);
+
+        List<ImportTextUnitStatisticsBody> textUnitStatistics = new ArrayList<>();
+        ImportTextUnitStatisticsBody statistic = getImportTextUnitStatisticsBody();
+        statistic.setComment("mismatched_comment");
+        textUnitStatistics.add(statistic);
+
+        tmTextUnitStatisticService.importStatistics(repository.getSourceLocale(), asset, textUnitStatistics).get();
+
+        List<TMTextUnitStatistic> actualTMTextUnitStatistics = tmTextUnitStatisticRepository
+                .findAll()
+                .stream()
+                .filter(ts -> Objects.equals(ts.getTMTextUnit().getAsset().getRepository().getId(), repository.getId()))
+                .collect(Collectors.toList());
+        assertEquals(0, actualTMTextUnitStatistics.size());
+    }
+}


### PR DESCRIPTION
Add tm_text_unit_statistic table to store usage information and an import API in
the TextUnitWS to be able to ingest the data into the system and link it to
existing text units by the MD5 of their name, content and comment information.