### PR TITLE
Change import localized asset jobs to persist the data in blob storage

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzJobInfo.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzJobInfo.java
@@ -62,7 +62,7 @@ public class QuartzJobInfo<I, O> {
     }
 
     public static <I, O> Builder<I, O> newBuilder(Class<? extends QuartzPollableJob<I, O>> clazz) {
-        Builder builder = new Builder();
+        Builder<I, O> builder = new Builder<I, O>();
         builder.clazz = clazz;
         return builder;
     }
@@ -81,48 +81,48 @@ public class QuartzJobInfo<I, O> {
         private Builder() {
         }
 
-        public Builder withInput(I val) {
+        public Builder<I, O> withInput(I val) {
             input = val;
             return this;
         }
 
-        public Builder withParentId(Long val) {
+        public Builder<I, O> withParentId(Long val) {
             parentId = val;
             return this;
         }
 
-        public Builder withMessage(String val) {
+        public Builder<I, O> withMessage(String val) {
             message = val;
             return this;
         }
 
-        public Builder withExpectedSubTaskNumber(int val) {
+        public Builder<I, O> withExpectedSubTaskNumber(int val) {
             expectedSubTaskNumber = val;
             return this;
         }
 
-        public Builder withTriggerStartDate(Date val) {
+        public Builder<I, O> withTriggerStartDate(Date val) {
             triggerStartDate = val;
             return this;
         }
 
-        public Builder withUniqueId(String val) {
+        public Builder<I, O> withUniqueId(String val) {
             uniqueId = val;
             return this;
         }
 
-        public Builder withInlineInput(boolean val) {
+        public Builder<I, O> withInlineInput(boolean val) {
             inlineInput = val;
             return this;
         }
 
-        public Builder withTimeout(long val) {
+        public Builder<I, O> withTimeout(long val) {
             timeout = val;
             return this;
         }
 
         public QuartzJobInfo<I, O> build() {
-            return new QuartzJobInfo(this);
+            return new QuartzJobInfo<I, O>(this);
         }
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -37,6 +37,7 @@ import com.box.l10n.mojito.okapi.qualitycheck.Parameters;
 import com.box.l10n.mojito.okapi.qualitycheck.QualityCheckStep;
 import com.box.l10n.mojito.okapi.steps.CheckForDoNotTranslateStep;
 import com.box.l10n.mojito.okapi.steps.FilterEventsToInMemoryRawDocumentStep;
+import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.WordCountService;
@@ -1082,8 +1083,11 @@ public class TMService {
         importLocalizedAssetJobInput.setFilterConfigIdOverride(filterConfigIdOverride);
         importLocalizedAssetJobInput.setFilterOptions(filterOptions);
 
-        PollableFuture<Void> pollableFuture = quartzPollableTaskScheduler.scheduleJob(ImportLocalizedAssetJob.class, importLocalizedAssetJobInput);
-        return pollableFuture;
+        QuartzJobInfo<ImportLocalizedAssetJobInput, Void> quartzJobInfo = QuartzJobInfo.newBuilder(ImportLocalizedAssetJob.class)
+                .withInlineInput(false)
+                .withInput(importLocalizedAssetJobInput).build();
+
+        return quartzPollableTaskScheduler.scheduleJob(quartzJobInfo);
     }
 
     public void importLocalizedAsset(


### PR DESCRIPTION
Changed to blob instead of SQL storage to prevent PacketTooBigException
when attempting to import large translated files.
Fixed raw & generics type mix in QuartzJobInfo.