### PR TITLE
Added Smartling glossary sync functionality

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/ThirdPartySyncAction.java
@@ -4,6 +4,7 @@ public enum ThirdPartySyncAction {
     PUSH,
     PUSH_TRANSLATION,
     PULL,
+    PULL_SOURCE,
     MAP_TEXTUNIT,
     PUSH_SCREENSHOT
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySyncAction.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/thirdparty/ThirdPartySyncAction.java
@@ -4,6 +4,7 @@ public enum ThirdPartySyncAction {
     PUSH,
     PUSH_TRANSLATION,
     PULL,
+    PULL_SOURCE,
     MAP_TEXTUNIT,
     PUSH_SCREENSHOT
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyService.java
@@ -141,6 +141,9 @@ public class ThirdPartyService {
         if (actions.contains(ThirdPartySyncAction.PUSH_TRANSLATION)) {
             pushTranslations(thirdPartyProjectId, pluralSeparator, localeMapping, skipTextUnitsWithPattern, skipAssetsWithPathPattern, includeTextUnitsWithPattern, options, repository, currentTask);
         }
+        if (actions.contains(ThirdPartySyncAction.PULL_SOURCE)) {
+            pullSource(thirdPartyProjectId, options, repository, localeMapping, currentTask);
+        }
         if (actions.contains(ThirdPartySyncAction.PULL)) {
             pull(thirdPartyProjectId, pluralSeparator, localeMapping, skipTextUnitsWithPattern, skipAssetsWithPathPattern, options, repository, currentTask);
         }
@@ -170,6 +173,11 @@ public class ThirdPartyService {
         thirdPartyTMS.pull(repository, thirdPartyProjectId, pluralSeparator,
                 parseLocaleMapping(localeMapping),
                 skipTextUnitsWithPattern, skipAssetsWithPathPattern, options);
+    }
+
+    @Pollable(message = "Pull source text units from third party service.")
+    private void pullSource(String thirdPartyProjectId, List<String> options, Repository repository, String localeMapping, @ParentTask PollableTask currentTask) {
+        thirdPartyTMS.pullSource(repository, thirdPartyProjectId, options, parseLocaleMapping(localeMapping));
     }
 
     @Pollable(message = "Map Mojito and third party text units.")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMS.java
@@ -73,4 +73,6 @@ interface ThirdPartyTMS {
                           String skipAssetsWithPathPattern,
                           String includeTextUnitsWithPattern,
                           List<String> optionList);
+
+    void pullSource(Repository repository, String projectId, List<String> optionList, Map<String, String> localeMapping);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSGlossarySyncException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSGlossarySyncException.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.service.thirdparty;
+
+public class ThirdPartyTMSGlossarySyncException extends RuntimeException {
+
+    public ThirdPartyTMSGlossarySyncException(String message) {
+        super(message);
+    }
+
+    public ThirdPartyTMSGlossarySyncException(String message, Throwable t) {
+        super(message, t);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSInMemory.java
@@ -91,4 +91,9 @@ public class ThirdPartyTMSInMemory implements ThirdPartyTMS {
                                  List<String> optionList) {
 
     }
+
+    @Override
+    public void pullSource(Repository repository, String projectId, List<String> optionList, Map<String, String> localeMapping) {
+
+    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossary.java
@@ -1,0 +1,300 @@
+package com.box.l10n.mojito.service.thirdparty;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.service.asset.AssetRepository;
+import com.box.l10n.mojito.service.asset.VirtualAsset;
+import com.box.l10n.mojito.service.asset.VirtualAssetBadRequestException;
+import com.box.l10n.mojito.service.asset.VirtualAssetRequiredException;
+import com.box.l10n.mojito.service.asset.VirtualAssetService;
+import com.box.l10n.mojito.service.asset.VirtualAssetTextUnit;
+import com.box.l10n.mojito.service.asset.VirutalAssetMissingTextUnitException;
+import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
+import com.box.l10n.mojito.service.thirdparty.smartling.SmartlingTBXReader;
+import com.box.l10n.mojito.smartling.SmartlingClient;
+import com.box.l10n.mojito.smartling.SmartlingClientException;
+import com.box.l10n.mojito.smartling.response.GlossarySourceTerm;
+import com.box.l10n.mojito.smartling.response.GlossaryTargetTerm;
+import com.box.l10n.mojito.smartling.response.GlossaryTermTranslation;
+import com.google.common.base.Strings;
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.lib.terminology.ConceptEntry;
+import net.sf.okapi.lib.terminology.LangEntry;
+import net.sf.okapi.lib.terminology.TermEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.box.l10n.mojito.service.thirdparty.ThirdPartyTMSSmartling.getRetryConfiguration;
+import static com.box.l10n.mojito.service.thirdparty.ThirdPartyTMSSmartling.getSmartlingLocale;
+
+/**
+ * Syncs Smartling glossary with a Mojito repository.
+ * <p>
+ * {@link ThirdPartyTMSSmartling} will redirect request to this class based on an option
+ */
+@ConditionalOnProperty(value = "l10n.ThirdPartyTMS.impl", havingValue = "ThirdPartyTMSSmartling")
+@Component
+public class ThirdPartyTMSSmartlingGlossary {
+
+    static Logger logger = LoggerFactory.getLogger(ThirdPartyTMSSmartlingGlossary.class);
+
+    @Autowired
+    VirtualAssetService virtualAssetService;
+
+    @Autowired
+    SmartlingClient smartlingClient;
+
+    @Autowired
+    AssetRepository assetRepository;
+
+    @Autowired
+    AssetTextUnitRepository assetTextUnitRepository;
+
+    @Value("${l10n.smartling.accountId}")
+    String accountId;
+
+    public void pullSourceTextUnits(Repository repository, String glossaryUID, Map<String, String> localeMapping) {
+        String glossaryName = getGlossaryName(glossaryUID);
+        String sourceLocale = getSmartlingLocale(localeMapping, getRepositorySourceLocale(repository));
+        VirtualAsset virtualAsset = getVirtualAsset(repository, glossaryName);
+        List<VirtualAssetTextUnit> textUnits = getSourceVirtualAssetTextUnits(glossaryUID, sourceLocale);
+        deleteExistingTextUnits(virtualAsset);
+        importSourceTextUnits(virtualAsset, textUnits);
+    }
+
+    public void pull(Repository repository, String glossaryUID, Map<String, String> localeMapping) {
+        String glossaryName = getGlossaryName(glossaryUID);
+        VirtualAsset virtualAsset = getVirtualAsset(repository, glossaryName);
+        String sourceLocale = getSmartlingLocale(localeMapping, getRepositorySourceLocale(repository));
+        repository.getRepositoryLocales().stream()
+                .filter(repositoryLocale -> repositoryLocale.getParentLocale() != null)
+                .forEach(repositoryLocale -> {
+                    String smartlingLocale = getSmartlingLocale(localeMapping, repositoryLocale.getLocale().getBcp47Tag());
+                    List<VirtualAssetTextUnit> translatedTextUnits = getTranslatedTextUnits(glossaryUID, smartlingLocale, sourceLocale);
+                    importLocalizedTextUnits(virtualAsset, repositoryLocale, translatedTextUnits);
+                });
+    }
+
+    public List<ThirdPartyTextUnit> getThirdPartyTextUnits(String glossaryId) {
+        String glossaryName = getGlossaryName(glossaryId);
+        String glossaryFile = downloadGlossaryFile(glossaryId);
+        SmartlingTBXReader tbxReader = new SmartlingTBXReader();
+        tbxReader.open(new ByteArrayInputStream(glossaryFile.getBytes(StandardCharsets.UTF_8)));
+        List<ThirdPartyTextUnit> thirdPartyTextUnits = new ArrayList<>();
+        while(tbxReader.hasNext()) {
+            thirdPartyTextUnits.add(mapConceptEntryToThirdPartyTextUnit(glossaryName, tbxReader.next()));
+        }
+
+        return thirdPartyTextUnits;
+    }
+
+    private void deleteExistingTextUnits(VirtualAsset virtualAsset) {
+        Asset asset = assetRepository.findById(virtualAsset.getId()).orElse(null);
+        if (asset != null) {
+            logger.debug("Deleting text units found for glossary asset: {}", asset.getPath());
+            List<AssetTextUnit> assetTextUnits = assetTextUnitRepository.findByAssetExtractionId(asset.getLastSuccessfulAssetExtraction().getId());
+
+            for (AssetTextUnit assetTextUnit : assetTextUnits) {
+                logger.debug("Deleting glossary asset text unit with name: {}, content: {}, perform delete", assetTextUnit.getName(), assetTextUnit.getContent());
+                virtualAssetService.deleteTextUnit(asset.getId(), assetTextUnit.getName());
+            }
+        }
+    }
+
+    private String downloadGlossaryFile(String glossaryId) {
+        return Mono.fromCallable(() -> smartlingClient.downloadGlossaryFile(accountId, glossaryId)).retryWhen(getRetryConfiguration()
+                .doBeforeRetry(e -> logger.info(String.format("Retrying after failure to download glossary file for glossary id: %s", glossaryId), e.failure())))
+                .doOnError(e -> {
+                    String msg = String.format("Error downloading glossary file from Smartling for glossary id: %s", glossaryId);
+                    logger.error(msg, e);
+                    throw new SmartlingClientException(msg, e);
+                }).blockOptional()
+                .orElseThrow(() -> new SmartlingClientException(String.format("Error downloading glossary file from Smartling for glossary id: %s, optional is empty", glossaryId)));
+    }
+
+    private String getGlossaryName(String glossaryUID) {
+        return Mono.fromCallable(() -> smartlingClient.getGlossaryDetails(accountId, glossaryUID).getName())
+                .retryWhen(getRetryConfiguration()
+                        .doBeforeRetry(e -> logger.info(String.format("Retrying after failure to retrieve glossary details from Smartling for glossary id: %s", glossaryUID), e.failure())))
+                .doOnError(e -> {
+                    String msg = String.format("Error retrieving glossary details from Smartling for glossary id: %s", glossaryUID);
+                    logger.info(msg, e);
+                    throw new SmartlingClientException(msg, e);
+                }).blockOptional()
+                .orElseThrow(() -> new SmartlingClientException(String.format("Error retrieving glossary details from Smartling for glossary id: %s, optional is empty", glossaryUID)));
+    }
+
+    private String getRepositorySourceLocale(Repository repository) {
+        return repository.getRepositoryLocales().stream()
+                .filter(repositoryLocale -> repositoryLocale.getParentLocale() == null)
+                .map(repositoryLocale -> repositoryLocale.getLocale().getBcp47Tag())
+                .findFirst()
+                .orElseThrow(() -> new ThirdPartyTMSGlossarySyncException("Unable to find source locale for repository: " + repository.getName()));
+    }
+
+    private VirtualAsset getVirtualAsset(Repository repository, String glossaryName) {
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setRepositoryId(repository.getId());
+        virtualAsset.setPath(glossaryName);
+        virtualAsset.setDeleted(false);
+        try {
+            virtualAsset = virtualAssetService.createOrUpdateVirtualAsset(virtualAsset);
+        } catch (VirtualAssetBadRequestException e) {
+            throw new ThirdPartyTMSGlossarySyncException(e.getMessage(), e);
+        }
+        return virtualAsset;
+    }
+
+    private void importSourceTextUnits(VirtualAsset virtualAsset, List<VirtualAssetTextUnit> textUnits) {
+        try {
+            virtualAssetService.addTextUnits(virtualAsset.getId(), textUnits);
+        } catch (VirtualAssetRequiredException e) {
+            logger.error("Error importing source text units to virtual asset: " + e.getMessage(), e);
+            throw new ThirdPartyTMSGlossarySyncException("Error importing source text units to virtual asset: " + e.getMessage());
+        }
+    }
+
+    private void importLocalizedTextUnits(VirtualAsset virtualAsset, RepositoryLocale repositoryLocale, List<VirtualAssetTextUnit> translatedTextUnits) {
+        try {
+            virtualAssetService.importLocalizedTextUnits(virtualAsset.getId(), repositoryLocale.getLocale().getId(), translatedTextUnits);
+        } catch (VirtualAssetRequiredException | VirutalAssetMissingTextUnitException e) {
+            logger.error("Error importing localized text units to virtual asset: " + e.getMessage(), e);
+            throw new ThirdPartyTMSGlossarySyncException("Error importing localized text units to virtual asset: " + e.getMessage(), e);
+        }
+    }
+
+    private VirtualAssetTextUnit getTranslatedVirtualAssetTextUnit(GlossaryTargetTerm glossaryTermTranslation) {
+        VirtualAssetTextUnit virtualAssetTextUnit = mapGlossaryTermToVirtualAssetTextUnit(glossaryTermTranslation);
+        virtualAssetTextUnit.setContent(glossaryTermTranslation.getGlossaryTermTranslation().getTranslatedTerm());
+        return virtualAssetTextUnit;
+    }
+
+    private List<VirtualAssetTextUnit> getSourceVirtualAssetTextUnits(String glossaryUID, String sourceLocale) {
+        return getGlossarySourceTextUnits(glossaryUID, sourceLocale);
+    }
+
+    private List<VirtualAssetTextUnit> getGlossarySourceTextUnits(String glossaryUID, String locale) {
+        String glossaryFile = downloadSourceGlossaryFile(glossaryUID, locale);
+        SmartlingTBXReader tbxReader = new SmartlingTBXReader();
+        tbxReader.open(new ByteArrayInputStream(glossaryFile.getBytes(StandardCharsets.UTF_8)));
+        List<GlossarySourceTerm> glossarySourceTerms = new ArrayList<>();
+        while(tbxReader.hasNext()) {
+            glossarySourceTerms.add(mapConceptEntryToGlossarySourceTerm(locale, tbxReader.next()));
+        }
+        return glossarySourceTerms.stream()
+                .filter(glossarySourceTerm -> !Strings.isNullOrEmpty(glossarySourceTerm.getTermText()))
+                .map(this::mapGlossaryTermToVirtualAssetTextUnit).collect(Collectors.toList());
+    }
+
+    private String downloadSourceGlossaryFile(String glossaryUID, String locale) {
+        return Mono.fromCallable(() -> smartlingClient.downloadSourceGlossaryFile(accountId, glossaryUID, locale)).retryWhen(getRetryConfiguration()
+                .doBeforeRetry(e -> logger.info(String.format("Retrying after failure to download source file for glossary id: %s", glossaryUID), e.failure())))
+                .doOnError(e -> {
+                    String msg = String.format("Error downloading source file for glossary id: %s", glossaryUID);
+                    logger.error(msg, e);
+                    throw new SmartlingClientException(msg, e);
+                }).blockOptional()
+                .orElseThrow(() -> new SmartlingClientException(String.format("Error downloading source file from Smartling for glossary id: %s, optional is not present", glossaryUID)));
+    }
+
+    private ThirdPartyTextUnit mapConceptEntryToThirdPartyTextUnit(String glossaryName, ConceptEntry conceptEntry) {
+        ThirdPartyTextUnit thirdPartyTextUnit = new ThirdPartyTextUnit();
+        thirdPartyTextUnit.setId(conceptEntry.getId());
+        thirdPartyTextUnit.setName(conceptEntry.getId());
+        thirdPartyTextUnit.setAssetPath(glossaryName);
+        return thirdPartyTextUnit;
+    }
+
+    private GlossarySourceTerm mapConceptEntryToGlossarySourceTerm(String locale, ConceptEntry conceptEntry) {
+        GlossarySourceTerm glossarySourceTerm = new GlossarySourceTerm();
+        glossarySourceTerm.setTermUid(conceptEntry.getId());
+        glossarySourceTerm.setDefinition(conceptEntry.getProperty("definition") != null ? conceptEntry.getProperty("definition").getValue() : "");
+        glossarySourceTerm.setPartOfSpeechCode(conceptEntry.getProperty("partOfSpeech") != null ? conceptEntry.getProperty("partOfSpeech").getValue() : "");
+        glossarySourceTerm.setTermText(conceptEntry.getEntries(LocaleId.fromString(locale)) != null ? conceptEntry.getEntries(LocaleId.fromString(locale)).getTerm(0).getText(): null);
+        return glossarySourceTerm;
+    }
+
+    private List<VirtualAssetTextUnit> getTranslatedTextUnits(String glossaryUID, String locale, String sourceLocale) {
+        String glossaryFile = downloadTranslatedGlossaryFile(glossaryUID, locale, sourceLocale);
+        SmartlingTBXReader tbxReader = new SmartlingTBXReader();
+        tbxReader.open(new ByteArrayInputStream(glossaryFile.getBytes(StandardCharsets.UTF_8)));
+        List<GlossaryTargetTerm> glossaryTargetTerms = new ArrayList<>();
+        while(tbxReader.hasNext()) {
+            glossaryTargetTerms.add(mapConceptEntryToGlossaryTargetTerm(locale, sourceLocale, tbxReader.next()));
+        }
+        return glossaryTargetTerms.stream()
+                .filter(glossaryTargetTerm -> !Strings.isNullOrEmpty(glossaryTargetTerm.getTermText())
+                        && glossaryTargetTerm.getGlossaryTermTranslation() != null)
+                .map(this::getTranslatedVirtualAssetTextUnit).collect(Collectors.toList());
+    }
+
+    private String downloadTranslatedGlossaryFile(String glossaryUID, String locale, String sourceLocale) {
+        return Mono.fromCallable(() -> smartlingClient.downloadGlossaryFileWithTranslations(accountId, glossaryUID, locale, sourceLocale))
+                .retryWhen(getRetryConfiguration().doBeforeRetry(e -> logger.info(String.format("Retrying after failure to download translated file from Smartling for glossary id: %s", glossaryUID), e.failure())))
+                .doOnError(e -> {
+                    String msg = String.format("Error downloading translated glossary file from Smartling for glossary id: %s", glossaryUID);
+                    logger.error(msg, e);
+                    throw new SmartlingClientException(msg, e);
+                }).blockOptional()
+                .orElseThrow(() -> new SmartlingClientException(String.format("Error downloading translated glossary file from Smartling for glossary id: %s, optional is not present", glossaryUID)));
+    }
+
+    private GlossaryTargetTerm mapConceptEntryToGlossaryTargetTerm(String locale, String sourceLocale, ConceptEntry conceptEntry) {
+        GlossaryTargetTerm glossaryTargetTerm = new GlossaryTargetTerm();
+        glossaryTargetTerm.setTermUid(conceptEntry.getId());
+        glossaryTargetTerm.setDefinition(conceptEntry.getProperty("definition") != null ? conceptEntry.getProperty("definition").getValue() : "");
+        glossaryTargetTerm.setPartOfSpeechCode(conceptEntry.getProperty("partOfSpeech") != null ? conceptEntry.getProperty("partOfSpeech").getValue() : "");
+        LangEntry sourceEntry = conceptEntry.getEntries(LocaleId.fromString(sourceLocale));
+        glossaryTargetTerm.setTermText(sourceEntry != null ? sourceEntry.getTerm(0).getText() : null);
+
+        LangEntry targetEntry = conceptEntry.getEntries(LocaleId.fromString(locale));
+        if (targetEntry != null) {
+            GlossaryTermTranslation glossaryTermTranslation = new GlossaryTermTranslation();
+            TermEntry termEntry = targetEntry.getTerm(0);
+            glossaryTermTranslation.setTranslatedTerm(termEntry.getText());
+            glossaryTargetTerm.setGlossaryTermTranslation(glossaryTermTranslation);
+        }
+
+        return glossaryTargetTerm;
+    }
+
+    private VirtualAssetTextUnit mapGlossaryTermToVirtualAssetTextUnit(GlossarySourceTerm glossarySourceTerm) {
+        VirtualAssetTextUnit virtualAssetTextUnit = new VirtualAssetTextUnit();
+        virtualAssetTextUnit.setContent(glossarySourceTerm.getTermText());
+        virtualAssetTextUnit.setName(getTextUnitName(glossarySourceTerm));
+        virtualAssetTextUnit.setComment(getTextUnitComment(glossarySourceTerm));
+        return virtualAssetTextUnit;
+    }
+
+    private String getTextUnitComment(GlossarySourceTerm glossarySourceTerm) {
+        String comment = glossarySourceTerm.getDefinition();
+        if (isPartOfSpeechAvailable(glossarySourceTerm)) {
+            comment = glossarySourceTerm.getDefinition() + " --- POS: " + glossarySourceTerm.getPartOfSpeechCode();
+        }
+
+        return comment;
+    }
+
+    private String getTextUnitName(GlossarySourceTerm glossarySourceTerm) {
+        return glossarySourceTerm.getTermUid();
+    }
+
+    private boolean isPartOfSpeechAvailable(GlossarySourceTerm glossarySourceTerm) {
+        return !Strings.isNullOrEmpty(glossarySourceTerm.getPartOfSpeechCode())
+                && !glossarySourceTerm.getPartOfSpeechCode().equalsIgnoreCase("UNSPECIFIED");
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingOptions.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingOptions.java
@@ -18,6 +18,7 @@ public final class SmartlingOptions {
     public static final String DRY_RUN = "dry-run";
     public static final String REQUEST_ID = "request-id";
     public static final String JSON_SYNC = "json-sync";
+    public static final String GLOSSARY_SYNC = "glossary-sync";
 
     private final Set<String> pluralFixForLocales;
     private final String placeholderFormat;
@@ -25,19 +26,22 @@ public final class SmartlingOptions {
     private final boolean dryRun;
     private final String requestId;
     private final boolean isJsonSync;
+    private final boolean isGlossarySync;
 
     public SmartlingOptions(Set<String> pluralFixForLocales,
                             String placeholderFormat,
                             String customPlaceholderFormat,
                             boolean dryRun,
                             String requestId,
-                            boolean isJsonSync) {
+                            boolean isJsonSync,
+                            boolean isGlossarySync) {
         this.pluralFixForLocales = pluralFixForLocales;
         this.placeholderFormat = placeholderFormat;
         this.customPlaceholderFormat = customPlaceholderFormat;
         this.dryRun = dryRun;
         this.requestId = requestId;
         this.isJsonSync = isJsonSync;
+        this.isGlossarySync = isGlossarySync;
     }
 
     public static SmartlingOptions parseList(List<String> options) {
@@ -53,6 +57,7 @@ public final class SmartlingOptions {
         String customPlaceholderFormat = map.get(PLACEHOLDER_FORMAT_CUSTOM);
         String requestId = map.get(REQUEST_ID);
         String isJsonSync = map.get(JSON_SYNC);
+        String isGlossarySync = map.get(GLOSSARY_SYNC);
 
         return new SmartlingOptions(
                 pluralFixStr.isEmpty() ? Collections.emptySet() : ImmutableSet.copyOf(pluralFixStr.split(",")),
@@ -60,7 +65,8 @@ public final class SmartlingOptions {
                 customPlaceholderFormat,
                 parseBoolean(dryRunStr),
                 requestId,
-                parseBoolean(isJsonSync));
+                parseBoolean(isJsonSync),
+                parseBoolean(isGlossarySync));
     }
 
     public Set<String> getPluralFixForLocales() {
@@ -85,5 +91,9 @@ public final class SmartlingOptions {
 
     public boolean isJsonSync() {
         return isJsonSync;
+    }
+
+    public boolean isGlossarySync() {
+        return isGlossarySync;
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingTBXReader.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/thirdparty/smartling/SmartlingTBXReader.java
@@ -1,0 +1,268 @@
+package com.box.l10n.mojito.service.thirdparty.smartling;
+
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.Util;
+import net.sf.okapi.common.exceptions.OkapiIOException;
+import net.sf.okapi.common.resource.Property;
+import net.sf.okapi.lib.terminology.ConceptEntry;
+import net.sf.okapi.lib.terminology.LangEntry;
+import net.sf.okapi.lib.terminology.TermEntry;
+
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+/**
+ *  Custom implementation of {@link net.sf.okapi.lib.terminology.tbx.TBXReader} that stores the 'definition' &
+ * 'partOfSpeechCode' values from Smartling TBX file as properties on the {@link ConceptEntry} if they exist.
+ */
+public class SmartlingTBXReader {
+
+    private ConceptEntry nextEntry;
+    private ConceptEntry cent;
+    private LangEntry lent;
+    private XMLStreamReader reader;
+
+    public void open (File file) {
+        try {
+            open(new FileInputStream(file));
+        }
+        catch ( Throwable e) {
+            throw new OkapiIOException("Error opening the URI.\n" + e.getLocalizedMessage());
+        }
+    }
+
+    public void open (InputStream input) {
+        try {
+            close();
+            XMLInputFactory fact = XMLInputFactory.newInstance();
+            fact.setProperty(XMLInputFactory.IS_COALESCING, true);
+
+            // security concern. Turn off DTD processing
+            // https://www.owasp.org/index.php/XML_External_Entity_%28XXE%29_Processing
+            fact.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+
+            reader = fact.createXMLStreamReader(input);
+
+            // Read the first entry
+            readNext();
+        }
+        catch ( Throwable e) {
+            throw new OkapiIOException("Error opening the URI.\n" + e.getLocalizedMessage());
+        }
+    }
+
+    public void close () {
+        nextEntry = null;
+        try {
+            if ( reader != null ) {
+                reader.close();
+                reader = null;
+            }
+        }
+        catch ( XMLStreamException e) {
+            throw new OkapiIOException(e);
+        }
+    }
+
+    public boolean hasNext () {
+        return (nextEntry != null);
+    }
+
+    public ConceptEntry next () {
+        ConceptEntry currentEntry = nextEntry; // Next entry becomes the current one
+        readNext(); // Parse the new next entry
+        return currentEntry; // Send the current entry
+    }
+
+    private void readNext () {
+        try {
+            nextEntry = cent = null;
+            while ( reader.hasNext() ) {
+                int eventType = reader.next();
+                switch ( eventType ) {
+                    case XMLStreamConstants.START_ELEMENT:
+                        String name = reader.getLocalName();
+                        if ( "termEntry".equals(name) ) {
+                            processTermEntry();
+                            return; // Done for this entry
+                        }
+                        break;
+                }
+            }
+        }
+        catch ( Throwable e ) {
+            throw new OkapiIOException("Error when reading." + e.getLocalizedMessage(), e);
+        }
+    }
+
+    private void processTermEntry () throws XMLStreamException {
+        cent = new ConceptEntry();
+        cent.setId(reader.getAttributeValue(null, "id"));
+        String name;
+        while ( reader.hasNext() ) {
+            int eventType = reader.next();
+            switch ( eventType ) {
+                case XMLStreamConstants.START_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "langSet".equals(name) ) {
+                        processLangSet();
+                    }
+                    if ( "descrip".equals(name)) {
+                        processDescripEntry();
+                    }
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "termEntry".equals(name) ) {
+                        nextEntry = cent; // No error, we can set the real entry
+                        return; // This termEntry is done
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void processDescripEntry () throws XMLStreamException {
+        String propertyName = reader.getAttributeValue(null,"type");
+        if (Util.isEmpty(propertyName)) {
+            throw new OkapiIOException("Missing or empty type attribute.");
+        }
+
+        switch (propertyName) {
+            case "definition":
+                Property definition = new Property("definition", reader.getElementText(), true);
+                cent.setProperty(definition);
+                break;
+            case "partOfSpeech":
+                Property partOfSpeech = new Property("partOfSpeech", reader.getElementText(), true);
+                cent.setProperty(partOfSpeech);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void processLangSet () throws XMLStreamException {
+        // Get the language information
+        String lang = reader.getAttributeValue(XMLConstants.XML_NS_URI, "lang");
+        if ( Util.isEmpty(lang) ) {
+            throw new OkapiIOException("Missing or empty xml:lang attribute.");
+        }
+        // Create the new language entry
+        lent = new LangEntry(LocaleId.fromString(lang));
+
+        String name;
+        while ( reader.hasNext() ) {
+            int eventType = reader.next();
+            switch ( eventType ) {
+                case XMLStreamConstants.START_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "tig".equals(name) ) {
+                        processTig();
+                    }
+                    else if ( "ntig".equals(name) ) {
+                        processNtig();
+                    }
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "langSet".equals(name) ) {
+                        cent.addLangEntry(lent);
+                        return; // This langSet is done
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void processTig () throws XMLStreamException {
+        String name;
+        while ( reader.hasNext() ) {
+            int eventType = reader.next();
+            switch ( eventType ) {
+                case XMLStreamConstants.START_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "term".equals(name) ) {
+                        processTerm();
+                    }
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "tig".equals(name) ) {
+                        return; // This tig is done
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void processNtig () throws XMLStreamException {
+        String name;
+        while ( reader.hasNext() ) {
+            int eventType = reader.next();
+            switch ( eventType ) {
+                case XMLStreamConstants.START_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "termGrp".equals(name) ) {
+                        processTermGrp();
+                    }
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "ntig".equals(name) ) {
+                        return; // This ntig is done
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void processTermGrp () throws XMLStreamException {
+        String name;
+        while ( reader.hasNext() ) {
+            int eventType = reader.next();
+            switch ( eventType ) {
+                case XMLStreamConstants.START_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "term".equals(name) ) {
+                        processTerm();
+                    }
+                    break;
+                case XMLStreamConstants.END_ELEMENT:
+                    name = reader.getLocalName();
+                    if ( "termGrp".equals(name) ) {
+                        return; // This termGrp is done
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void processTerm () throws XMLStreamException {
+        String id = reader.getAttributeValue(null, "id");
+        // We do not read the <hi> element, but just get its content
+        StringBuilder tmp = new StringBuilder();
+        while ( reader.hasNext() ) {
+            int eventType = reader.next();
+            switch ( eventType ) {
+                case XMLStreamConstants.END_ELEMENT:
+                    if ( "term".equals(reader.getLocalName()) ) {
+                        TermEntry term = new TermEntry(tmp.toString());
+                        term.setId(id);
+                        lent.addTerm(term);
+                        return;
+                    }
+                    break;
+                case XMLStreamConstants.CHARACTERS:
+                    tmp.append(reader.getText());
+                    break;
+            }
+        }
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GetGlossaryDetailsResponse.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GetGlossaryDetailsResponse.java
@@ -1,0 +1,4 @@
+package com.box.l10n.mojito.smartling.response;
+
+public class GetGlossaryDetailsResponse extends Response<GlossaryDetails>{
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GetGlossarySourceTermsResponse.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GetGlossarySourceTermsResponse.java
@@ -1,0 +1,4 @@
+package com.box.l10n.mojito.smartling.response;
+
+public class GetGlossarySourceTermsResponse extends Response<Items<GlossarySourceTerm>>{
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GetGlossaryTargetTermsResponse.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GetGlossaryTargetTermsResponse.java
@@ -1,0 +1,4 @@
+package com.box.l10n.mojito.smartling.response;
+
+public class GetGlossaryTargetTermsResponse extends Response<Items<GlossaryTargetTerm>> {
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossaryDetails.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossaryDetails.java
@@ -1,0 +1,61 @@
+package com.box.l10n.mojito.smartling.response;
+
+import java.util.Date;
+
+public class GlossaryDetails {
+
+    String createdByUserId;
+    Date createdDate;
+    String description;
+    String glossaryUid;
+    String name;
+    String sourceLocaleId;
+
+    public String getCreatedByUserId() {
+        return createdByUserId;
+    }
+
+    public void setCreatedByUserId(String createdByUserId) {
+        this.createdByUserId = createdByUserId;
+    }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getGlossaryUid() {
+        return glossaryUid;
+    }
+
+    public void setGlossaryUid(String glossaryUid) {
+        this.glossaryUid = glossaryUid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSourceLocaleId() {
+        return sourceLocaleId;
+    }
+
+    public void setSourceLocaleId(String sourceLocaleId) {
+        this.sourceLocaleId = sourceLocaleId;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossarySourceTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossarySourceTerm.java
@@ -1,0 +1,142 @@
+package com.box.l10n.mojito.smartling.response;
+
+import java.util.Date;
+
+public class GlossarySourceTerm {
+
+    String antonyms;
+    boolean caseSensitive;
+    Date createdDate;
+    String definition;
+    boolean deprecated;
+    boolean doNotTranslate;
+    boolean exactMatch;
+    Date modifiedDate;
+    String notes;
+    String partOfSpeechCode;
+    boolean seo;
+    String synonyms;
+    String termText;
+    String termUid;
+    String variations;
+
+    public String getAntonyms() {
+        return antonyms;
+    }
+
+    public void setAntonyms(String antonyms) {
+        this.antonyms = antonyms;
+    }
+
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(String definition) {
+        this.definition = definition;
+    }
+
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public boolean isDoNotTranslate() {
+        return doNotTranslate;
+    }
+
+    public void setDoNotTranslate(boolean doNotTranslate) {
+        this.doNotTranslate = doNotTranslate;
+    }
+
+    public boolean isExactMatch() {
+        return exactMatch;
+    }
+
+    public void setExactMatch(boolean exactMatch) {
+        this.exactMatch = exactMatch;
+    }
+
+    public Date getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public void setModifiedDate(Date modifiedDate) {
+        this.modifiedDate = modifiedDate;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getPartOfSpeechCode() {
+        return partOfSpeechCode;
+    }
+
+    public void setPartOfSpeechCode(String partOfSpeechCode) {
+        this.partOfSpeechCode = partOfSpeechCode;
+    }
+
+    public boolean isSeo() {
+        return seo;
+    }
+
+    public void setSeo(boolean seo) {
+        this.seo = seo;
+    }
+
+    public String getSynonyms() {
+        return synonyms;
+    }
+
+    public void setSynonyms(String synonyms) {
+        this.synonyms = synonyms;
+    }
+
+    public String getTermText() {
+        return termText;
+    }
+
+    public void setTermText(String termText) {
+        this.termText = termText;
+    }
+
+    public String getTermUid() {
+        return termUid;
+    }
+
+    public void setTermUid(String termUid) {
+        this.termUid = termUid;
+    }
+
+    public String getVariations() {
+        return variations;
+    }
+
+    public void setVariations(String variations) {
+        this.variations = variations;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossaryTargetTerm.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossaryTargetTerm.java
@@ -1,0 +1,14 @@
+package com.box.l10n.mojito.smartling.response;
+
+public class GlossaryTargetTerm extends GlossarySourceTerm {
+
+    GlossaryTermTranslation glossaryTermTranslation;
+
+    public GlossaryTermTranslation getGlossaryTermTranslation() {
+        return glossaryTermTranslation;
+    }
+
+    public void setGlossaryTermTranslation(GlossaryTermTranslation glossaryTermTranslation) {
+        this.glossaryTermTranslation = glossaryTermTranslation;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossaryTermTranslation.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/smartling/response/GlossaryTermTranslation.java
@@ -1,0 +1,79 @@
+package com.box.l10n.mojito.smartling.response;
+
+import java.util.Date;
+
+public class GlossaryTermTranslation {
+
+    Date createdDate;
+    String localeId;
+    boolean lockTranslation;
+    Date modifiedDate;
+    String notes;
+    boolean submittedForTranslation;
+    String translatedTerm;
+    String translatorUserUid;
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getLocaleId() {
+        return localeId;
+    }
+
+    public void setLocaleId(String localeId) {
+        this.localeId = localeId;
+    }
+
+    public boolean isLockTranslation() {
+        return lockTranslation;
+    }
+
+    public void setLockTranslation(boolean lockTranslation) {
+        this.lockTranslation = lockTranslation;
+    }
+
+    public Date getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public void setModifiedDate(Date modifiedDate) {
+        this.modifiedDate = modifiedDate;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public boolean isSubmittedForTranslation() {
+        return submittedForTranslation;
+    }
+
+    public void setSubmittedForTranslation(boolean submittedForTranslation) {
+        this.submittedForTranslation = submittedForTranslation;
+    }
+
+    public String getTranslatedTerm() {
+        return translatedTerm;
+    }
+
+    public void setTranslatedTerm(String translatedTerm) {
+        this.translatedTerm = translatedTerm;
+    }
+
+    public String getTranslatorUserUid() {
+        return translatorUserUid;
+    }
+
+    public void setTranslatorUserUid(String translatorUserUid) {
+        this.translatorUserUid = translatorUserUid;
+    }
+}

--- a/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
+++ b/webapp/src/main/resources/public/js/components/workbench/GitBlameInfoModal.js
@@ -220,6 +220,7 @@ class GitBlameInfoModal extends React.Component {
     getBaseParams = () => {
         return {
             textUnitName: this.props.textUnit.getName(),
+            textUnitContent: this.props.textUnit.getSource(),
             textUnitNameInSource: this.getTextUnitNameInSource(),
             assetPath: this.props.textUnit.getAssetPath(),
             thirdPartyTextUnitId: this.getThirdPartyTextUnitId(),

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossaryTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossaryTest.java
@@ -1,0 +1,217 @@
+package com.box.l10n.mojito.service.thirdparty;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.AssetExtraction;
+import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.service.asset.AssetRepository;
+import com.box.l10n.mojito.service.asset.VirtualAsset;
+import com.box.l10n.mojito.service.asset.VirtualAssetBadRequestException;
+import com.box.l10n.mojito.service.asset.VirtualAssetRequiredException;
+import com.box.l10n.mojito.service.asset.VirtualAssetService;
+import com.box.l10n.mojito.service.asset.VirtualAssetTextUnit;
+import com.box.l10n.mojito.service.asset.VirutalAssetMissingTextUnitException;
+import com.box.l10n.mojito.service.assetTextUnit.AssetTextUnitRepository;
+import com.box.l10n.mojito.smartling.SmartlingClient;
+import com.box.l10n.mojito.smartling.SmartlingClientException;
+import com.box.l10n.mojito.smartling.response.GlossaryDetails;
+import com.box.l10n.mojito.test.TestIdWatcher;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.io.Files;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ThirdPartyTMSSmartlingGlossaryTest {
+
+    private static final String SCHOOL_TEXT_UNIT_ID = "bd3a096a-ab4f-49ac-b033-099086cfe271";
+    public static final String HOUSE_TEXT_UNIT_ID = "8300f245-5072-4918-a59b-4d1cdf5c8cf2";
+    public static final String FIELD_TEXT_UNIT_ID = "b35b5435-16ca-4fa3-95cd-8527420c9240";
+    @Rule
+    public TestIdWatcher testIdWatcher = new TestIdWatcher();
+
+    @Mock
+    VirtualAssetService mockVirtualAssetService;
+
+    @Mock
+    SmartlingClient mockSmartlingClient;
+
+    @Mock
+    AssetRepository mockAssetRepository;
+
+    @Mock
+    AssetTextUnitRepository mockAssetTextUnitRepository;
+
+    @Mock
+    Repository mockRepository;
+
+    @Mock
+    Asset mockAsset;
+
+    @Mock
+    AssetExtraction mockAssetExtraction;
+
+    @Captor
+    ArgumentCaptor<List<VirtualAssetTextUnit>> textUnitsCaptor;
+
+    @Captor
+    ArgumentCaptor<Long> localeIdCaptor;
+
+    @Captor
+    ArgumentCaptor<Long> assetIdCaptor;
+
+    ThirdPartyTMSSmartlingGlossary thirdPartyTMSSmartlingGlossary;
+
+    String testTBXFileString;
+
+    Map<String, String> localeMapping = Maps.newHashMap();
+
+    @Before
+    public void setup() throws IOException, VirtualAssetBadRequestException {
+        MockitoAnnotations.initMocks(this);
+        VirtualAsset virtualAsset = new VirtualAsset();
+        virtualAsset.setId(100L);
+        virtualAsset.setPath("Test Glossary");
+        GlossaryDetails glossaryDetails = new GlossaryDetails();
+        glossaryDetails.setName("Test Glossary");
+        StringBuilder tbxStringBuilder = new StringBuilder();
+        Files.readLines(new File("src/test/resources/com/box/l10n/mojito/service/thirdparty/Test_Glossary.tbx"), StandardCharsets.UTF_8).stream().forEach(line -> {
+            tbxStringBuilder.append(line);
+        });
+        localeMapping.put("en", "en-US");
+        testTBXFileString = tbxStringBuilder.toString();
+        thirdPartyTMSSmartlingGlossary = new ThirdPartyTMSSmartlingGlossary();
+        thirdPartyTMSSmartlingGlossary.smartlingClient = mockSmartlingClient;
+        thirdPartyTMSSmartlingGlossary.assetTextUnitRepository = mockAssetTextUnitRepository;
+        thirdPartyTMSSmartlingGlossary.assetRepository = mockAssetRepository;
+        thirdPartyTMSSmartlingGlossary.virtualAssetService = mockVirtualAssetService;
+        thirdPartyTMSSmartlingGlossary.accountId = "testAccountId";
+
+        AssetTextUnit school = new AssetTextUnit();
+        school.setName("school");
+        school.setId(1L);
+
+        AssetTextUnit house = new AssetTextUnit();
+        house.setName("house");
+        house.setId(2L);
+
+        List<AssetTextUnit> assetTextUnitList = Lists.newArrayList(school, house);
+
+        RepositoryLocale en = new RepositoryLocale();
+        Locale enLocale = new Locale();
+        enLocale.setBcp47Tag("en");
+        enLocale.setId(1L);
+        en.setLocale(enLocale);
+        RepositoryLocale frFR = new RepositoryLocale();
+        Locale frFRLocale = new Locale();
+        frFR.setParentLocale(en);
+        frFRLocale.setBcp47Tag("fr-FR");
+        frFRLocale.setId(2L);
+        frFR.setLocale(frFRLocale);
+        when(mockRepository.getRepositoryLocales()).thenReturn(Sets.newHashSet(en, frFR));
+        doReturn(glossaryDetails).when(mockSmartlingClient).getGlossaryDetails(anyString(), anyString());
+        doReturn(testTBXFileString).when(mockSmartlingClient).downloadGlossaryFile(anyString(), anyString());
+        doReturn(testTBXFileString).when(mockSmartlingClient).downloadSourceGlossaryFile(anyString(), anyString(), anyString());
+        doReturn(testTBXFileString).when(mockSmartlingClient).downloadGlossaryFileWithTranslations(anyString(), anyString(), anyString(), anyString());
+        doReturn(virtualAsset).when(mockVirtualAssetService).createOrUpdateVirtualAsset(isA(VirtualAsset.class));
+        doReturn(Optional.of(mockAsset)).when(mockAssetRepository).findById(100L);
+        when(mockAsset.getLastSuccessfulAssetExtraction()).thenReturn(mockAssetExtraction);
+        when(mockAsset.getId()).thenReturn(100L);
+        when(mockAssetExtraction.getId()).thenReturn(1L);
+        doReturn(assetTextUnitList).when(mockAssetTextUnitRepository).findByAssetExtractionId(anyLong());
+    }
+
+    @Test
+    public void testPullSourceDeletesExistingAndImportsTextUnits() throws VirtualAssetRequiredException {
+        thirdPartyTMSSmartlingGlossary.pullSourceTextUnits(mockRepository, "someUid", localeMapping);
+        verify(mockSmartlingClient, times(1)).getGlossaryDetails("testAccountId", "someUid");
+        verify(mockSmartlingClient, times(1)).downloadSourceGlossaryFile("testAccountId", "someUid", "en-US");
+        verify(mockVirtualAssetService, times(1)).deleteTextUnit(100L, "school");
+        verify(mockVirtualAssetService, times(1)).deleteTextUnit(100L, "house");
+        verify(mockVirtualAssetService, times(1)).addTextUnits(anyLong(), textUnitsCaptor.capture());
+        List<VirtualAssetTextUnit> virtualAssetTextUnits = textUnitsCaptor.getValue();
+        assertEquals(3, virtualAssetTextUnits.size());
+        assertTrue(virtualAssetTextUnits.stream().filter(textUnit -> textUnit.getContent().equals("school") && textUnit.getName().equals(SCHOOL_TEXT_UNIT_ID)).count() == 1);
+        assertTrue(virtualAssetTextUnits.stream().filter(textUnit -> textUnit.getContent().equals("house") && textUnit.getName().equals(HOUSE_TEXT_UNIT_ID)).count() == 1);
+        assertTrue(virtualAssetTextUnits.stream().filter(textUnit -> textUnit.getContent().equals("field") && textUnit.getName().equals(FIELD_TEXT_UNIT_ID)).count() == 1);
+        assertTrue(virtualAssetTextUnits.stream().filter(virtualAssetTextUnit -> virtualAssetTextUnit.getComment().equals("school comment")).count() == 1);
+        assertTrue(virtualAssetTextUnits.stream().filter(virtualAssetTextUnit -> virtualAssetTextUnit.getComment().equals("house comment")).count() == 1);
+        assertTrue(virtualAssetTextUnits.stream().filter(virtualAssetTextUnit -> virtualAssetTextUnit.getComment().equals("field comment --- POS: noun")).count() == 1);
+    }
+
+    @Test(expected = SmartlingClientException.class)
+    public void testExceptionThrownIfErrorRetrievingGlossaryDetails() {
+        doThrow(new RuntimeException("External Smartling error")).when(mockSmartlingClient).getGlossaryDetails(anyString(), anyString());
+        thirdPartyTMSSmartlingGlossary.pullSourceTextUnits(mockRepository, "someUid", localeMapping);
+    }
+
+    @Test(expected = SmartlingClientException.class)
+    public void testExceptionThrownIfErrorDownloadingSourceGlossaryFile() {
+        doThrow(new RuntimeException("External Smartling error")).when(mockSmartlingClient).downloadSourceGlossaryFile(anyString(), anyString(), anyString());
+        thirdPartyTMSSmartlingGlossary.pullSourceTextUnits(mockRepository, "someUid", localeMapping);
+    }
+
+    @Test
+    public void testPull() throws VirutalAssetMissingTextUnitException, VirtualAssetRequiredException {
+        thirdPartyTMSSmartlingGlossary.pull(mockRepository, "someUid", localeMapping);
+        verify(mockSmartlingClient, times(1)).downloadGlossaryFileWithTranslations("testAccountId", "someUid", "fr-FR", "en-US");
+        verify(mockVirtualAssetService, times(1)).importLocalizedTextUnits(assetIdCaptor.capture(), localeIdCaptor.capture(), textUnitsCaptor.capture());
+        List<VirtualAssetTextUnit> translatedTextUnits = textUnitsCaptor.getValue();
+        assertTrue(assetIdCaptor.getValue() == 100L);
+        assertTrue(localeIdCaptor.getValue() == 2L);
+        assertEquals(3, translatedTextUnits.size());
+        assertTrue(translatedTextUnits.stream().filter(textUnit -> textUnit.getContent().equals("l'école") && textUnit.getName().equals(SCHOOL_TEXT_UNIT_ID) ).count() == 1);
+        assertTrue(translatedTextUnits.stream().filter(textUnit -> textUnit.getContent().equals("maison") && textUnit.getName().equals(HOUSE_TEXT_UNIT_ID)).count() == 1);
+        assertTrue(translatedTextUnits.stream().filter(textUnit -> textUnit.getContent().equals("le champ") && textUnit.getName().equals(FIELD_TEXT_UNIT_ID)).count() == 1);
+    }
+
+    @Test
+    public void testGetThirdPartyTextUnits() {
+        List<ThirdPartyTextUnit> thirdPartyTextUnits = thirdPartyTMSSmartlingGlossary.getThirdPartyTextUnits("someUid");
+        verify(mockSmartlingClient, times(1)).getGlossaryDetails("testAccountId", "someUid");
+        verify(mockSmartlingClient, times(1)).downloadGlossaryFile("testAccountId", "someUid");
+        assertEquals(3, thirdPartyTextUnits.size());
+        assertTrue(thirdPartyTextUnits.stream().filter(textUnit -> textUnit.getId().equals(SCHOOL_TEXT_UNIT_ID) && textUnit.getName().equals(SCHOOL_TEXT_UNIT_ID)).count() == 1);
+        assertTrue(thirdPartyTextUnits.stream().filter(textUnit -> textUnit.getId().equals(HOUSE_TEXT_UNIT_ID) && textUnit.getName().equals(HOUSE_TEXT_UNIT_ID)).count() == 1);
+        assertTrue(thirdPartyTextUnits.stream().filter(textUnit -> textUnit.getId().equals(FIELD_TEXT_UNIT_ID) && textUnit.getName().equals(FIELD_TEXT_UNIT_ID)).count() == 1);
+        assertEquals(3, thirdPartyTextUnits.stream().filter(textUnit -> textUnit.getAssetPath().equals("Test Glossary")).count());
+    }
+
+    @Test(expected = SmartlingClientException.class)
+    public void testExceptionThrownIfErrorDownloadingGlossaryFile() {
+        doThrow(new RuntimeException("External Smartling error")).when(mockSmartlingClient).downloadGlossaryFile(anyString(), anyString());
+        thirdPartyTMSSmartlingGlossary.getThirdPartyTextUnits("someUid");
+    }
+
+    @Test(expected = SmartlingClientException.class)
+    public void testExceptionThrownIfErrorDownloadingTranslatedGlossaryFile() {
+        doThrow(new RuntimeException("External Smartling error")).when(mockSmartlingClient).downloadGlossaryFileWithTranslations(anyString(), anyString(), anyString(), anyString());
+        thirdPartyTMSSmartlingGlossary.pull(mockRepository, "someUid", localeMapping);
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingTest.java
@@ -100,6 +100,9 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     @Mock
     ThirdPartyTMSSmartlingWithJson mockThirdPartyTMSSmartlingWithJson;
 
+    @Mock
+    ThirdPartyTMSSmartlingGlossary mockThirdPartyTMSSmartlingGlossary;
+
     @Autowired
     AssetPathAndTextUnitNameKeys assetPathAndTextUnitNameKeys;
 
@@ -160,7 +163,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         doReturn(null).when(smartlingClient).uploadLocalizedFile(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
         doReturn(null).when(mockTextUnitBatchImporterService).importTextUnits(any(), eq(false), eq(true));
         resultProcessor = new StubSmartlingResultProcessor();
-        tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher, assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+        tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher, assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
 
         mapper = new AndroidStringDocumentMapper(pluralSep, null);
     }
@@ -185,7 +188,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<SmartlingFile> result;
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
 
         TM tm = repository.getTm();
         Asset asset = assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
@@ -222,7 +225,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<SmartlingFile> result;
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
         // throw timeout exception for first request, following request should be successful
         when(smartlingClient.uploadFile(any(), any(), any(), any(), any(), any())).
                 thenThrow(new SmartlingClientException(new HttpServerErrorException(HttpStatus.GATEWAY_TIMEOUT))).
@@ -266,7 +269,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<SmartlingFile> result;
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
 
 
         TM tm = repository.getTm();
@@ -299,7 +302,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<SmartlingFile> result;
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
 
         TM tm = repository.getTm();
         Asset asset = assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
@@ -340,7 +343,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<SmartlingFile> result;
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
 
         TM tm = repository.getTm();
         Asset asset = assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
@@ -476,7 +479,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 eq(pluralFileName(repository, 0)), eq(false));
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
         tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, Collections.emptyList());
 
         verify(mockTextUnitBatchImporterService, times(4)).importTextUnits(
@@ -532,7 +535,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 eq(pluralFileName(repository, 0)), eq(false));
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
         tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, Collections.emptyList());
 
         verify(mockTextUnitBatchImporterService, times(4)).importTextUnits(
@@ -577,7 +580,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         repositoryService.addRepositoryLocale(repository, jaJP.getBcp47Tag());
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
         RuntimeException exception = assertThrows(SmartlingClientException.class, () -> tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, Collections.emptyList()));
         assertTrue(exception.getMessage().contains("Retries exhausted: 10/10"));
         verify(smartlingClient, times(11)).downloadPublishedFile(anyString(), anyString(), anyString(), anyBoolean());
@@ -605,7 +608,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 eq(pluralFileName(repository, 0)), eq(false));
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
         tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, Collections.emptyList());
 
         verify(mockTextUnitBatchImporterService, times(4)).importTextUnits(
@@ -656,7 +659,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 eq(pluralFileName(repository, 0)), eq(false));
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
         tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping,
                 null, null, ImmutableList.of("smartling-plural-fix=ja-JP"));
 
@@ -720,7 +723,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
                 eq(pluralFileName(repository, 0)), eq(false));
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary);
         tmsSmartling.pull(repository, "projectId", pluralSep, localeMapping, null, null, ImmutableList.of("dry-run=true"));
 
         verify(mockTextUnitBatchImporterService, never()).importTextUnits(
@@ -737,7 +740,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<Locale> locales = new ArrayList<>();
         Map<String, String> localeMapping = Collections.emptyMap();
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         Locale frCA = localeService.findByBcp47Tag("fr-CA");
         Locale jaJP = localeService.findByBcp47Tag("ja-JP");
@@ -1236,7 +1239,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         List<SmartlingFile> result;
         List<Locale> locales = new ArrayList<>();
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, batchSize);
+                assetPathAndTextUnitNameKeys, textUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary, batchSize);
         Repository repository = repositoryService.createRepository(testIdWatcher.getEntityName("batchRepo"));
         Locale frCA = localeService.findByBcp47Tag("fr-CA");
         Locale jaJP = localeService.findByBcp47Tag("ja-JP");
@@ -1347,7 +1350,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
     public void testBatchesFor(){
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson,3);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson,mockThirdPartyTMSSmartlingGlossary, 3);
 
         assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
         assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);
@@ -1359,7 +1362,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         assertThat(tmsSmartling.batchesFor(32)).isEqualTo(11);
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson,35);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson, mockThirdPartyTMSSmartlingGlossary,35);
 
         assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
         assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);
@@ -1369,7 +1372,7 @@ public class ThirdPartyTMSSmartlingTest extends ServiceTestBase {
         assertThat(tmsSmartling.batchesFor(290)).isEqualTo(9);
 
         tmsSmartling = new ThirdPartyTMSSmartling(smartlingClient, textUnitSearcher,
-                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson,4231);
+                assetPathAndTextUnitNameKeys, mockTextUnitBatchImporterService, resultProcessor, mockThirdPartyTMSSmartlingWithJson,mockThirdPartyTMSSmartlingGlossary, 4231);
 
         assertThat(tmsSmartling.batchesFor(0)).isEqualTo(0);
         assertThat(tmsSmartling.batchesFor(1)).isEqualTo(1);

--- a/webapp/src/test/resources/com/box/l10n/mojito/service/thirdparty/Test_Glossary.tbx
+++ b/webapp/src/test/resources/com/box/l10n/mojito/service/thirdparty/Test_Glossary.tbx
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE martif SYSTEM "TBXcoreStructV02.dtd">
+<martif type="TBX" xml:lang="en-US">
+	<martifHeader>
+		<fileDesc>
+			<sourceDesc>
+				<p>Smartling's TBX glossary export for Test Glossary</p>
+			</sourceDesc>
+		</fileDesc>
+		<encodingDesc>
+			<p type="XCSURI">http://www.ttt.org/oscarstandards/tbx/TBXXCS.xcs</p>
+		</encodingDesc>
+	</martifHeader>
+	<text>
+		<body>
+			<termEntry id="8300f245-5072-4918-a59b-4d1cdf5c8cf2">
+				<descrip type="definition">house comment</descrip>
+				<langSet xml:lang="en-US">
+					<tig>
+						<term>house</term>
+					</tig>
+				</langSet>
+				<langSet xml:lang="fr-FR">
+					<tig>
+						<term>maison</term>
+					</tig>
+				</langSet>
+			</termEntry>
+			<termEntry id="bd3a096a-ab4f-49ac-b033-099086cfe271">
+				<descrip type="definition">school comment</descrip>
+				<langSet xml:lang="en-US">
+					<tig>
+						<term>school</term>
+					</tig>
+				</langSet>
+				<langSet xml:lang="fr-FR">
+					<tig>
+						<term>l'école</term>
+					</tig>
+				</langSet>
+			</termEntry>
+			<termEntry id="b35b5435-16ca-4fa3-95cd-8527420c9240">
+				<descrip type="definition">field comment</descrip>
+				<descrip type="partOfSpeech">noun</descrip>
+				<langSet xml:lang="en-US">
+					<tig>
+						<term>field</term>
+						<termNote type="partOfSpeech">noun</termNote>
+					</tig>
+				</langSet>
+				<langSet xml:lang="fr-FR">
+					<tig>
+						<term>le champ</term>
+						<termNote type="partOfSpeech">noun</termNote>
+					</tig>
+				</langSet>
+			</termEntry>
+		</body>
+	</text>
+</martif>


### PR DESCRIPTION
Adds functionality to sync a Smartling glossary to a Mojito repository. The Smartling glossary name is used as the asset path, when executing a PULL_SOURCE action the text units are pulled from Smartling and any existing text units in Mojito are deleted before importing the updates. 