### PR TITLE
Fix for handling absolute paths with no context in RecommendStringIdChecker

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
@@ -71,10 +71,10 @@ public class RecommendStringIdChecker extends AbstractCliChecker {
     private RecommendStringIdCheckResult generateRecommendation(AssetExtractorTextUnit textUnit, RecommendStringIdCheckResult recommendation) {
         List<String> possiblePrefixes = new ArrayList<>();
         String msgctxt = removeIgnoredLabelFromContext(textUnit.getName().contains(ID_SEPARATOR) ? textUnit.getName().split(ID_SEPARATOR)[1] : "");
-        String cwd = Paths.get(".").toAbsolutePath() + FileSystems.getDefault().getSeparator();
+        String cwd = Paths.get(".").toAbsolutePath().toString();
         for (String filePath : textUnit.getUsages()) {
             if (Paths.get(filePath).isAbsolute()) {
-                filePath = filePath.replace(cwd, "");
+                filePath = filePath.replace(cwd.replace(FileSystems.getDefault().getSeparator() + ".", FileSystems.getDefault().getSeparator()), "");
             }
             Path file = Paths.get(removeLineNumberFromUsage(filePath));
             String fileName = file.getFileName().toString();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdCheckerTest.java
@@ -118,7 +118,7 @@ public class RecommendStringIdCheckerTest {
         AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
         assetExtractorTextUnit.setName("A source string with no errors. --- someDir.someSubDir.someStringId");
         assetExtractorTextUnit.setSource("A source string with no errors.");
-        assetExtractorTextUnit.setUsages(Sets.newHashSet(cwd + FileSystems.getDefault().getSeparator() + "someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        assetExtractorTextUnit.setUsages(Sets.newHashSet(cwd.replace(".", "") + "someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
         addedTUs.add(assetExtractorTextUnit);
         List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
         AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
@@ -128,6 +128,25 @@ public class RecommendStringIdCheckerTest {
         CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
         Assert.assertTrue(result.isSuccessful());
         Assert.assertTrue(result.getNotificationText().isEmpty());
+    }
+
+    @Test
+    public void testAbsolutePathAsUsageWithNoContext() {
+        String cwd = Paths.get(".").toAbsolutePath().toString();
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("A source string with no errors. ");
+        assetExtractorTextUnit.setSource("A source string with no errors.");
+        assetExtractorTextUnit.setUsages(Sets.newHashSet(cwd.replace(".", "") + "someDir/someSubDir/anotherLevel/evenDeeper/someSourceFile.java:1497"));
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = recommendStringIdChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertTrue(result.getNotificationText().contains("someDir.someSubDir."));
     }
 
     @Test


### PR DESCRIPTION
Fixes the issue found in handling of absolute paths in the RecommendStringIdChecker where the root directory names are included in the id.