### PR TITLE
Removing comments from Smartling retry tests

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartling.java
@@ -97,7 +97,7 @@ public class ThirdPartyTMSSmartling implements ThirdPartyTMS {
     private final Set<String> supportedImageExtensions = Sets.newHashSet("png", "jpg", "jpeg", "gif", "tiff");
 
     protected static RetryBackoffSpec getRetryConfiguration(){
-        return Retry.backoff(3, Duration.ofSeconds(0)).maxBackoff(Duration.ofSeconds(1));
+        return Retry.backoff(10, Duration.ofSeconds(0)).maxBackoff(Duration.ofSeconds(60));
     }
 
     @Autowired

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -290,7 +290,6 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         RuntimeException exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.push(repository, "projectId", pluralSep, null, null, Collections.emptyList()));
         assertTrue(exception.getMessage().contains("Retries exhausted: 10/10"));
-        // Verify Smartling client called 4 times, original request and then 3 retries before failure
         verify(smartlingClient, times(11)).uploadFile(any(), any(), any(), any(), any(), any());
     }
 
@@ -581,7 +580,6 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
         RuntimeException exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, Collections.emptyList()));
         assertTrue(exception.getMessage().contains("Retries exhausted: 10/10"));
-        // Verify 1 request and 3 retry attempts before exception thrown.
         verify(smartlingClient, times(11)).downloadPublishedFile(anyString(), anyString(), anyString(), anyBoolean());
     }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -289,9 +289,9 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
         RuntimeException exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.push(repository, "projectId", pluralSep, null, null, Collections.emptyList()));
-        assertTrue(exception.getMessage().contains("Retries exhausted: 3/3"));
+        assertTrue(exception.getMessage().contains("Retries exhausted: 10/10"));
         // Verify Smartling client called 4 times, original request and then 3 retries before failure
-        verify(smartlingClient, times(4)).uploadFile(any(), any(), any(), any(), any(), any());
+        verify(smartlingClient, times(11)).uploadFile(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -580,9 +580,9 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
                 assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
         RuntimeException exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, Collections.emptyList()));
-        assertTrue(exception.getMessage().contains("Retries exhausted: 3/3"));
+        assertTrue(exception.getMessage().contains("Retries exhausted: 10/10"));
         // Verify 1 request and 3 retry attempts before exception thrown.
-        verify(smartlingClient, times(4)).downloadPublishedFile(anyString(), anyString(), anyString(), anyBoolean());
+        verify(smartlingClient, times(11)).downloadPublishedFile(anyString(), anyString(), anyString(), anyBoolean());
     }
 
     @Test
@@ -917,7 +917,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         Exception exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, ImmutableList.of()));
         assertTrue(exception.getMessage().contains("Error uploading localized file to Smartling"));
 
-        verify(smartlingClient, times(4)).uploadLocalizedFile(
+        verify(smartlingClient, times(11)).uploadLocalizedFile(
                 anyString(),
                 anyString(),
                 anyString(),


### PR DESCRIPTION
As requested in https://github.com/box/mojito/pull/744 removing the comments from unit tests that are outdated.