### PR TITLE
Update PO plural rules used for Hebrew

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/POFilter.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/POFilter.java
@@ -254,6 +254,9 @@ public class POFilter extends net.sf.okapi.filters.po.POFilter {
                 } else if (zero != null) {
                     logger.debug("Other and few are not defined but one is, means it is for a language where few can be copied like Arabic");
                     other = createCopyOf(zero, "zero", "other");
+                } else if (two != null) {
+                    logger.debug("Other, few and zero are not defined but one is, copy from two.");
+                    other = createCopyOf(two, "two", "other");
                 }
             }
 

--- a/common/src/main/java/com/box/l10n/mojito/po/PoPluralRule.java
+++ b/common/src/main/java/com/box/l10n/mojito/po/PoPluralRule.java
@@ -69,6 +69,10 @@ public enum PoPluralRule {
             "nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;",
             PoFormToCLDRForm.THREE_FORMS_ONE_FEW_MANY,
             CldrFormsToCopyOnImport.FEW_TO_OTHER),
+    FOUR_FORMS_FRACTIONAL_DIGITS_OTHER(
+            "nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;",
+            PoFormToCLDRForm.FOUR_FORMS_ONE_TWO_MANY_OTHER,
+            CldrFormsToCopyOnImport.NONE), // diverges from https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Plural-forms.html to match CLDR
     SIX_FORMS(
             "nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;",
             PoFormToCLDRForm.SIX_FORMS,
@@ -97,6 +101,8 @@ public enum PoPluralRule {
         mappingForNonDefault.put("sk", PoPluralRule.THREE_FORMS_SPECIAL_FOR_1_2_3_4);
         mappingForNonDefault.put("pl", PoPluralRule.THREE_FORMS_SPECIAL_FOR_1_AND_ENDING_234);
         mappingForNonDefault.put("sl", PoPluralRule.THREE_FORMS_SPECIAL_ENDING_020310_AND_1199); // incompatible with CLDR?
+        mappingForNonDefault.put("he", PoPluralRule.FOUR_FORMS_FRACTIONAL_DIGITS_OTHER);
+        mappingForNonDefault.put("iw", PoPluralRule.FOUR_FORMS_FRACTIONAL_DIGITS_OTHER);
         mappingForNonDefault.put("ar", PoPluralRule.SIX_FORMS);
     }
     
@@ -190,6 +196,12 @@ public enum PoPluralRule {
                 "0", "one",
                 "1", "two",
                 "2", "few"
+        )),
+        FOUR_FORMS_ONE_TWO_MANY_OTHER(ImmutableBiMap.of(
+                "0", "one",
+                "1", "two",
+                "2", "many",
+                "3", "other"
         )),
         SIX_FORMS(ImmutableBiMap.<String, String>builder().
                 put("0", "zero").

--- a/common/src/test/java/com/box/l10n/mojito/po/PoPluralRuleTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/po/PoPluralRuleTest.java
@@ -122,6 +122,12 @@ public class PoPluralRuleTest {
         Assert.assertEquals(PoPluralRule.TWO_FORMS_SINGULAR_FOR_ONE, rulesForBcp47Tag);
     }
 
+    @Test
+    public void testHebrew() {
+        PoPluralRule rulesForBcp47Tag = PoPluralRule.fromBcp47Tag("he");
+        Assert.assertEquals(PoPluralRule.FOUR_FORMS_FRACTIONAL_DIGITS_OTHER, rulesForBcp47Tag);
+    }
+
     @Test(expected = NullPointerException.class)
     public void testNull() {
         PoPluralRule.fromBcp47Tag(null);


### PR DESCRIPTION
Updated POPluralRules so that plural forms for Hebrew match CLDR rules specified [here](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html)