### PR TITLE
Throw exception if no account id provided for glossary sync

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossaryTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/thirdparty/ThirdPartyTMSSmartlingGlossaryTest.java
@@ -214,4 +214,22 @@ public class ThirdPartyTMSSmartlingGlossaryTest {
         doThrow(new RuntimeException("External Smartling error")).when(mockSmartlingClient).downloadGlossaryFileWithTranslations(anyString(), anyString(), anyString(), anyString());
         thirdPartyTMSSmartlingGlossary.pull(mockRepository, "someUid", localeMapping);
     }
+
+    @Test(expected = ThirdPartyTMSGlossarySyncException.class)
+    public void testNoAccountIdProvidedPullSource() {
+        thirdPartyTMSSmartlingGlossary.accountId = "";
+        thirdPartyTMSSmartlingGlossary.pullSourceTextUnits(mockRepository, "someUid", localeMapping);
+    }
+
+    @Test(expected = ThirdPartyTMSGlossarySyncException.class)
+    public void testNoAccountIdProvidedPull() {
+        thirdPartyTMSSmartlingGlossary.accountId = "";
+        thirdPartyTMSSmartlingGlossary.pull(mockRepository, "someUid", localeMapping);
+    }
+
+    @Test(expected = ThirdPartyTMSGlossarySyncException.class)
+    public void testNoAccountIdProvidedGetThirdPartyTextUnits() {
+        thirdPartyTMSSmartlingGlossary.accountId = "";
+        thirdPartyTMSSmartlingGlossary.getThirdPartyTextUnits( "someUid");
+    }
 }


### PR DESCRIPTION
Fixes startup issue where a `l10n.smartling.accountID` property is required for a successful startup. Value now defaults to an empty string, if a glossary sync is called and `accountId` string is empty an exception is thrown.