### PR TITLE
Added Empty Placeholder, Glossary, Placeholder comment & Recommend String id cli checkers

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
@@ -51,4 +51,5 @@ public abstract class AbstractCliChecker {
     protected List<Pattern> getRegexPatterns() {
         return cliCheckerOptions.getParameterRegexSet().stream().map(regex -> Pattern.compile(regex.getRegex())).collect(Collectors.toList());
     }
+
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractPlaceholderDescriptionCheck.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractPlaceholderDescriptionCheck.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public abstract class AbstractPlaceholderDescriptionCheck {
 
@@ -12,10 +13,14 @@ public abstract class AbstractPlaceholderDescriptionCheck {
     public Optional<String> getFailureText(String placeholder) {
         String failureText = null;
         if (StringUtils.isNumeric(placeholder)) {
-            failureText = "Missing description for placeholder number '" + placeholder + "' in comment.";
+            failureText = "Missing description for placeholder number '" + placeholder + "' in comment. Please add a description in the string comment in the form " + placeholder + ":<description>";
         } else if (!placeholder.trim().isEmpty()) {
-            failureText ="Missing description for placeholder with name '" + placeholder + "' in comment.";
+            failureText = "Missing description for placeholder with name '" + placeholder + "' in comment. Please add a description in the string comment in the form " + placeholder + ":<description>";
         }
         return Optional.ofNullable(failureText);
+    }
+
+    protected boolean isPlaceholderDescriptionMissingInComment(String comment, String placeholder) {
+        return StringUtils.isBlank(comment) || !Pattern.compile(placeholder + ":.+").matcher(comment).find();
     }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -1,0 +1,23 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.ibm.icu.text.BreakIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class CheckerUtils {
+
+    public static List<String> getWordsInString(String str) {
+        List<String> words = new ArrayList<>();
+        BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
+        wordBreakIterator.setText(str);
+        int start = wordBreakIterator.first();
+        for (int end = wordBreakIterator.next(); end != BreakIterator.DONE; start = end, end = wordBreakIterator.next()) {
+            if (wordBreakIterator.getRuleStatus() != BreakIterator.WORD_NONE) {
+                words.add(str.substring(start, end));
+            }
+        }
+        return words;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerType.java
@@ -5,7 +5,11 @@ import com.box.l10n.mojito.cli.command.CommandException;
 public enum CliCheckerType {
 
     SPELL_CHECKER(SpellCliChecker.class),
-    CONTEXT_COMMENT_CHECKER(ContextAndCommentCliChecker.class);
+    CONTEXT_COMMENT_CHECKER(ContextAndCommentCliChecker.class),
+    EMPTY_PLACEHOLDER_CHECKER(EmptyPlaceholderChecker.class),
+    PLACEHOLDER_COMMENT_CHECKER(PlaceholderCommentChecker.class),
+    GLOSSARY_CASE_CHECKER(GlossaryCaseChecker.class),
+    RECOMMEND_STRING_ID_CHECKER(RecommendStringIdChecker.class);
 
     Class<? extends AbstractCliChecker> type;
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/DoubleBracesPlaceholderDescriptionChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/DoubleBracesPlaceholderDescriptionChecker.java
@@ -1,0 +1,19 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import java.util.Set;
+
+public class DoubleBracesPlaceholderDescriptionChecker extends SingleBracesPlaceholderDescriptionChecker {
+
+    private static final String LEFT_DOUBLE_BRACES_REGEX = "\\{\\{.*?";
+    private static final String RIGHT_DOUBLE_BRACES_REGEX = "\\}\\}.*?";
+
+    @Override
+    public Set<String> checkCommentForDescriptions(String source, String comment) {
+        return super.checkCommentForDescriptions(replaceDoubleBracesWithSingle(source), comment);
+    }
+
+    private String replaceDoubleBracesWithSingle(String str) {
+        return str.replaceAll(LEFT_DOUBLE_BRACES_REGEX, "{")
+                .replaceAll(RIGHT_DOUBLE_BRACES_REGEX, "}");
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderChecker.java
@@ -1,0 +1,76 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * {@link AbstractCliChecker} that verifies a source string does not contain an empty placeholder e.g. '{}'.
+ *
+ * The check uses Single or Double braces regex to identify placeholders in a source string and then checks that the
+ * placeholder substring contains regex 'word' values.
+ *
+ * @author mallen
+ */
+public class EmptyPlaceholderChecker extends AbstractCliChecker {
+
+    static Logger logger = LoggerFactory.getLogger(EmptyPlaceholderChecker.class);
+
+    private Pattern wordPattern = Pattern.compile("\\w+");
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        CliCheckResult cliCheckResult = createCliCheckerResult();
+        Set<String> failures = checkForEmptyPlaceholders(assetExtractionDiffs);
+        if (!failures.isEmpty()) {
+            cliCheckResult.setSuccessful(false);
+            cliCheckResult.setNotificationText(buildNotificationText(failures).toString());
+        }
+
+        return cliCheckResult;
+    }
+
+    private Set<String> checkForEmptyPlaceholders(List<AssetExtractionDiff> assetExtractionDiffs) {
+        return cliCheckerOptions.getParameterRegexSet().stream()
+                .filter(regex -> isEmptyPlaceholderRegex(regex))
+                .flatMap(placeholderRegularExpressions -> getAddedTextUnits(assetExtractionDiffs).stream()
+                    .map(assetExtractorTextUnit -> assetExtractorTextUnit.getSource())
+                    .filter(source -> isSourceStringWithEmptyPlaceholders(placeholderRegularExpressions, source))).collect(Collectors.toSet());
+    }
+
+    private boolean isEmptyPlaceholderRegex(PlaceholderRegularExpressions regex) {
+        return regex.equals(PlaceholderRegularExpressions.SINGLE_BRACE_REGEX) || regex.equals(PlaceholderRegularExpressions.DOUBLE_BRACE_REGEX);
+    }
+
+    private boolean isSourceStringWithEmptyPlaceholders(PlaceholderRegularExpressions placeholderRegularExpressions, String source) {
+        Matcher matcher = Pattern.compile(placeholderRegularExpressions.getRegex()).matcher(source);
+        while (matcher.find()) {
+            String placeholder = source.substring(matcher.start(), matcher.end());
+            logger.debug("Found placeholder '{}' in source string '{}'", placeholder, source);
+            if (!wordPattern.matcher(placeholder).find()) {
+                logger.debug("Found empty placeholder '{}' in source string '{}'", placeholder, source);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private StringBuilder buildNotificationText(Set<String> failures) {
+        StringBuilder notificationText = new StringBuilder();
+        notificationText.append("Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:");
+        notificationText.append(System.lineSeparator());
+        notificationText.append(failures.stream()
+                .map(source -> "* '" + source + "'")
+                .collect(Collectors.joining(System.lineSeparator())));
+        notificationText.append(System.lineSeparator());
+        return notificationText;
+    }
+
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseChecker.java
@@ -1,0 +1,69 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.CommandException;
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GlossaryCaseChecker extends AbstractCliChecker {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        CliCheckResult cliCheckResult = createCliCheckerResult();
+        try {
+            GlossaryTermCaseCheckerTrie glossaryTermCaseCheckerTrie = getGlossaryTermTrie();
+            List<GlossaryCaseCheckerSearchResult> failures = getGlossarySearchResults(glossaryTermCaseCheckerTrie, assetExtractionDiffs);
+            if(!failures.isEmpty()){
+                if(failures.stream().anyMatch(result -> result.isMajorFailure())){
+                    cliCheckResult.setSuccessful(false);
+                }
+                cliCheckResult.setNotificationText(buildNotificationText(failures).toString());
+            }
+        } catch (IOException e) {
+            throw new CommandException(String.format("Error retrieving glossary terms from file path %s: %s", cliCheckerOptions.getGlossaryFilePath(), e.getMessage()));
+        }
+
+        return cliCheckResult;
+    }
+
+    private List<GlossaryCaseCheckerSearchResult> getGlossarySearchResults(GlossaryTermCaseCheckerTrie glossaryTermCaseCheckerTrie, List<AssetExtractionDiff> assetExtractionDiffs) {
+        List<GlossaryCaseCheckerSearchResult> failures = getAddedTextUnits(assetExtractionDiffs).stream()
+            .map(assetExtractorTextUnit -> glossaryTermCaseCheckerTrie.runGlossaryCaseCheck(assetExtractorTextUnit.getSource()))
+            .filter(result -> !result.isSuccess())
+            .collect(Collectors.toList());
+        return failures;
+    }
+
+    private GlossaryTermCaseCheckerTrie getGlossaryTermTrie() throws IOException {
+        List<GlossaryTerm> terms = Arrays.asList(objectMapper.readValue(Paths.get(cliCheckerOptions.getGlossaryFilePath()).toFile(), GlossaryTerm[].class));
+        GlossaryTermCaseCheckerTrie glossaryTermCaseCheckerTrie = new GlossaryTermCaseCheckerTrie(terms);
+        return glossaryTermCaseCheckerTrie;
+    }
+
+    private StringBuilder buildNotificationText(List<GlossaryCaseCheckerSearchResult> failures){
+        StringBuilder builder = new StringBuilder();
+        builder.append("Glossary check failures:");
+        builder.append(System.lineSeparator());
+        builder.append(failures.stream()
+                .map(failure -> getFailureText(builder, failure))
+                .collect(Collectors.joining(System.lineSeparator())));
+        return builder;
+    }
+
+    private String getFailureText(StringBuilder builder, GlossaryCaseCheckerSearchResult failure) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(System.lineSeparator());
+        for (String failureText : failure.getFailures()) {
+            builder.append(String.format("* %s", failureText));
+            builder.append(System.lineSeparator());
+        }
+        return sb.toString();
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseCheckerSearchResult.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseCheckerSearchResult.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import java.util.List;
+
+class GlossaryCaseCheckerSearchResult {
+    List<String> failures;
+    boolean isSuccess;
+    boolean isMajorFailure;
+    final String source;
+
+    public GlossaryCaseCheckerSearchResult(String source) {
+        this.source = source;
+        this.isSuccess = true;
+    }
+
+    public boolean isSuccess() {
+        return isSuccess;
+    }
+
+    public boolean isMajorFailure() {
+        return isMajorFailure;
+    }
+
+    public List<String> getFailures() {
+        return failures;
+    }
+
+    public String getSource() {
+        return source;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryTerm.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryTerm.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public class GlossaryTerm {
+
+    private String term;
+    @JsonProperty("severity")
+    private GlossaryTermSeverity severity;
+
+    public String getTerm() {
+        return term;
+    }
+
+    public void setTerm(String term) {
+        this.term = term;
+    }
+
+    public GlossaryTermSeverity getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(GlossaryTermSeverity severity) {
+        this.severity = severity;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryTermCaseCheckerTrie.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryTermCaseCheckerTrie.java
@@ -1,0 +1,92 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class GlossaryTermCaseCheckerTrie {
+
+    private final Node rootNode = new Node();
+
+    public GlossaryTermCaseCheckerTrie(List<GlossaryTerm> terms) {
+        for (GlossaryTerm term : terms) {
+            this.add(term);
+        }
+    }
+
+    public void add(GlossaryTerm term) {
+        List<String> words = CheckerUtils.getWordsInString(term.getTerm());
+        Node currentNode = rootNode;
+        for (String word : words) {
+            word = word.toLowerCase();
+            if (!currentNode.children.containsKey(word)) {
+                currentNode.children.put(word, new Node());
+            }
+            currentNode = currentNode.children.get(word);
+        }
+        currentNode.glossaryTerms.add(term);
+    }
+
+    public GlossaryCaseCheckerSearchResult runGlossaryCaseCheck(String source) {
+        String sourceTrimmedWhitespace = source.trim().replaceAll(" +", " ");
+        List<String> words = CheckerUtils.getWordsInString(source);
+        GlossaryCaseCheckerSearchResult result = new GlossaryCaseCheckerSearchResult(source);
+        List<String> failures = new ArrayList<>();
+        for (int i = 0; i < words.size(); i++) {
+            Node current = rootNode;
+            for (int j = i; j < words.size(); j++) {
+                current = current.children.get(words.get(j).toLowerCase());
+                if (current == null) {
+                    break;
+                }
+                if (!current.glossaryTerms.isEmpty() && isGlossaryTermValid(sourceTrimmedWhitespace, current)) {
+                    addFailureText(source, result, failures, current);
+                }
+            }
+        }
+        result.failures = failures;
+        return result;
+    }
+
+    private boolean isGlossaryTermValid(String source, Node current) {
+        boolean allFailed = true;
+        for (GlossaryTerm glossaryTerm : current.glossaryTerms) {
+            int index = StringUtils.indexOfIgnoreCase(source, glossaryTerm.getTerm());
+            if (index > -1) {
+                String glossaryTermInString = source.substring(index, index + glossaryTerm.getTerm().length());
+                if (glossaryTermInString.equals(glossaryTerm.getTerm())) {
+                    allFailed = false;
+                }
+            }
+        }
+
+        return allFailed;
+    }
+
+    private void addFailureText(String source, GlossaryCaseCheckerSearchResult result, List<String> failures, Node current) {
+        result.isSuccess = false;
+        if (current.glossaryTerms.stream().anyMatch(term -> term.getSeverity() == GlossaryTermSeverity.MAJOR)) {
+            result.isMajorFailure = true;
+            failures.add(String.format("MAJOR: String '%s' contains glossary term '%s' which must match exactly.", source,
+                    current.glossaryTerms.stream().filter(term -> term.getSeverity() == GlossaryTermSeverity.MAJOR)
+                            .map(GlossaryTerm::getTerm).findFirst().get()));
+        } else {
+            if (current.glossaryTerms.size() > 1) {
+                failures.add(String.format("WARN: String '%s' contains glossary terms %s but does not exactly match one of the terms.", source,
+                        current.glossaryTerms.stream().map(term -> "'" + term.getTerm() + "'")
+                                .collect(Collectors.joining(" or "))));
+            } else {
+                failures.add(String.format("WARN: String '%s' contains glossary term '%s' but does not exactly match the glossary term.", source, current.glossaryTerms.get(0).getTerm()));
+            }
+        }
+    }
+
+    private class Node {
+        Map<String, Node> children = new HashMap<>();
+        List<GlossaryTerm> glossaryTerms = new ArrayList<>();
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryTermSeverity.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryTermSeverity.java
@@ -1,0 +1,6 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+public enum GlossaryTermSeverity {
+    MAJOR,
+    MINOR;
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
@@ -1,0 +1,131 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * {@link AbstractCliChecker} that verifies that a description of a placeholder is present in the associated
+ * comment in the form <placeholder name>:<description> or <placeholder position>:<description>
+ *
+ * @author mallen
+ */
+public class PlaceholderCommentChecker extends AbstractCliChecker {
+
+    static Logger logger = LoggerFactory.getLogger(PlaceholderCommentChecker.class);
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        CliCheckResult cliCheckResult = new CliCheckResult(isHardFail(), CliCheckerType.PLACEHOLDER_COMMENT_CHECKER.name());
+        Map<String, List<String>> failureMap = checkForPlaceholderDescriptionsInComment(assetExtractionDiffs);
+        if (!failureMap.isEmpty()) {
+            cliCheckResult.setSuccessful(false);
+            cliCheckResult.setNotificationText(buildNotificationText(failureMap).toString());
+        }
+        return cliCheckResult;
+    }
+
+    protected Map<String, List<String>> checkForPlaceholderDescriptionsInComment(List<AssetExtractionDiff> assetExtractionDiffs) {
+        List<AbstractPlaceholderDescriptionCheck> placeholderDescriptionChecks = getPlaceholderCommentChecks();
+
+        return getAddedTextUnits(assetExtractionDiffs).stream()
+                .map(assetExtractorTextUnit -> getPlaceholderCommentCheckResult(placeholderDescriptionChecks, assetExtractorTextUnit))
+                .filter(result -> !result.getFailures().isEmpty())
+                .collect(Collectors.toMap(PlaceholderCommentCheckResult::getSource, PlaceholderCommentCheckResult::getFailures));
+    }
+
+    private PlaceholderCommentCheckResult getPlaceholderCommentCheckResult(List<AbstractPlaceholderDescriptionCheck> placeholderDescriptionChecks, AssetExtractorTextUnit assetExtractorTextUnit) {
+        PlaceholderCommentCheckResult result;
+        String source = assetExtractorTextUnit.getSource();
+        String comment = assetExtractorTextUnit.getComments();
+        if (StringUtils.isBlank(comment)) {
+            result = new PlaceholderCommentCheckResult(source, Lists.newArrayList("Comment is empty."));
+        } else {
+            List<String> failures = placeholderDescriptionChecks.stream()
+                    .flatMap(check -> check.checkCommentForDescriptions(source, comment).stream())
+                    .collect(Collectors.toList());
+            result = new PlaceholderCommentCheckResult(source, failures);
+        }
+
+        return result;
+    }
+
+    private List<AbstractPlaceholderDescriptionCheck> getPlaceholderCommentChecks() {
+        return cliCheckerOptions.getParameterRegexSet().stream()
+                .map(placeholderRegularExpressions -> getPlaceholderDescriptionCheck(placeholderRegularExpressions))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+    }
+
+    private Optional<AbstractPlaceholderDescriptionCheck> getPlaceholderDescriptionCheck(PlaceholderRegularExpressions placeholderRegularExpression) {
+        AbstractPlaceholderDescriptionCheck placeholderDescriptionCheck = null;
+        switch (placeholderRegularExpression) {
+            case SINGLE_BRACE_REGEX:
+                placeholderDescriptionCheck = new SingleBracesPlaceholderDescriptionChecker();
+                break;
+            case DOUBLE_BRACE_REGEX:
+                placeholderDescriptionCheck = new DoubleBracesPlaceholderDescriptionChecker();
+                break;
+            case PRINTF_LIKE_VARIABLE_TYPE_REGEX:
+                placeholderDescriptionCheck = new PrintfLikeVariableTypePlaceholderDescriptionChecker();
+                break;
+            case PLACEHOLDER_NO_SPECIFIER_REGEX:
+            case SIMPLE_PRINTF_REGEX:
+            case PRINTF_LIKE_REGEX:
+            case PLACEHOLDER_IGNORE_PERCENTAGE_AFTER_BRACKETS:
+                placeholderDescriptionCheck = new SimpleRegexPlaceholderDescriptionChecker(placeholderRegularExpression);
+                break;
+            default:
+                logger.warn("Placeholder comment checker not implemented for regex {}", placeholderRegularExpression.name());
+        }
+        return Optional.ofNullable(placeholderDescriptionCheck);
+    }
+
+    private StringBuilder buildNotificationText(Map<String, List<String>> failureMap) {
+        StringBuilder notificationText = new StringBuilder();
+        notificationText.append("Placeholder description in comment check failed.");
+        notificationText.append(System.lineSeparator());
+        notificationText.append(System.lineSeparator());
+        notificationText.append(failureMap.keySet().stream()
+                .map(source -> {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("String '" + source + "' failed check:");
+                    sb.append(System.lineSeparator());
+                    return sb.append(failureMap.get(source).stream()
+                                    .map(failure -> "* " + failure)
+                                    .collect(Collectors.joining(System.lineSeparator())))
+                            .toString();
+                })
+                .collect(Collectors.joining(System.lineSeparator())));
+
+        return notificationText;
+    }
+
+    class PlaceholderCommentCheckResult {
+        final List<String> failures;
+        final String source;
+
+        PlaceholderCommentCheckResult(String source, List<String> failures) {
+            this.source = source;
+            this.failures = failures;
+        }
+
+        public List<String> getFailures() {
+            return failures;
+        }
+
+        public String getSource() {
+            return source;
+        }
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PrintfLikeVariableTypePlaceholderDescriptionChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PrintfLikeVariableTypePlaceholderDescriptionChecker.java
@@ -1,0 +1,54 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class PrintfLikeVariableTypePlaceholderDescriptionChecker extends AbstractPlaceholderDescriptionCheck {
+
+    private Pattern pattern = Pattern.compile(PlaceholderRegularExpressions.PRINTF_LIKE_VARIABLE_TYPE_REGEX.getRegex());
+
+    /**
+     * Pattern to extract the name from within brackets e.g %(count)d or %{count}d will extract 'count' as the
+     * placeholder name.
+     */
+    private Pattern namePattern = Pattern.compile("(?<=\\()\\w+?(?=\\))|(?<=\\{)\\w+?(?=\\})");
+
+    @Override
+    public Set<String> checkCommentForDescriptions(String source, String comment) {
+        Matcher placeHolderMatcher = pattern.matcher(source);
+        return getPlaceholderNames(source, placeHolderMatcher).stream()
+            .filter(placeholder -> isPlaceholderDescriptionMissingInComment(comment, placeholder))
+            .map(placeholder -> getFailureText(placeholder))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toSet());
+    }
+
+    private List<String> getPlaceholderNames(String source, Matcher placeHolderMatcher) {
+        List<String> placeholderNames = new ArrayList<>();
+        int placeholderCount = 0;
+        while (placeHolderMatcher.find()) {
+            placeholderNames.add(getPlaceholderName(source.substring(placeHolderMatcher.start(), placeHolderMatcher.end()), placeholderCount));
+            placeholderCount++;
+        }
+        return placeholderNames;
+    }
+
+    private String getPlaceholderName(String placeholderText, int placeholderCount) {
+        String name;
+        Matcher nameMatcher = namePattern.matcher(placeholderText);
+        if(nameMatcher.find()){
+            name = placeholderText.substring(nameMatcher.start(), nameMatcher.end());
+        }else {
+            name = Integer.toString(placeholderCount);
+        }
+        return name;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
@@ -1,0 +1,140 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * {@link AbstractCliChecker} that generates a recommended string id based off the file path of the file that contains the new string.
+ * <br>
+ * <br>
+ * <b>NOTE:</b> For an id to be recommended the text unit must contain an existing message context value in its name.
+ * e.g. "Some string --- some.message.context"
+ *
+ * @author mallen
+ */
+public class RecommendStringIdChecker extends AbstractCliChecker {
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        CliCheckResult result = createCliCheckerResult();
+        List<String> recommendations = getRecommendedIdPrefixUpdates(assetExtractionDiffs);
+        if (!recommendations.isEmpty()) {
+            result.setSuccessful(false);
+            result.setNotificationText(buildNotificationText(recommendations));
+        }
+        return result;
+    }
+
+    private String buildNotificationText(List<String> recommendations) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Recommended id updates for the following strings:");
+        sb.append(System.lineSeparator());
+        sb.append(recommendations.stream()
+                .map(recommendation -> "* " + recommendation)
+                .collect(Collectors.joining(System.lineSeparator())));
+        sb.append(System.lineSeparator());
+        return sb.toString();
+    }
+
+    private List<String> getRecommendedIdPrefixUpdates(List<AssetExtractionDiff> assetExtractionDiffs) {
+        return getAddedTextUnits(assetExtractionDiffs).stream().map(textUnit -> getRecommendStringIdCheckResult(textUnit))
+                .filter(recommendation -> recommendation.isRecommendedUpdate())
+                .map(recommendation -> String.format("Please update id for string '%s' to be prefixed with '%s'", recommendation.getSource(), recommendation.getRecommendedIdPrefix()))
+                .collect(Collectors.toList());
+    }
+
+    private RecommendStringIdCheckResult getRecommendStringIdCheckResult(AssetExtractorTextUnit textUnit) {
+        RecommendStringIdCheckResult recommendation = new RecommendStringIdCheckResult();
+        recommendation.setSource(textUnit.getSource());
+        recommendation.setRecommendedUpdate(false);
+        return generateRecommendation(textUnit, recommendation);
+    }
+
+    private String removeLineNumberFromUsage(String usage) {
+        int lastIndexOfColon = usage.lastIndexOf(":");
+        if (lastIndexOfColon > -1 && lastIndexOfColon < usage.length() - 1 && StringUtils.isNumeric(usage.substring(lastIndexOfColon + 1))) {
+            usage = usage.substring(0, lastIndexOfColon);
+        }
+        return usage;
+    }
+
+    private RecommendStringIdCheckResult generateRecommendation(AssetExtractorTextUnit textUnit, RecommendStringIdCheckResult recommendation) {
+        List<String> possiblePrefixes = new ArrayList<>();
+        String msgctxt = textUnit.getName().contains("---") ? textUnit.getName().split("---")[1].trim() : "";
+        String cwd = Paths.get(".").toAbsolutePath() + FileSystems.getDefault().getSeparator();
+
+        for (String filePath : textUnit.getUsages()) {
+            if (Paths.get(filePath).isAbsolute()) {
+                filePath = filePath.replace(cwd, "");
+            }
+            Path file = Paths.get(removeLineNumberFromUsage(filePath));
+            String fileName = file.getFileName().toString();
+            Deque<String> dirNames = getDirectoryNames(file);
+            String idPrefix = "";
+            if (dirNames.size() >= 2) {
+                idPrefix = dirNames.pop() + "." + dirNames.pop() + ".";
+            } else if (!dirNames.isEmpty() && !dirNames.peek().equals(fileName)) {
+                idPrefix = dirNames.pop() + ".";
+            } else {
+                idPrefix = "root.";
+            }
+            possiblePrefixes.add(idPrefix);
+        }
+
+        if (!possiblePrefixes.isEmpty() && !possiblePrefixes.stream().anyMatch(prefix -> msgctxt.startsWith(prefix))) {
+            recommendation.setRecommendedUpdate(true);
+            recommendation.setRecommendedIdPrefix(possiblePrefixes.get(0));
+        }
+
+        return recommendation;
+    }
+
+    private Deque<String> getDirectoryNames(Path file) {
+        Deque<String> dirNames = new ArrayDeque<>();
+        while (file.getParent() != null) {
+            dirNames.push(file.getParent().getFileName().toString());
+            file = file.getParent();
+        }
+        return dirNames;
+    }
+
+    class RecommendStringIdCheckResult {
+        String source;
+        String recommendedIdPrefix;
+        boolean isRecommendedUpdate;
+
+        public String getSource() {
+            return source;
+        }
+
+        public void setSource(String source) {
+            this.source = source;
+        }
+
+        public String getRecommendedIdPrefix() {
+            return recommendedIdPrefix;
+        }
+
+        public void setRecommendedIdPrefix(String recommendedIdPrefix) {
+            this.recommendedIdPrefix = recommendedIdPrefix;
+        }
+
+        public boolean isRecommendedUpdate() {
+            return isRecommendedUpdate;
+        }
+
+        public void setRecommendedUpdate(boolean recommendedUpdate) {
+            isRecommendedUpdate = recommendedUpdate;
+        }
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SimpleRegexPlaceholderDescriptionChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SimpleRegexPlaceholderDescriptionChecker.java
@@ -1,0 +1,55 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Checks for placeholders by number using a regex pattern, expects to find descriptions in the comment
+ * that matches the number of placeholders in the source string.
+ *
+ * @author mallen
+ */
+public class SimpleRegexPlaceholderDescriptionChecker extends AbstractPlaceholderDescriptionCheck {
+
+    private Pattern pattern;
+
+    public SimpleRegexPlaceholderDescriptionChecker(PlaceholderRegularExpressions placeholderRegularExpressions) {
+        this.pattern = Pattern.compile(placeholderRegularExpressions.getRegex());
+    }
+
+    @Override
+    public Set<String> checkCommentForDescriptions(String source, String comment) {
+        Matcher placeHolderMatcher = pattern.matcher(source);
+        return getPlaceholderNames(source, placeHolderMatcher).stream()
+                .filter(placeholder -> isPlaceholderDescriptionMissingInComment(comment, placeholder))
+                .map(placeholder -> getFailureText(placeholder))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+    }
+
+    public void setPattern(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    protected List<String> getPlaceholderNames(String source, Matcher placeHolderMatcher) {
+        List<String> placeholderNames = new ArrayList<>();
+        Set<String> previousPlaceholders = new HashSet<>();
+        while (placeHolderMatcher.find()) {
+            String placeholder = source.substring(placeHolderMatcher.start(), placeHolderMatcher.end()).replaceAll("\\[\\d+\\]", "");
+            if(!previousPlaceholders.contains(placeholder)){
+                placeholderNames.add(placeholder);
+                previousPlaceholders.add(placeholder);
+            }
+        }
+        return placeholderNames;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SingleBracesPlaceholderDescriptionChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SingleBracesPlaceholderDescriptionChecker.java
@@ -1,0 +1,38 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.ibm.icu.text.MessageFormat;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class SingleBracesPlaceholderDescriptionChecker extends AbstractPlaceholderDescriptionCheck {
+
+    static Logger logger = LoggerFactory.getLogger(SingleBracesPlaceholderDescriptionChecker.class);
+
+    @Override
+    public Set<String> checkCommentForDescriptions(String source, String comment) {
+
+        try {
+            MessageFormat messageFormat = new MessageFormat(source);
+            return messageFormat.getArgumentNames().stream()
+                    .filter(placeholder -> isPlaceholderDescriptionMissingInComment(comment, placeholder))
+                    .map(placeholder -> getFailureText(placeholder))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toSet());
+        } catch (IllegalArgumentException e) {
+            logger.debug("String '{}' is not in ICU format, attempting to parse with regex", source);
+            SimpleRegexPlaceholderDescriptionChecker regexChecker = new SingleBracesRegexPlaceholderDescriptionChecker();
+            return regexChecker.checkCommentForDescriptions(source, comment);
+        }
+
+    }
+
+
+
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SingleBracesRegexPlaceholderDescriptionChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SingleBracesRegexPlaceholderDescriptionChecker.java
@@ -1,0 +1,32 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+public class SingleBracesRegexPlaceholderDescriptionChecker extends SimpleRegexPlaceholderDescriptionChecker {
+
+    public SingleBracesRegexPlaceholderDescriptionChecker() {
+        super(PlaceholderRegularExpressions.SINGLE_BRACE_REGEX);
+    }
+
+    @Override
+    protected List<String> getPlaceholderNames(String source, Matcher placeHolderMatcher) {
+        List<String> placeholderNames = new ArrayList<>();
+        Set<String> previousPlaceholders = new HashSet<>();
+        while (placeHolderMatcher.find()) {
+            String placeholder = source.substring(placeHolderMatcher.start(), placeHolderMatcher.end())
+                    .replaceAll("\\{", "")
+                    .replaceAll("\\}", "");
+            if(!previousPlaceholders.contains(placeholder)){
+                placeholderNames.add(placeholder);
+                previousPlaceholders.add(placeholder);
+            }
+        }
+        return placeholderNames;
+    }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.cli.command.checks;
 import com.box.l10n.mojito.cli.command.CommandException;
 import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
 import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+import com.ibm.icu.text.BreakIterator;
 import dumonts.hunspell.Hunspell;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -12,10 +13,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -110,7 +113,7 @@ public class SpellCliChecker extends AbstractCliChecker {
     }
 
     private SpellCliCheckerResult getSpellCliCheckerResult(String sourceString) {
-        SpellCliCheckerResult result = new SpellCliCheckerResult(sourceString, spellCheckSourceString(Arrays.asList(removePlaceholdersFromString(sourceString).split("\\W+"))));
+        SpellCliCheckerResult result = new SpellCliCheckerResult(sourceString, spellCheckSourceString(CheckerUtils.getWordsInString(removePlaceholdersFromString(sourceString))));
         if(!result.getSuggestionMap().isEmpty()) {
             result.setSuccessful(false);
         }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/DoubleBracesPlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/DoubleBracesPlaceholderDescriptionCheckerTest.java
@@ -1,0 +1,70 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class DoubleBracesPlaceholderDescriptionCheckerTest {
+
+    private DoubleBracesPlaceholderDescriptionChecker doubleBracesPlaceholderCommentChecker;
+
+    @Before
+    public void setup() {
+        doubleBracesPlaceholderCommentChecker = new DoubleBracesPlaceholderDescriptionChecker();
+
+    }
+
+    @Test
+    public void testSuccessRun() {
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {{placeholder}}.", "Test comment placeholder:This is a description of a placeholder");
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testMissingPlaceholderDescriptionInComment() {
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {{placeholder}}.", "Test comment");
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'placeholder' in comment. Please add a description in the string comment in the form placeholder:<description>"));
+    }
+
+    @Test
+    public void testNullComment() {
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {{placeholder}}.", null);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'placeholder' in comment. Please add a description in the string comment in the form placeholder:<description>"));
+    }
+
+    @Test
+    public void testMultiplePlaceholderDescriptionsInComment() {
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {{placeholder}} and {another} and so {more}.", "Test comment placeholder:description 1,another: description 2,more: description 3");
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testOneOfMultiplePlaceholderDescriptionsMissingInComment() {
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {{placeholder}} and {another} and some {more}.", "Test comment placeholder:description 1,more: description 3");
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'another' in comment. Please add a description in the string comment in the form another:<description>"));
+    }
+
+    @Test
+    public void testPluralPlaceholderMissingDescription(){
+        String source = "{{numFiles, plural, one{{# There is one file}} other{{There are # files}}}}";
+        String comment = "Test comment";
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'numFiles' in comment. Please add a description in the string comment in the form numFiles:<description>"));
+    }
+
+    @Test
+    public void testNumberedPlaceholder() {
+        String source = "A source string with a single {{0}}.";
+        String comment = "Test comment";
+        Set<String> failures = doubleBracesPlaceholderCommentChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder number '0' in comment. Please add a description in the string comment in the form 0:<description>"));
+    }
+
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderCheckerTest.java
@@ -1,0 +1,173 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
+
+public class EmptyPlaceholderCheckerTest {
+
+    private EmptyPlaceholderChecker emptyPlaceholderChecker;
+
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        emptyPlaceholderChecker = new EmptyPlaceholderChecker();
+        emptyPlaceholderChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(), "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a single {placeholder}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+    }
+
+    @Test
+    public void testNoEmptyPlaceholders() {
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testEmptyPlaceholder() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a empty placeholder {}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:" + System.lineSeparator() +
+                "* 'A source string with a empty placeholder {}.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testMultipleEmptyPlaceholdersInString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with two {} empty placeholders {}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:" + System.lineSeparator() +
+                "* 'A source string with two {} empty placeholders {}.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testMixOfStringsWithEmptyAndNonEmptyPlaceholders() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with two {} empty placeholders {}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        AssetExtractorTextUnit assetExtractorTextUnit2 = new AssetExtractorTextUnit();
+        assetExtractorTextUnit2.setName("Another string id --- Another Test context");
+        assetExtractorTextUnit2.setSource("Another source string with two {name1} placeholders {name2}.");
+        assetExtractorTextUnit2.setComments("Another comment");
+        addedTUs.add(assetExtractorTextUnit2);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:" + System.lineSeparator() +
+                "* 'A source string with two {} empty placeholders {}.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testStringContainingEmptyAndNamedPlaceholders() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with two {} placeholders {name}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:" + System.lineSeparator() +
+                "* 'A source string with two {} placeholders {name}.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testMultipleStringsWithEmptyPlaceholders() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with two {} empty placeholders {}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        AssetExtractorTextUnit assetExtractorTextUnit2 = new AssetExtractorTextUnit();
+        assetExtractorTextUnit2.setName("Another string id --- Another Test context");
+        assetExtractorTextUnit2.setSource("Another source string with two {} empty placeholders {}.");
+        assetExtractorTextUnit2.setComments("Another comment");
+        addedTUs.add(assetExtractorTextUnit2);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:" + System.lineSeparator() +
+                "* 'A source string with two {} empty placeholders {}.'" + System.lineSeparator() +
+                "* 'Another source string with two {} empty placeholders {}.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testStringWithNestedICUPlaceholder() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a nested ICU placeholder {pagesCount, plural, one {# page.} other {# pages.}}.");
+        assetExtractorTextUnit.setComments("Test comment");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = emptyPlaceholderChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseCheckerTest.java
@@ -1,0 +1,189 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GlossaryCaseCheckerTest {
+
+    private GlossaryCaseChecker glossaryCaseChecker;
+
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        glossaryCaseChecker = new GlossaryCaseChecker();
+        glossaryCaseChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(), Sets.newHashSet(), "", "target/test-classes/com/box/l10n/mojito/cli/glossarychecker/glossary.json"));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with Company in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+    }
+
+    @Test
+    public void testSuccess() {
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void testFailure() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string company in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+    }
+
+    @Test
+    public void testMajorErrorContainsMajorInNotificationString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with company in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().contains("MAJOR"));
+    }
+
+    @Test
+    public void testMultipleGlossaryTermsInString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with company and ads Manager in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertEquals("Glossary check failures:"
+                + System.lineSeparator() + "* MAJOR: String 'A source string with company and ads Manager in it.' contains glossary term 'Company' which must match exactly." + System.lineSeparator()
+                + "* WARN: String 'A source string with company and ads Manager in it.' contains glossary term 'Ads Manager' but does not exactly match the glossary term."
+                + System.lineSeparator() + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testGlossaryTermInStringWithAdditionalSpaces() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with ads                Manager in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertEquals("Glossary check failures:"
+                + System.lineSeparator() + "* WARN: String 'A source string with ads                Manager in it.' contains glossary term 'Ads Manager' but does not exactly match the glossary term."
+                + System.lineSeparator() + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testStringWithNoGlossaryTerms() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with no glossary terms in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void testMinorFailuresDontCauseOverallResultFail() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with ads Manager in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertEquals("Glossary check failures:"
+                + System.lineSeparator() + "* WARN: String 'A source string with ads Manager in it.' contains glossary term 'Ads Manager' but does not exactly match the glossary term."
+                + System.lineSeparator() + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testHyphenatedGlossaryTermInString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with Ads-Manager in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertEquals("Glossary check failures:"
+                + System.lineSeparator() + "* WARN: String 'A source string with Ads-Manager in it.' contains glossary term 'Ads Manager' but does not exactly match the glossary term."
+                + System.lineSeparator() + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testSameTermDifferentCaseInGlossary() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with Event manager in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test
+    public void testSameTermDifferentCaseInGlossaryFailure() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with event Manager in it.");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = glossaryCaseChecker.run(assetExtractionDiffs);
+        Assert.assertEquals("Glossary check failures:"
+                + System.lineSeparator() + "* WARN: String 'A source string with event Manager in it.' contains glossary terms 'Event Manager' or 'Event manager' but does not exactly match one of the terms."
+                + System.lineSeparator() + System.lineSeparator(), result.getNotificationText());
+    }
+
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
@@ -1,0 +1,158 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.DOUBLE_BRACE_REGEX;
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX;
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PRINTF_LIKE_VARIABLE_TYPE_REGEX;
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
+
+public class PlaceholderCommentCheckerTest {
+
+    private PlaceholderCommentChecker placeholderCommentChecker;
+
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        placeholderCommentChecker = new PlaceholderCommentChecker();
+        placeholderCommentChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(), "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a single {placeholder}.");
+        assetExtractorTextUnit.setComments("Test comment placeholder:This is a description of a placeholder");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+    }
+
+    @Test
+    public void testSuccessRun() {
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testMissingPlaceholderDescriptionInComment() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a single {placeholder}.");
+        assetExtractorTextUnit.setComments("Test comment ");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testMultiplePlaceholderDescriptionsInComment() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a single {placeholder} and {another} and so {more}.");
+        assetExtractorTextUnit.setComments("Test comment placeholder:description 1,another: description 2,more: description 3");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+    @Test
+    public void testOneOfMultiplePlaceholderDescriptionsMissingInComment() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a single {placeholder} and {another} and some {more}.");
+        assetExtractorTextUnit.setComments("Test comment placeholder:description 1,more: description 3");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+        Assert.assertEquals("Placeholder description in comment check failed." + System.lineSeparator()
+                + System.lineSeparator() +
+                "String 'A source string with a single {placeholder} and {another} and some {more}.' failed check:" + System.lineSeparator() +
+                "* Missing description for placeholder with name 'another' in comment. Please add a description in the string comment in the form another:<description>", result.getNotificationText());
+    }
+
+    @Test
+    public void testMultipleRegexsChecked() {
+        placeholderCommentChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(DOUBLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX, PLACEHOLDER_NO_SPECIFIER_REGEX), Sets.newHashSet(), "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with different {placeholder} %(placeholder2)s {{placeholder3}} %d");
+        assetExtractorTextUnit.setComments("Test comment placeholder:A description of placeholder,placeholder2: Another description,%d:some more,placeholder3: another description");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void testMultipleRegexsCheckedFailure() {
+        placeholderCommentChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(DOUBLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX, PLACEHOLDER_NO_SPECIFIER_REGEX), Sets.newHashSet(), "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with different {placeholder} %(placeholder2)s {{placeholder3}} %d");
+        assetExtractorTextUnit.setComments("Test comment placeholder:A description of placeholder,placeholder3: another description");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().contains("* Missing description for placeholder with name 'placeholder2' in comment."));
+        Assert.assertTrue(result.getNotificationText().contains("* Missing description for placeholder with name '%d' in comment."));
+    }
+
+    @Test
+    public void testNullComment() {
+        placeholderCommentChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(DOUBLE_BRACE_REGEX, PRINTF_LIKE_VARIABLE_TYPE_REGEX, PLACEHOLDER_NO_SPECIFIER_REGEX), Sets.newHashSet(), "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("A source string with different {placeholder} %(placeholder2)s {{placeholder3}} %d");
+        assetExtractorTextUnit.setComments(null);
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().contains("Comment is empty."));
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PrintfLikeVariableTypePlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PrintfLikeVariableTypePlaceholderDescriptionCheckerTest.java
@@ -1,0 +1,78 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class PrintfLikeVariableTypePlaceholderDescriptionCheckerTest {
+
+    private PrintfLikeVariableTypePlaceholderDescriptionChecker printfLikeVariableTypePlaceholderDescriptionChecker;
+
+    @Before
+    public void setup() {
+        printfLikeVariableTypePlaceholderDescriptionChecker = new PrintfLikeVariableTypePlaceholderDescriptionChecker();
+    }
+
+    @Test
+    public void testSuccess() {
+        String source = "There is %(count)d books on %(count)d shelves";
+        String comment = "Test comment count:The number of books and shelves";
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testSuccessWithBraces() {
+        String source = "There is %{count}d books on %{count}d shelves";
+        String comment = "Test comment count:The number of books and shelves";
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testFailure() {
+        String source = "There is %(count)d books";
+        String comment = "Test comment";
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'count' in comment. Please add a description in the string comment in the form count:<description>"));
+    }
+
+    @Test
+    public void testFailureWithBraces() {
+        String source = "There is %{count}d books";
+        String comment = "Test comment";
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'count' in comment. Please add a description in the string comment in the form count:<description>"));
+    }
+
+    @Test
+    public void testNullComment() {
+        String source = "There is %(count)d books";
+        String comment = null;
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'count' in comment. Please add a description in the string comment in the form count:<description>"));
+    }
+
+    @Test
+    public void testFailureWithMultiplePlaceholders() {
+        String source = "There is %(count)d books and %(shelf_count)d shelves";
+        String comment = "Test comment count:The number of books";
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'shelf_count' in comment. Please add a description in the string comment in the form shelf_count:<description>"));
+    }
+
+    @Test
+    public void testSuccessWithMultiplePlaceholders() {
+        String source = "There is %(count)d books and %(shelf_count)d shelves";
+        String comment = "Test comment count:The number of books,shelf_count:The number of shelves";
+        Set<String> failures = printfLikeVariableTypePlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 0);
+    }
+
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdCheckerTest.java
@@ -1,0 +1,225 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
+
+public class RecommendStringIdCheckerTest {
+
+    private RecommendStringIdChecker recommendStringIdChecker;
+
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        recommendStringIdChecker = new RecommendStringIdChecker();
+        List<String> modifiedFiles = new ArrayList<>(Arrays.asList("someDir/someOtherDir/evenDeeperDir/test1.txt", "someDir/someOtherDir/test2.txt"));
+        recommendStringIdChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(),
+                "", ""));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- someDir.someSubDir.someStringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someDir/someSubDir/someSourceFile.java"));
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+    }
+
+    @Test
+    public void testSuccess() {
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test
+    public void testFailure() {
+        CliCheckResult result = recommendStringIdChecker.run(setTextUnitId("incorrect.prefix.someStringId"));
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertEquals("Recommended id updates for the following strings:" + System.lineSeparator()
+                + "* Please update id for string 'A source string with no errors.' to be prefixed with 'someDir.someSubDir.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testMultipleUsagesProvided() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors.  --- anotherDir.someSubDir.stringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497", "anotherDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test
+    public void testRecommendationWhenMultipleUsagesProvided() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- aDifferentDir.someSubDir.stringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497", "anotherDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().contains("someDir.someSubDir.") || result.getNotificationText().contains("anotherDir.someSubDir."));
+    }
+
+    @Test
+    public void testEmptyMsgContextReceivesRecommendation() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors.");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().contains("someDir.someSubDir."));
+    }
+
+    @Test
+    public void testAbsolutePathAsUsage() {
+        String cwd = Paths.get(".").toAbsolutePath().toString();
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- someDir.someSubDir.someStringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet(cwd + FileSystems.getDefault().getSeparator() + "someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test
+    public void testRecommendedUpdatesAreLimitedToADepthOfTwo() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- someStringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertEquals("Recommended id updates for the following strings:" + System.lineSeparator()
+                + "* Please update id for string 'A source string with no errors.' to be prefixed with 'someDir.someSubDir.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testTopLevelFileRecommendedWithRootPrefix() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- someStringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someSourceFile.java:123"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertEquals("Recommended id updates for the following strings:" + System.lineSeparator()
+                + "* Please update id for string 'A source string with no errors.' to be prefixed with 'root.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    @Test
+    public void testEmptyUsagesSetPassesCheck() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- someDir.someSubDir.someStringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet());
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertTrue(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test
+    public void testMultipleRecommendations() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- someStringId");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someSourceFile.java"));
+        addedTUs.add(assetExtractorTextUnit);
+        AssetExtractorTextUnit assetExtractorTextUnit2 = new AssetExtractorTextUnit();
+        assetExtractorTextUnit2.setName("Another source string with no errors. --- someOtherStringId");
+        assetExtractorTextUnit2.setSource("Another source string with no errors.");
+        assetExtractorTextUnit2.setUsages(Sets.newHashSet("someDir/someSubDir/someOtherSourceFile.java:2"));
+        addedTUs.add(assetExtractorTextUnit2);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertEquals("Recommended id updates for the following strings:" + System.lineSeparator()
+                + "* Please update id for string 'A source string with no errors.' to be prefixed with 'root.'" + System.lineSeparator()
+                + "* Please update id for string 'Another source string with no errors.' to be prefixed with 'someDir.someSubDir.'" + System.lineSeparator(), result.getNotificationText());
+    }
+
+    private List<AssetExtractionDiff> setTextUnitId(String id) {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. --- " + id);
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet("someDir/someSubDir/evenDeeperSubDir/someSourceFile.java:1111"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+        return assetExtractionDiffs;
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SimpleRegexPlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SimpleRegexPlaceholderDescriptionCheckerTest.java
@@ -1,0 +1,84 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.regex.PlaceholderRegularExpressions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class SimpleRegexPlaceholderDescriptionCheckerTest {
+
+    private SimpleRegexPlaceholderDescriptionChecker simpleRegexPlaceholderDescriptionChecker;
+
+    @Before
+    public void setup(){
+        simpleRegexPlaceholderDescriptionChecker = new SimpleRegexPlaceholderDescriptionChecker(PlaceholderRegularExpressions.SIMPLE_PRINTF_REGEX);
+    }
+
+    @Test
+    public void testSuccess() {
+        String source = "There is %1 books on %1 shelves";
+        String comment = "Test comment %1:The number of books and shelves";
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testFailure() {
+        String source = "There is %1 books";
+        String comment = "Test comment";
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name '%1' in comment. Please add a description in the string comment in the form %1:<description>"));
+    }
+
+    @Test
+    public void testNullComment() {
+        String source = "There is %1 books";
+        String comment = null;
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name '%1' in comment. Please add a description in the string comment in the form %1:<description>"));
+    }
+
+    @Test
+    public void testFailureWithMultiplePlaceholders() {
+        String source = "There is %1 books and %2 shelves";
+        String comment = "Test comment %1:The number of books";
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name '%2' in comment. Please add a description in the string comment in the form %2:<description>"));
+    }
+
+    @Test
+    public void testNoSpecifierRegexSuccess() {
+        String source = "There is %d books on %d shelves";
+        String comment = "Test comment %d:The number of books and shelves";
+        simpleRegexPlaceholderDescriptionChecker.setPattern(Pattern.compile(PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX.getRegex()));
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testNoSpecifierRegexFailure() {
+        String source = "There is %d books on %d shelves";
+        String comment = "Test comment";
+        simpleRegexPlaceholderDescriptionChecker.setPattern(Pattern.compile(PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX.getRegex()));
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name '%d' in comment. Please add a description in the string comment in the form %d:<description>"));
+    }
+
+
+    @Test
+    public void testNoSpecifierRegexFailureWithMultiplePlaceholders() {
+        String source = "There is %d books and %s shelves";
+        String comment = "Test comment %d:The number of books";
+        simpleRegexPlaceholderDescriptionChecker.setPattern(Pattern.compile(PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX.getRegex()));
+        Set<String> failures = simpleRegexPlaceholderDescriptionChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name '%s' in comment. Please add a description in the string comment in the form %s:<description>"));
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SingleBracesPlaceholderDescriptionCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SingleBracesPlaceholderDescriptionCheckerTest.java
@@ -1,0 +1,79 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class SingleBracesPlaceholderDescriptionCheckerTest {
+
+    private SingleBracesPlaceholderDescriptionChecker messageFormatPlaceholderCommentChecker;
+
+    @Before
+    public void setup() {
+        messageFormatPlaceholderCommentChecker = new SingleBracesPlaceholderDescriptionChecker();
+    }
+
+    @Test
+    public void testSuccessRun() {
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {placeholder}.", "Test comment placeholder:This is a description of a placeholder");
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testMissingPlaceholderDescriptionInComment() {
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {placeholder}.", "Test comment");
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'placeholder' in comment. Please add a description in the string comment in the form placeholder:<description>"));
+    }
+
+    @Test
+    public void testNullComment() {
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {placeholder}.", null);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'placeholder' in comment. Please add a description in the string comment in the form placeholder:<description>"));
+    }
+
+    @Test
+    public void testMultiplePlaceholderDescriptionsInComment() {
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {placeholder} and {another} and so {more}.", "Test comment placeholder:description 1,another: description 2,more: description 3");
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    @Test
+    public void testOneOfMultiplePlaceholderDescriptionsMissingInComment() {
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions("A source string with a single {placeholder} and {another} and some {more}.", "Test comment placeholder:description 1,more: description 3");
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'another' in comment. Please add a description in the string comment in the form another:<description>"));
+    }
+
+    @Test
+    public void testPluralPlaceholderMissingDescription(){
+        String source = "{numFiles, plural, one{# There is one file} other{There are # files}}";
+        String comment = "Test comment";
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder with name 'numFiles' in comment. Please add a description in the string comment in the form numFiles:<description>"));
+    }
+
+    @Test
+    public void testNumberedPlaceholder() {
+        String source = "A source string with a single {0}.";
+        String comment = "Test comment";
+
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 1);
+        Assert.assertTrue(failures.contains("Missing description for placeholder number '0' in comment. Please add a description in the string comment in the form 0:<description>"));
+    }
+
+    @Test
+    public void testOtherRegexInString() {
+        String source = "A source string with a different placeholder types %(count)s %d %3.";
+        String comment = "Test comment";
+
+        Set<String> failures = messageFormatPlaceholderCommentChecker.checkCommentForDescriptions(source, comment);
+        Assert.assertTrue(failures.size() == 0);
+    }
+    
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/glossarychecker/glossary.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/glossarychecker/glossary.json
@@ -1,0 +1,18 @@
+[
+  {
+    "term": "Company",
+    "severity": "MAJOR"
+  },
+  {
+    "term": "Ads Manager",
+    "severity": "MINOR"
+  },
+  {
+    "term": "Event Manager",
+    "severity": "MINOR"
+  },
+  {
+    "term": "Event manager",
+    "severity": "MINOR"
+  }
+]


### PR DESCRIPTION
Added additional cli checker implementations.

**EMPTY_PLACEHOLDER_CHECKER**
Checks that there is no empty placeholders in a source string when the single or double brace placeholder regex is in use.

**GLOSSARY_CHECKER**
Checks source strings for terms specified in a glossary file, if a term is found then it needs to exactly match the glossary term. Glossary terms can be configured with either a MAJOR or MINOR severity level. MINOR failures will not fail the check, a warning will be added to the notification text. MAJOR failures fail the glossary check and an error message will be added to the notification text. The glossary file is in json format and contains an array of objects containing a term and its associated severity level, example below.

`[
  {
    "term": "Some major term",
    "severity": "MAJOR"
  },
  {
    "term": "Some minor term",
    "severity": "MINOR"
  }
]`

**PLACEHOLDER_COMMENT_CHECKER**
Verifies that any placeholders in a source string have a description in the comment explaining the placeholder. The comment must contain the description in the form _**<placeholder_name>:<placeholder_description>**_

**Recommend String Id**
Checks that string context value is prefixed with the top two directory names in the file path, if not a recommendation is made to prefix the message context value with the relevant directory names.