### PR TITLE
Added '--include-text-units-with-pattern' parameter to thirdparty-sync command

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ThirdPartySyncCommand.java
@@ -64,6 +64,9 @@ public class ThirdPartySyncCommand extends Command {
     @Parameter(names = {"--skip-assets-path-pattern", "-sa"}, arity = 1, required = false, description = "Do not process text units whose assets path match the SQL LIKE expression")
     String skipAssetsWithPathPattern;
 
+    @Parameter(names = {"--include-text-units-with-pattern", "-it"}, arity = 1, required = false, description = "Only process text units matching with the SQL LIKE expression. Only used in conjunction with the PUSH_TRANSLATION action")
+    String includeTextUnitsWithPattern;
+
     @Parameter(names = {"--options", "-o"}, variableArity = true, required = false, description = "Options to synchronize")
     List<String> options;
 
@@ -85,12 +88,13 @@ public class ThirdPartySyncCommand extends Command {
                 .a(" locale-mapping: ").fg(CYAN).a(localeMapping).reset()
                 .a(" skip-text-units-with-pattern: ").fg(CYAN).a(skipTextUnitsWithPattern).reset()
                 .a(" skip-assets-path-pattern: ").fg(CYAN).a(skipAssetsWithPathPattern).reset()
+                .a(" include-text-units-with-pattern" ).fg(CYAN).a(includeTextUnitsWithPattern).reset()
                 .a(" options: ").fg(CYAN).a(Objects.toString(options)).println(2);
 
         Repository repository = commandHelper.findRepositoryByName(repositoryParam);
 
         PollableTask pollableTask = thirdPartyClient.sync(repository.getId(), thirdPartyProjectId, pluralSeparator, localeMapping,
-                actions, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
+                actions, skipTextUnitsWithPattern, skipAssetsWithPathPattern, includeTextUnitsWithPattern, options);
 
         commandHelper.waitForPollableTask(pollableTask.getId());
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartyClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartyClient.java
@@ -27,6 +27,7 @@ public class ThirdPartyClient extends BaseClient {
                              List<ThirdPartySyncAction> actions,
                              String skipTextUnitsWithPattern,
                              String skipAssetsWithPathPattern,
+                             String includeTextUnitsWithPattern,
                              List<String> options) {
 
         ThirdPartySync thirdPartySync = new ThirdPartySync();
@@ -38,6 +39,7 @@ public class ThirdPartyClient extends BaseClient {
         thirdPartySync.setLocaleMapping(localeMapping);
         thirdPartySync.setSkipTextUnitsWithPattern(skipTextUnitsWithPattern);
         thirdPartySync.setSkipAssetsWithPathPattern(skipAssetsWithPathPattern);
+        thirdPartySync.setIncludeTextUnitsWithPattern(includeTextUnitsWithPattern);
         thirdPartySync.setOptions(options);
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromPath(getBasePathForEntity()).pathSegment("sync");

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartySync.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/ThirdPartySync.java
@@ -14,6 +14,7 @@ public class ThirdPartySync {
     String localeMapping;
     String skipTextUnitsWithPattern;
     String skipAssetsWithPathPattern;
+    String includeTextUnitsWithPattern;
     List<String> options = new ArrayList<>();
 
     public Long getRepositoryId() {
@@ -78,5 +79,13 @@ public class ThirdPartySync {
 
     public void setOptions(List<String> options) {
         this.options = options;
+    }
+
+    public String getIncludeTextUnitsWithPattern() {
+        return includeTextUnitsWithPattern;
+    }
+
+    public void setIncludeTextUnitsWithPattern(String includeTextUnitsWithPattern) {
+        this.includeTextUnitsWithPattern = includeTextUnitsWithPattern;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySync.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySync.java
@@ -12,6 +12,7 @@ public class ThirdPartySync {
     String localeMapping;
     String skipTextUnitsWithPattern;
     String skipAssetsWithPathPattern;
+    String includeTextUnitsWithPattern;
     List<String> options = new ArrayList<>();
 
     public Long getRepositoryId() {
@@ -68,6 +69,14 @@ public class ThirdPartySync {
 
     public void setSkipAssetsWithPathPattern(String skipAssetsWithPathPattern) {
         this.skipAssetsWithPathPattern = skipAssetsWithPathPattern;
+    }
+
+    public String getIncludeTextUnitsWithPattern() {
+        return includeTextUnitsWithPattern;
+    }
+
+    public void setIncludeTextUnitsWithPattern(String includeTextUnitsWithPattern) {
+        this.includeTextUnitsWithPattern = includeTextUnitsWithPattern;
     }
 
     public List<String> getOptions() {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -110,6 +110,7 @@ public class ThirdPartyService {
         thirdPartySyncJobInput.setLocaleMapping(thirdPartySync.getLocaleMapping());
         thirdPartySyncJobInput.setSkipTextUnitsWithPattern(thirdPartySync.getSkipTextUnitsWithPattern());
         thirdPartySyncJobInput.setSkipAssetsWithPathPattern(thirdPartySync.getSkipAssetsWithPathPattern());
+        thirdPartySyncJobInput.setIncludeTextUnitsWithPattern(thirdPartySync.getIncludeTextUnitsWithPattern());
         thirdPartySyncJobInput.setOptions(thirdPartySync.getOptions());
 
         return quartzPollableTaskScheduler.scheduleJob(ThirdPartySyncJob.class, thirdPartySyncJobInput);
@@ -122,14 +123,15 @@ public class ThirdPartyService {
                                      String localeMapping,
                                      String skipTextUnitsWithPattern,
                                      String skipAssetsWithPathPattern,
+                                     String includeTextUnitsWithPattern,
                                      List<String> options,
                                      PollableTask currentTask) {
         logger.debug("Thirdparty TMS Sync: repositoryId={} thirdPartyProjectId={} " +
                         "actions={} pluralSeparator={} localeMapping={} " +
-                        "skipTextUnitsWithPattern={} skipAssetsWithPattern={} " +
+                        "skipTextUnitsWithPattern={} skipAssetsWithPattern={} includeTextUnitsWithPattern={}" +
                         "options={}", repositoryId, thirdPartyProjectId, actions,
                 pluralSeparator, localeMapping, skipTextUnitsWithPattern,
-                skipAssetsWithPathPattern, options);
+                skipAssetsWithPathPattern, includeTextUnitsWithPattern, options);
 
         Repository repository = repositoryRepository.findById(repositoryId).orElse(null);
 
@@ -137,7 +139,7 @@ public class ThirdPartyService {
             push(thirdPartyProjectId, pluralSeparator, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options, repository, currentTask);
         }
         if (actions.contains(ThirdPartySyncAction.PUSH_TRANSLATION)) {
-            pushTranslations(thirdPartyProjectId, pluralSeparator, localeMapping, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options, repository, currentTask);
+            pushTranslations(thirdPartyProjectId, pluralSeparator, localeMapping, skipTextUnitsWithPattern, skipAssetsWithPathPattern, includeTextUnitsWithPattern, options, repository, currentTask);
         }
         if (actions.contains(ThirdPartySyncAction.PULL)) {
             pull(thirdPartyProjectId, pluralSeparator, localeMapping, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options, repository, currentTask);
@@ -157,10 +159,10 @@ public class ThirdPartyService {
     }
 
     @Pollable(message = "Push translations to third party service.")
-    private void pushTranslations(String thirdPartyProjectId, String pluralSeparator, String localeMapping, String skipTextUnitsWithPattern, String skipAssetsWithPathPattern, List<String> options, Repository repository, @ParentTask PollableTask currentTask) {
+    private void pushTranslations(String thirdPartyProjectId, String pluralSeparator, String localeMapping, String skipTextUnitsWithPattern, String skipAssetsWithPathPattern, String includeTextUnitsWithPattern, List<String> options, Repository repository, @ParentTask PollableTask currentTask) {
         thirdPartyTMS.pushTranslations(repository, thirdPartyProjectId, pluralSeparator,
                 parseLocaleMapping(localeMapping),
-                skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
+                skipTextUnitsWithPattern, skipAssetsWithPathPattern, includeTextUnitsWithPattern, options);
     }
 
     @Pollable(message = "Pull translations from third party service.")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJob.java
@@ -35,6 +35,7 @@ public class ThirdPartySyncJob extends QuartzPollableJob<ThirdPartySyncJobInput,
                 input.getLocaleMapping(),
                 input.getSkipTextUnitsWithPattern(),
                 input.getSkipAssetsWithPathPattern(),
+                input.getIncludeTextUnitsWithPattern(),
                 input.getOptions(),
                 getCurrentPollableTask());
         return null;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJobInput.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartySyncJobInput.java
@@ -17,6 +17,7 @@ public class ThirdPartySyncJobInput {
     String localeMapping;
     String skipTextUnitsWithPattern;
     String skipAssetsWithPathPattern;
+    String includeTextUnitsWithPattern;
     List<String> options;
 
     public Long getRepositoryId() {
@@ -73,6 +74,14 @@ public class ThirdPartySyncJobInput {
 
     public void setSkipAssetsWithPathPattern(String skipAssetsWithPathPattern) {
         this.skipAssetsWithPathPattern = skipAssetsWithPathPattern;
+    }
+
+    public String getIncludeTextUnitsWithPattern() {
+        return includeTextUnitsWithPattern;
+    }
+
+    public void setIncludeTextUnitsWithPattern(String includeTextUnitsWithPattern) {
+        this.includeTextUnitsWithPattern = includeTextUnitsWithPattern;
     }
 
     public List<String> getOptions() {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
@@ -71,5 +71,6 @@ interface ThirdPartyTMS {
                           Map<String, String> localeMapping,
                           String skipTextUnitsWithPattern,
                           String skipAssetsWithPathPattern,
+                          String includeTextUnitsWithPattern,
                           List<String> optionList);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
@@ -87,6 +87,7 @@ public class ThirdPartyTMSInMemory implements ThirdPartyTMS {
                                  Map<String, String> localeMapping,
                                  String skipTextUnitsWithPattern,
                                  String skipAssetsWithPathPattern,
+                                 String includeTextUnitsWithPattern,
                                  List<String> optionList) {
 
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJson.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJson.java
@@ -159,6 +159,7 @@ public class ThirdPartyTMSSmartlingWithJson {
                                  Map<String, String> localeMapping,
                                  String skipTextUnitsWithPattern,
                                  String skipAssetsWithPathPattern,
+                                 String includeTextUnitsWithPattern,
                                  SmartlingOptions smartlingOptions) {
 
         logger.info("Push translation from repository: {} into project: {}", repository.getName(), projectId);
@@ -166,7 +167,7 @@ public class ThirdPartyTMSSmartlingWithJson {
         getRepositoryLocaleWithoutRootStream(repository)
                 .forEach(repositoryLocale -> {
                     long partitionCount = Spliterators.partitionStreamWithIndex(
-                            getTargetTextUnitIterator(repository, repositoryLocale.getLocale().getId(), skipTextUnitsWithPattern, skipAssetsWithPathPattern),
+                            getTargetTextUnitIterator(repository, repositoryLocale.getLocale().getId(), skipTextUnitsWithPattern, skipAssetsWithPathPattern, includeTextUnitsWithPattern),
                             batchSize,
                             (textUnitDTOS, index) -> {
                                 String fileName = getSourceFileName(repository.getName(), index);
@@ -216,7 +217,8 @@ public class ThirdPartyTMSSmartlingWithJson {
             Repository repository,
             Long localeId,
             String skipTextUnitsWithPattern,
-            String skipAssetsWithPathPattern) {
+            String skipAssetsWithPathPattern,
+            String includeTextUnitsWithPattern) {
 
         PageFetcherOffsetAndLimitSplitIterator<TextUnitDTO> textUnitDTOPageFetcherOffsetAndLimitSplitIterator = new PageFetcherOffsetAndLimitSplitIterator<>(
                 (offset, limit) -> {
@@ -228,6 +230,7 @@ public class ThirdPartyTMSSmartlingWithJson {
                     parameters.setUsedFilter(UsedFilter.USED);
                     parameters.setSkipTextUnitWithPattern(skipTextUnitsWithPattern);
                     parameters.setSkipAssetPathWithPattern(skipAssetsWithPathPattern);
+                    parameters.setIncludeTextUnitsWithPattern(includeTextUnitsWithPattern);
                     parameters.setOffset(offset);
                     parameters.setLimit(limit);
                     parameters.setPluralFormsFiltered(true);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcher.java
@@ -290,6 +290,10 @@ public class TextUnitSearcher {
             conjunction.add(new NativeNotILikeExp("tu.name", searchParameters.getSkipTextUnitWithPattern()));
         }
 
+        if (searchParameters.getIncludeTextUnitsWithPattern() != null) {
+            conjunction.add(new NativeILikeExp("tu.name", searchParameters.getIncludeTextUnitsWithPattern()));
+        }
+
         if (searchParameters.getSkipAssetPathWithPattern() != null) {
             conjunction.add(new NativeNotILikeExp("a.path", searchParameters.getSkipAssetPathWithPattern()));
         }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/search/TextUnitSearcherParameters.java
@@ -46,6 +46,7 @@ public class TextUnitSearcherParameters {
     DateTime tmTextUnitCreatedAfter;
     Long branchId;
     String skipTextUnitWithPattern;
+    String includeTextUnitsWithPattern;
     String skipAssetPathWithPattern;
 
     public String getName() {
@@ -290,6 +291,14 @@ public class TextUnitSearcherParameters {
 
     public void setSkipTextUnitWithPattern(String skipTextUnitWithPattern) {
         this.skipTextUnitWithPattern = skipTextUnitWithPattern;
+    }
+
+    public String getIncludeTextUnitsWithPattern() {
+        return includeTextUnitsWithPattern;
+    }
+
+    public void setIncludeTextUnitsWithPattern(String includeTextUnitsWithPattern) {
+        this.includeTextUnitsWithPattern = includeTextUnitsWithPattern;
     }
 
     public String getSkipAssetPathWithPattern() {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyServiceTest.java
@@ -475,6 +475,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         thirdPartySync.setLocaleMapping(localeMapping);
         thirdPartySync.setSkipTextUnitsWithPattern("text_unit_pattern");
         thirdPartySync.setSkipAssetsWithPathPattern("asset_path_pattern");
+        thirdPartySync.setIncludeTextUnitsWithPattern("include_text_unit_pattern");
         thirdPartySync.setOptions(Arrays.asList("option1=value1", "option2=value2"));
         ArgumentCaptor<Repository> repoCaptor = ArgumentCaptor.forClass(Repository.class);
 
@@ -487,6 +488,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
                 localeMappingArgumentCaptor.capture(),
                 eq("text_unit_pattern"),
                 eq("asset_path_pattern"),
+                eq("include_text_unit_pattern"),
                 optionsArgumentCaptor.capture());
 
         assertThat(repoCaptor.getValue().getId()).isEqualTo(repository.getId());
@@ -507,6 +509,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
         thirdPartySync.setLocaleMapping(localeMapping);
         thirdPartySync.setSkipTextUnitsWithPattern("text_unit_pattern");
         thirdPartySync.setSkipAssetsWithPathPattern("asset_path_pattern");
+        thirdPartySync.setIncludeTextUnitsWithPattern("include_text_unit_pattern");
         thirdPartySync.setOptions(Arrays.asList("option1=value1", "option2=value2"));
         ArgumentCaptor<Repository> repoCaptor = ArgumentCaptor.forClass(Repository.class);
 
@@ -519,6 +522,7 @@ public class ThirdPartyServiceTest extends ServiceTestBase {
                 localeMappingArgumentCaptor.capture(),
                 eq("text_unit_pattern"),
                 eq("asset_path_pattern"),
+                eq("include_text_unit_pattern"),
                 optionsArgumentCaptor.capture());
 
         assertThat(repoCaptor.getValue().getId()).isEqualTo(repository.getId());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -854,7 +854,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
-        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, ImmutableList.of());
+        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, null, ImmutableList.of());
         result = resultProcessor.pushTranslationFiles;
 
         assertThat(result).hasSize(2);
@@ -914,7 +914,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
-        Exception exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, ImmutableList.of()));
+        Exception exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, null, ImmutableList.of()));
         assertTrue(exception.getMessage().contains("Error uploading localized file to Smartling"));
 
         verify(smartlingClient, times(11)).uploadLocalizedFile(
@@ -960,7 +960,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
-        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, ImmutableList.of());
+        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, null, ImmutableList.of());
         result = resultProcessor.pushTranslationFiles;
 
         assertThat(result).hasSize(2);
@@ -1022,7 +1022,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
         tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(),
-                null, null, ImmutableList.of("dry-run=true"));
+                null, null, null, ImmutableList.of("dry-run=true"));
         result = resultProcessor.pushTranslationFiles;
 
         assertThat(result).hasSize(2);
@@ -1098,7 +1098,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
-        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, ImmutableList.of());
+        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, null, ImmutableList.of());
         result = resultProcessor.pushTranslationFiles;
 
         assertThat(result).hasSize(4);
@@ -1200,7 +1200,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
         tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(),
-                null, null, ImmutableList.of("smartling-plural-fix=" + frCA.getBcp47Tag()));
+                null, null, null, ImmutableList.of("smartling-plural-fix=" + frCA.getBcp47Tag()));
         result = resultProcessor.pushTranslationFiles;
 
         assertThat(result).hasSize(locales.size());
@@ -1289,7 +1289,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
 
         prepareAssetAndTextUnits(assetExtraction, asset, tm);
 
-        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, ImmutableList.of());
+        tmsSmartling.pushTranslations(repository, "projectId", pluralSep, ImmutableMap.of(), null, null, null, ImmutableList.of());
         result = resultProcessor.pushTranslationFiles;
 
         assertThat(result).hasSize((singularBatches + pluralBatches) * locales.size());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJsonTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingWithJsonTest.java
@@ -142,7 +142,7 @@ public class ThirdPartyTMSSmartlingWithJsonTest extends ServiceTestBase {
 
         waitForCondition("eventually we should be able to push translation", () -> {
             logger.debug("Pushing translation...");
-            thirdPartyTMSSmartlingWithJson.pushTranslations(repository, testConfig.projectId, null, ImmutableMap.of(), null, null, smartlingOptions);
+            thirdPartyTMSSmartlingWithJson.pushTranslations(repository, testConfig.projectId, null, ImmutableMap.of(), null, null, null, smartlingOptions);
             return true;
         }, 3, 1000);
 


### PR DESCRIPTION
Added new parameter to the thirdparty-sync command that allows an SQL LIKE pattern to be passed from the cli that will be used to filter the text units that are processed with the PUSH_TRANSLATION action.