### PR TITLE
Control character checker

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerType.java
@@ -10,7 +10,8 @@ public enum CliCheckerType {
     PLACEHOLDER_COMMENT_CHECKER(PlaceholderCommentChecker.class),
     GLOSSARY_CASE_CHECKER(GlossaryCaseChecker.class),
     RECOMMEND_STRING_ID_CHECKER(RecommendStringIdChecker.class),
-    CONTEXT_COMMENT_REJECT_PATTERN_CHECKER(ContextCommentRejectPatternChecker.class);
+    CONTEXT_COMMENT_REJECT_PATTERN_CHECKER(ContextCommentRejectPatternChecker.class),
+    CONTROL_CHARACTER_CHECKER(ControlCharacterChecker.class);
 
     Class<? extends AbstractCliChecker> type;
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ControlCharacterChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ControlCharacterChecker.java
@@ -1,0 +1,65 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.google.common.base.CharMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
+
+public class ControlCharacterChecker extends AbstractCliChecker {
+
+    class ControlCharacterCheckerResult {
+        boolean isSuccessful = true;
+        String failureText = "";
+    }
+
+    @Override
+    public CliCheckResult run(List<AssetExtractionDiff> assetExtractionDiffs) {
+        List<String> failures = getSourceStringsFromDiff(assetExtractionDiffs).stream()
+                .map(this::getControlCharacterCheckerResult)
+                .filter(result -> !result.isSuccessful)
+                .map(result -> result.failureText)
+                .collect(Collectors.toList());
+        CliCheckResult result = createCliCheckerResult();
+        if (!failures.isEmpty()) {
+            result.setSuccessful(false);
+            result.setNotificationText(getNotificationText(failures));
+        }
+        return result;
+    }
+
+    private ControlCharacterCheckerResult getControlCharacterCheckerResult(String source) {
+        ControlCharacterCheckerResult result = new ControlCharacterCheckerResult();
+        char[] characters = source.toCharArray();
+        List<Integer> indexMatches = new ArrayList<>();
+        for (int i = 0; i < characters.length; i++) {
+            if (CharMatcher.anyOf("\t\r\n").negate().and(CharMatcher.javaIsoControl()).matches(characters[i])) {
+                indexMatches.add(i);
+                result.isSuccessful = false;
+            }
+        }
+
+        if (!result.isSuccessful) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("* Control character found in source string " + QUOTE_MARKER + source + QUOTE_MARKER + " at index " +
+                    indexMatches.stream()
+                            .map(index -> Integer.toString(index))
+                            .collect(Collectors.joining(", ")));
+            sb.append(".");
+            result.failureText = sb.toString();
+        }
+        return result;
+    }
+
+    private String getNotificationText(List<String> failures) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(failures.stream()
+            .collect(Collectors.joining(System.lineSeparator()))).toString();
+        sb.append(System.lineSeparator() + System.lineSeparator());
+        sb.append("Please remove control characters from source strings.");
+        return sb.toString();
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ControlCharacterCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ControlCharacterCheckerTest.java
@@ -1,0 +1,89 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
+import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ControlCharacterCheckerTest {
+
+    ControlCharacterChecker controlCharacterChecker;
+    private List<AssetExtractionDiff> assetExtractionDiffs;
+
+    @Before
+    public void setup() {
+        controlCharacterChecker = new ControlCharacterChecker();
+        controlCharacterChecker.setCliCheckerOptions(new CliCheckerOptions(Sets.newHashSet(), Sets.newHashSet(), ImmutableMap.<String, String>builder().build()));
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("\u0010Text containing a control character.");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+    }
+
+    @Test
+    public void testFailure() {
+        CliCheckResult result = controlCharacterChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertTrue(result.getNotificationText().contains("\u0010Text containing a control character."));
+        assertTrue(result.getNotificationText().contains(" at index 0."));
+    }
+
+    @Test
+    public void testMultipleControlCharactersInString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("\u0010Text containing multiple \u0000 control characters.\u0007");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = controlCharacterChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertTrue(result.getNotificationText().contains("\u0010Text containing multiple \u0000 control characters.\u0007"));
+        assertTrue(result.getNotificationText().contains(" at index 0, 26, 47."));
+    }
+
+    @Test
+    public void testNegatedCharactersInString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("\tText containing multiple \n control characters.\r");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = controlCharacterChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+    }
+
+    @Test
+    public void testSuccess() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("Text containing no control character.");
+        addedTUs.add(assetExtractorTextUnit);
+        assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = controlCharacterChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+    }
+}


### PR DESCRIPTION
Adds a new extraction check that scans a source string for the presence of control characters. If found the check fails and the error outputted to the user indicates the index in the string that caused the failure.