### PR TITLE
Fix DropImportCommand flaky test

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
@@ -161,13 +161,13 @@ public class DropExportCommand extends Command {
         return bcp47tags;
     }
     
-    private boolean shouldCreateDrop(Repository repository) {
+    protected boolean shouldCreateDrop(Repository repository) {
         boolean createDrop = false;
-        Set<String> Bcp47TagsForTranslation = Sets.newHashSet(getBcp47TagsForExportFromRepository(repository));
+        Set<String> bcp47TagsForTranslation = Sets.newHashSet(getBcp47TagsForExportFromRepository(repository));
         RepositoryStatistic repoStat = repository.getRepositoryStatistic();
         if (repoStat != null) {
             for (RepositoryLocaleStatistic repoLocaleStat : repoStat.getRepositoryLocaleStatistics()) {
-                if (Bcp47TagsForTranslation.contains(repoLocaleStat.getLocale().getBcp47Tag()) && repoLocaleStat.getForTranslationCount() > 0L) {
+                if (bcp47TagsForTranslation.contains(repoLocaleStat.getLocale().getBcp47Tag()) && repoLocaleStat.getForTranslationCount() > 0L) {
                     createDrop = true;
                     break;
                 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
@@ -6,8 +6,6 @@ import com.box.l10n.mojito.entity.Locale;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.rest.client.RepositoryClient;
-import com.box.l10n.mojito.rest.entity.RepositoryLocaleStatistic;
-import com.box.l10n.mojito.rest.entity.RepositoryStatistic;
 import com.box.l10n.mojito.rest.resttemplate.AuthenticatedRestTemplate;
 import com.box.l10n.mojito.rest.resttemplate.ResttemplateConfig;
 import com.box.l10n.mojito.service.asset.AssetRepository;
@@ -195,20 +193,4 @@ public class CLITestBase extends IOTestBase {
             Thread.sleep(numberAttempt * 100);
         }
     }
-
-    protected void waitForRepositoryToHaveStringsForTranslations(Long repositoryId) throws InterruptedException {
-        waitForCondition("wait for repository stats to show forTranslationCount > 0 before exporting a drop", () -> {
-            com.box.l10n.mojito.rest.entity.Repository repository = repositoryClient.getRepositoryById(repositoryId);
-            RepositoryStatistic repositoryStat = repository.getRepositoryStatistic();
-            boolean forTranslation = false;
-            for (RepositoryLocaleStatistic repositoryLocaleStat : repositoryStat.getRepositoryLocaleStatistics()) {
-                if (repositoryLocaleStat.getForTranslationCount() > 0L) {
-                    forTranslation = true;
-                }
-                break;
-            }
-            return forTranslation;
-        });
-    }
-
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/DropExportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/DropExportCommandTest.java
@@ -4,6 +4,7 @@ import com.box.l10n.mojito.cli.CLITestBase;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.rest.client.AssetClient;
 import com.box.l10n.mojito.rest.client.DropClient;
+import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.entity.Asset;
 import com.box.l10n.mojito.rest.entity.Drop;
 import com.box.l10n.mojito.rest.entity.Page;
@@ -31,6 +32,9 @@ public class DropExportCommandTest extends CLITestBase {
     @Autowired
     RepositoryRepository repositoryRepository;
 
+    @Autowired
+    RepositoryClient repositoryClient;
+
     @Test
     public void export() throws Exception {
 
@@ -39,7 +43,11 @@ public class DropExportCommandTest extends CLITestBase {
         getL10nJCommander().run("push", "-r", repository.getName(),
                 "-s", getInputResourcesTestDir("source").getAbsolutePath());
 
-        waitForRepositoryToHaveStringsForTranslations(repository.getId());
+        RepositoryStatusChecker repositoryStatusChecker = new RepositoryStatusChecker();
+        waitForCondition("wait for repository stats to show forTranslationCount > 0 before exporting a drop",
+                () -> repositoryStatusChecker.hasStringsForTranslationsForExportableLocales(
+                        repositoryClient.getRepositoryById(repository.getId())
+                ));
 
         Page<Drop> findAllBefore = dropClient.getDrops(repository.getId(), null, null, null);
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/DropImportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/DropImportCommandTest.java
@@ -7,6 +7,7 @@ import com.box.l10n.mojito.cli.console.Console;
 import com.box.l10n.mojito.entity.Drop;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.rest.client.AssetClient;
+import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.entity.Asset;
 import com.box.l10n.mojito.service.drop.DropRepository;
 import com.box.l10n.mojito.service.drop.DropService;
@@ -78,6 +79,9 @@ public class DropImportCommandTest extends CLITestBase {
     @Autowired
     DropRepository dropRepository;
 
+    @Autowired
+    private RepositoryClient repositoryClient;
+
     @Test
     public void dropImport() throws Exception {
 
@@ -94,7 +98,11 @@ public class DropImportCommandTest extends CLITestBase {
         importTranslations(asset2.getId(), "source2-xliff_", "fr-FR");
         importTranslations(asset2.getId(), "source2-xliff_", "ja-JP");
 
-        waitForRepositoryToHaveStringsForTranslations(repository.getId());
+        RepositoryStatusChecker repositoryStatusChecker = new RepositoryStatusChecker();
+        waitForCondition("wait for repository stats to show forTranslationCount > 0 before exporting a drop",
+                () -> repositoryStatusChecker.hasStringsForTranslationsForExportableLocales(
+                        repositoryClient.getRepositoryById(repository.getId())
+                ));
 
         getL10nJCommander().run("drop-export", "-r", repository.getName());
 
@@ -149,7 +157,11 @@ public class DropImportCommandTest extends CLITestBase {
         importTranslations(asset2.getId(), "source2-xliff_", "fr-FR");
         importTranslations(asset2.getId(), "source2-xliff_", "ja-JP");
 
-        waitForRepositoryToHaveStringsForTranslations(repository.getId());
+        RepositoryStatusChecker repositoryStatusChecker = new RepositoryStatusChecker();
+        waitForCondition("wait for repository stats to show forTranslationCount > 0 before exporting a drop",
+                () -> repositoryStatusChecker.hasStringsForTranslationsForExportableLocales(
+                        repositoryClient.getRepositoryById(repository.getId())
+                ));
 
         getL10nJCommander().run("drop-export", "-r", repository.getName());
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/DropXliffImportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/DropXliffImportCommandTest.java
@@ -6,6 +6,7 @@ import com.box.l10n.mojito.cli.CLITestBase;
 import com.box.l10n.mojito.entity.Drop;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.rest.client.AssetClient;
+import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.entity.Asset;
 import com.box.l10n.mojito.service.drop.DropRepository;
 import com.box.l10n.mojito.service.drop.DropService;
@@ -70,6 +71,9 @@ public class DropXliffImportCommandTest extends CLITestBase {
     @Autowired
     DropImportCommand dropImportCommand;
 
+    @Autowired
+    RepositoryClient repositoryClient;
+
     @Test
     public void dropXliffImport() throws Exception {
 
@@ -86,7 +90,11 @@ public class DropXliffImportCommandTest extends CLITestBase {
         importTranslations(asset2.getId(), "source2-xliff_", "fr-FR");
         importTranslations(asset2.getId(), "source2-xliff_", "ja-JP");
 
-        waitForRepositoryToHaveStringsForTranslations(repository.getId());
+        RepositoryStatusChecker repositoryStatusChecker = new RepositoryStatusChecker();
+        waitForCondition("wait for repository stats to show forTranslationCount > 0 before exporting a drop",
+                () -> repositoryStatusChecker.hasStringsForTranslationsForExportableLocales(
+                        repositoryClient.getRepositoryById(repository.getId())
+                ));
 
         getL10nJCommander().run("drop-export", "-r", repository.getName());
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepositoryStatusChecker.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepositoryStatusChecker.java
@@ -1,0 +1,14 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.rest.entity.Repository;
+
+/**
+ *
+ * @author garion
+ */
+public class RepositoryStatusChecker {
+    public boolean hasStringsForTranslationsForExportableLocales(Repository repository ) {
+        DropExportCommand dropExportCommand = new DropExportCommand();
+        return dropExportCommand.shouldCreateDrop(repository);
+    }
+}


### PR DESCRIPTION
Fix DropImportCommand flaky test by ensuring the wait condition is
applied to exportable locales only instead of all locales, by reusing
the shouldCreateDrop method.