### PR TITLE
Add a database-backed cache

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -301,6 +301,11 @@
             <version>6.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/webapp/src/main/java/com/box/l10n/mojito/CacheType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/CacheType.java
@@ -1,0 +1,23 @@
+package com.box.l10n.mojito;
+
+/**
+ * Typed cache names to be used from @Cacheable annotations.
+ */
+public enum CacheType {
+    DEFAULT(Names.DEFAULT),
+    LOCALES(Names.LOCALES),
+    PLURAL_FORMS(Names.PLURAL_FORMS),
+    MACHINE_TRANSLATION(Names.MACHINE_TRANSLATION);
+
+    public static class Names {
+        public static final String DEFAULT = "default";
+        public static final String LOCALES = "locales";
+        public static final String PLURAL_FORMS = "pluralForms";
+        public static final String MACHINE_TRANSLATION = "machineTranslation";
+    }
+
+    CacheType(String cacheName) {
+        if(!cacheName.equals(this.name()))
+            throw new IllegalArgumentException();
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/CachingConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/CachingConfig.java
@@ -1,36 +1,91 @@
 package com.box.l10n.mojito;
 
+import com.box.l10n.mojito.service.cache.DatabaseCache;
+import com.box.l10n.mojito.service.cache.DatabaseCacheConfiguration;
+import com.box.l10n.mojito.service.cache.TieredCache;
+import com.box.l10n.mojito.service.machinetranslation.MTServiceCacheConfiguration;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.AdviceMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 /**
- *
  * @author jaurambault
  */
 @Configuration
 @EnableCaching(mode = AdviceMode.ASPECTJ)
 public class CachingConfig extends CachingConfigurerSupport {
 
+    final MTServiceCacheConfiguration mtServiceCacheConfiguration;
+
+    public CachingConfig(MTServiceCacheConfiguration mtServiceCacheConfiguration) {
+        this.mtServiceCacheConfiguration = mtServiceCacheConfiguration;
+    }
+
     @Bean
     @Override
     public CacheManager cacheManager() {
-        Cache defaultCache = new ConcurrentMapCache("default");
-        Cache localesCache = new ConcurrentMapCache("locales");
-        Cache pluralForm = new ConcurrentMapCache("pluralForms");
+        Cache defaultCache = new ConcurrentMapCache(CacheType.Names.DEFAULT);
+        Cache localesCache = new ConcurrentMapCache(CacheType.Names.LOCALES);
+        Cache pluralForm = new ConcurrentMapCache(CacheType.Names.PLURAL_FORMS);
+
+        TieredCache machineTranslationTieredCache = getMachineTranslationCache();
 
         SimpleCacheManager manager = new SimpleCacheManager();
-        manager.setCaches(Arrays.asList(defaultCache, localesCache, pluralForm));
+        manager.setCaches(Arrays.asList(
+                defaultCache,
+                localesCache,
+                pluralForm,
+                machineTranslationTieredCache));
 
         return manager;
+    }
+
+    private TieredCache getMachineTranslationCache() {
+        com.github.benmanes.caffeine.cache.@NonNull Cache<Object, Object> machineTranslationCaffeineCache =
+                Caffeine.newBuilder()
+                        .expireAfterWrite(
+                                mtServiceCacheConfiguration.getInMemory().getTtl().toMillis(),
+                                TimeUnit.MILLISECONDS)
+                        .maximumSize(mtServiceCacheConfiguration.getInMemory().getMaximumSize())
+                        .build();
+
+        CaffeineCache machineTranslationMemoryCache = new CaffeineCache(
+                "machineTranslationInMemory",
+                machineTranslationCaffeineCache
+        );
+
+        DatabaseCache machineTranslationDatabaseCache = null;
+
+        if (mtServiceCacheConfiguration.getDatabase().isEnabled()) {
+            DatabaseCacheConfiguration mtDbCacheConfiguration = new DatabaseCacheConfiguration();
+            mtDbCacheConfiguration.setTtl(mtServiceCacheConfiguration.getDatabase().getTtl());
+            mtDbCacheConfiguration.setEvictEntryOnDeserializationFailure(
+                    mtServiceCacheConfiguration.getDatabase().isEvictEntryOnDeserializationFailure());
+
+            machineTranslationDatabaseCache = new DatabaseCache(
+                    "machineTranslationInDb",
+                    mtDbCacheConfiguration
+            );
+        }
+
+        return new TieredCache(
+                CacheType.Names.MACHINE_TRANSLATION,
+                machineTranslationMemoryCache,
+                machineTranslationDatabaseCache
+        );
     }
 
     @Bean

--- a/webapp/src/main/java/com/box/l10n/mojito/CustomKeyGenerator.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/CustomKeyGenerator.java
@@ -15,6 +15,8 @@ public class CustomKeyGenerator extends SimpleKeyGenerator {
      */
     @Override
     public Object generate(Object target, Method method, Object... params) {
-        return generateKey(method, params);
+        // Use the java.lang.reflect.Method's generic string description as part of the key, to enable a variety of
+        // serialization-based caches to work out of the box, as the Method class isn't serializable itself.
+        return generateKey(method.toGenericString(), params);
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/ApplicationCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/ApplicationCache.java
@@ -1,0 +1,84 @@
+package com.box.l10n.mojito.entity;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Type;
+import org.joda.time.DateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * Entity that contains the cache entry details for a database-backed application cache.
+ * Each entity is identified by a specific {@Link ApplicationCacheType} and MD5 hash of the key.
+ * A TTL / expiry date can also be configured on the entries, the application being responsible for the entry eviction.
+ *
+ * @author garion
+ */
+@Entity
+@Table(name = "application_cache",
+        indexes = {
+                @Index(name = "UK__APPLICATION_CACHE__CACHE_TYPE_ID__KEY_MD5", columnList = "cache_type_id, key_md5", unique = true),
+                @Index(name = "I__APPLICATION_CACHE__EXPIRY_DATE", columnList = "expiry_date")
+        })
+@BatchSize(size = 1000)
+public class ApplicationCache extends BaseEntity {
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "cache_type_id", foreignKey = @ForeignKey(name = "FK__APPLICATION_CACHE__CACHE_TYPE_ID"))
+    private ApplicationCacheType applicationCacheType;
+
+    @Column(name = "key_md5", length = 32)
+    private String keyMD5;
+
+    @Column(name = "value", length = Integer.MAX_VALUE)
+    @Lob
+    private byte[] value;
+
+    @Column(name = "created_date")
+    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+    private DateTime createdDate;
+
+    @Column(name = "expiry_date")
+    @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+    private DateTime expiryDate;
+
+    public ApplicationCache() {
+    }
+
+    public ApplicationCache(ApplicationCacheType applicationCacheType, String keyMD5, byte[] value, DateTime expiryDate) {
+        this.applicationCacheType = applicationCacheType;
+        this.keyMD5 = keyMD5;
+        this.value = value;
+        this.expiryDate = expiryDate;
+    }
+
+    public byte[] getValue() {
+        return value;
+    }
+
+    public void setValue(byte[] value) {
+        this.value = value;
+    }
+
+    public DateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(DateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public DateTime getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(DateTime expireDate) {
+        this.expiryDate = expireDate;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/ApplicationCacheType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/ApplicationCacheType.java
@@ -1,0 +1,74 @@
+package com.box.l10n.mojito.entity;
+
+
+import com.box.l10n.mojito.rest.View;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.google.common.base.Objects;
+import org.hibernate.annotations.BatchSize;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Entity to manage the different database-backed application cache instances/types.
+ * Application cache entries {@link ApplicationCache} are always created against a specific cache type.
+ *
+ * @author garion
+ */
+@Entity
+@Table(name = "application_cache_type")
+@BatchSize(size = 1000)
+public class ApplicationCacheType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @JsonView(View.IdAndName.class)
+    protected short id;
+
+    @Column(name = "name")
+    private String name;
+
+    public ApplicationCacheType() {
+    }
+
+    public ApplicationCacheType(String name) {
+        this.name = name;
+    }
+
+    public ApplicationCacheType(short id) {
+        this.id = id;
+    }
+
+    public short getId() {
+        return id;
+    }
+
+    public void setId(short id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApplicationCacheType that = (ApplicationCacheType) o;
+        return id == that.id && Objects.equal(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, name);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/BatchTranslationRequestDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/BatchTranslationRequestDTO.java
@@ -1,5 +1,8 @@
 package com.box.l10n.mojito.rest.machinetranslation;
 
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -7,7 +10,7 @@ import java.util.List;
  *
  * @author garion
  */
-public class BatchTranslationRequestDTO {
+public class BatchTranslationRequestDTO implements Serializable {
     List<String> textSources;
     String sourceBcp47Tag;
     List<String> targetBcp47Tags;
@@ -70,5 +73,38 @@ public class BatchTranslationRequestDTO {
 
     public void setRepositoryNames(List<String> repositoryNames) {
         this.repositoryNames = repositoryNames;
+    }
+
+    @Override
+    public boolean equals(Object another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null || getClass() != another.getClass()) {
+            return false;
+        }
+        BatchTranslationRequestDTO that = (BatchTranslationRequestDTO) another;
+
+        return skipFunctionalProtection == that.skipFunctionalProtection
+                && skipLeveraging == that.skipLeveraging
+                && Objects.equal(textSources, that.textSources)
+                && Objects.equal(sourceBcp47Tag, that.sourceBcp47Tag)
+                && Objects.equal(targetBcp47Tags, that.targetBcp47Tags)
+                && Objects.equal(repositoryIds, that.repositoryIds)
+                && Objects.equal(repositoryNames, that.repositoryNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                textSources,
+                sourceBcp47Tag,
+                targetBcp47Tags,
+                skipFunctionalProtection,
+                skipLeveraging,
+                repositoryIds,
+                repositoryNames
+        );
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/MachineTranslationWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/MachineTranslationWS.java
@@ -11,12 +11,15 @@ import com.box.l10n.mojito.service.pollableTask.PollableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.box.l10n.mojito.CacheType.Names.MACHINE_TRANSLATION;
 
 
 /**
@@ -38,6 +41,7 @@ public class MachineTranslationWS {
 
     @RequestMapping(method = RequestMethod.POST, value = "/api/machine-translation-batch")
     @ResponseStatus(HttpStatus.OK)
+    @Cacheable(MACHINE_TRANSLATION)
     public PollableTask getTranslations(@RequestBody BatchTranslationRequestDTO translationRequest) {
         QuartzJobInfo<BatchTranslationRequestDTO, TranslationsResponseDTO> quartzJobInfo =
                 QuartzJobInfo.newBuilder(BatchMachineTranslationJob.class)
@@ -50,6 +54,7 @@ public class MachineTranslationWS {
 
     @RequestMapping(method = RequestMethod.POST, value = "/api/machine-translation")
     @ResponseStatus(HttpStatus.OK)
+    @Cacheable(MACHINE_TRANSLATION)
     public TranslationDTO getSingleTranslation(@RequestBody TranslationRequestDTO translationRequest) {
         return machineTranslationService.getSingleTranslation(
                 translationRequest.getTextSource(),

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/TranslationRequestDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/TranslationRequestDTO.java
@@ -1,5 +1,8 @@
 package com.box.l10n.mojito.rest.machinetranslation;
 
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -7,7 +10,7 @@ import java.util.List;
  *
  * @author garion
  */
-public class TranslationRequestDTO {
+public class TranslationRequestDTO implements Serializable {
     String textSource;
     String sourceBcp47Tag;
     String targetBcp47Tag;
@@ -71,4 +74,39 @@ public class TranslationRequestDTO {
     public void setRepositoryNames(List<String> repositoryNames) {
         this.repositoryNames = repositoryNames;
     }
+
+    @Override
+    public boolean equals(Object another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null || getClass() != another.getClass()) {
+            return false;
+        }
+
+        TranslationRequestDTO that = (TranslationRequestDTO) another;
+
+        return skipFunctionalProtection == that.skipFunctionalProtection
+                && skipLeveraging == that.skipLeveraging
+                && Objects.equal(textSource, that.textSource)
+                && Objects.equal(sourceBcp47Tag, that.sourceBcp47Tag)
+                && Objects.equal(targetBcp47Tag, that.targetBcp47Tag)
+                && Objects.equal(repositoryIds, that.repositoryIds)
+                && Objects.equal(repositoryNames, that.repositoryNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                textSource,
+                sourceBcp47Tag,
+                targetBcp47Tag,
+                skipFunctionalProtection,
+                skipLeveraging,
+                repositoryIds,
+                repositoryNames
+        );
+    }
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/DBUtils.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/DBUtils.java
@@ -13,4 +13,7 @@ public class DBUtils {
         return url.contains("mysql");
     }
 
+    public boolean isHsql() {
+        return url.contains("hsqldb");
+    }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheRepository.java
@@ -1,0 +1,43 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.box.l10n.mojito.entity.ApplicationCache;
+import com.box.l10n.mojito.entity.ApplicationCacheType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+import java.util.Optional;
+
+/**
+ * @author garion
+ */
+@RepositoryRestResource(exported = false)
+public interface ApplicationCacheRepository extends JpaRepository<ApplicationCache, Long> {
+
+    @Query(value = "select ac from ApplicationCache ac " +
+            "where ac.applicationCacheType = :applicationCacheType and ac.keyMD5 = :keyMD5 " +
+            "and (ac.expiryDate is null or ac.expiryDate > CURRENT_TIMESTAMP)")
+    Optional<ApplicationCache> findByIdAndNotExpired(
+            @Param("applicationCacheType") ApplicationCacheType applicationCacheType,
+            @Param("keyMD5") String keyMD5);
+
+    Optional<ApplicationCache> findByApplicationCacheTypeAndKeyMD5(
+            @Param("applicationCacheType") ApplicationCacheType applicationCacheType,
+            @Param("keyMD5") String keyMD5);
+
+    void deleteByApplicationCacheTypeAndKeyMD5(
+            @Param("applicationCacheType") ApplicationCacheType applicationCacheType,
+            @Param("keyMD5") String keyMD5);
+
+    @Modifying
+    @Query(value = "delete from ApplicationCache ac " +
+            "where ac.applicationCacheType.id = :cacheId "
+    )
+    void clearCache(@Param("cacheId") short cacheId);
+
+    @Modifying
+    @Query("delete from ApplicationCache ac where ac.expiryDate <= CURRENT_TIMESTAMP")
+    void clearAllExpired();
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheTypeRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheTypeRepository.java
@@ -1,0 +1,14 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.box.l10n.mojito.entity.ApplicationCacheType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+/**
+ * @author garion
+ */
+@RepositoryRestResource(exported = false)
+public interface ApplicationCacheTypeRepository extends JpaRepository<ApplicationCacheType, Short> {
+    ApplicationCacheType findByName(@Param("name") String name);
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheUpdaterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/ApplicationCacheUpdaterService.java
@@ -1,0 +1,142 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.box.l10n.mojito.entity.ApplicationCache;
+import com.box.l10n.mojito.entity.ApplicationCacheType;
+import com.box.l10n.mojito.service.DBUtils;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Class that implements MySQL optimized versions of the upsert methods for the database-backed cache.
+ */
+@Component
+public class ApplicationCacheUpdaterService {
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(ApplicationCacheUpdaterService.class);
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    ApplicationCacheRepository applicationCacheRepository;
+
+    @Autowired
+    DBUtils dbUtils;
+
+    /**
+     * Upsert a cache entry with a TTL, with a MySql optimized version.
+     */
+    void upsertWithTTL(@Param("cacheTypeId") short cacheTypeId,
+                       @Param("keyMD5") String keyMD5,
+                       @Param("value") byte[] value,
+                       @Param("ttlInSeconds") long ttlInSeconds) {
+        if (dbUtils.isMysql()) {
+            String mySqlQuery = "INSERT INTO application_cache " +
+                    "value (NULL, :cacheTypeId, :keyMD5, :value, CURRENT_TIMESTAMP, ADDDATE(CURRENT_TIMESTAMP, INTERVAL :ttlInSeconds SECOND))" +
+                    "ON DUPLICATE KEY UPDATE value = :value, created_date = CURRENT_TIMESTAMP, expiry_date = ADDDATE(CURRENT_TIMESTAMP, INTERVAL :ttlInSeconds SECOND)";
+
+            Query query = entityManager.createNativeQuery(mySqlQuery);
+            query.setParameter("cacheTypeId", cacheTypeId);
+            query.setParameter("keyMD5", keyMD5);
+            query.setParameter("value", value);
+            query.setParameter("ttlInSeconds", ttlInSeconds);
+            query.executeUpdate();
+
+            entityManager.flush();
+            entityManager.clear();
+        } else {
+            ApplicationCacheType applicationCacheType = new ApplicationCacheType(cacheTypeId);
+
+            Optional<ApplicationCache> existingEntry = applicationCacheRepository.findByApplicationCacheTypeAndKeyMD5(
+                    applicationCacheType,
+                    keyMD5
+            );
+            DateTime currentSqlTimestamp = getCurrentSqlTimestamp();
+
+            ApplicationCache applicationCache;
+
+            if (existingEntry.isPresent()) {
+                applicationCache = existingEntry.get();
+                applicationCache.setValue(value);
+                applicationCache.setCreatedDate(currentSqlTimestamp.plusSeconds((int) ttlInSeconds));
+            } else {
+                applicationCache = new ApplicationCache(
+                        applicationCacheType,
+                        keyMD5,
+                        value,
+                        currentSqlTimestamp.plusSeconds((int) ttlInSeconds));
+                applicationCache.setCreatedDate(currentSqlTimestamp);
+                applicationCacheRepository.save(applicationCache);
+            }
+        }
+    }
+
+    /**
+     * Upsert a cache entry without a TTL being specified, with a MySql optimized version.
+     */
+    void upsertNoExpiryDate(@Param("cacheTypeId") short cacheTypeId,
+                            @Param("keyMD5") String keyMD5,
+                            @Param("value") byte[] value) {
+        if (dbUtils.isMysql()) {
+            String mySqlQuery = "insert into application_cache " +
+                    "value (NULL, :cacheTypeId, :keyMD5, :value, CURRENT_TIMESTAMP, NULL)" +
+                    "ON DUPLICATE KEY UPDATE value = :value, created_date = CURRENT_TIMESTAMP";
+
+            Query query = entityManager.createNativeQuery(mySqlQuery);
+            query.setParameter("cacheTypeId", cacheTypeId);
+            query.setParameter("keyMD5", keyMD5);
+            query.setParameter("value", value);
+
+            query.executeUpdate();
+
+            entityManager.flush();
+            entityManager.clear();
+        } else {
+            ApplicationCacheType applicationCacheType = new ApplicationCacheType(cacheTypeId);
+
+            Optional<ApplicationCache> existingEntry = applicationCacheRepository.findByApplicationCacheTypeAndKeyMD5(
+                    applicationCacheType,
+                    keyMD5
+            );
+            ApplicationCache applicationCache;
+            DateTime currentSqlTimestamp = getCurrentSqlTimestamp();
+
+            if (existingEntry.isPresent()) {
+                applicationCache = existingEntry.get();
+                applicationCache.setValue(value);
+                applicationCache.setCreatedDate(currentSqlTimestamp);
+            } else {
+                applicationCache = new ApplicationCache(
+                        applicationCacheType,
+                        keyMD5,
+                        value,
+                        null);
+                applicationCache.setCreatedDate(currentSqlTimestamp);
+                applicationCacheRepository.save(applicationCache);
+            }
+        }
+    }
+
+    private DateTime getCurrentSqlTimestamp() {
+        DateTime currentTimestamp;
+
+        try {
+            currentTimestamp = new DateTime(entityManager.createNativeQuery("SELECT TOP 1 CURRENT_TIMESTAMP FROM INFORMATION_SCHEMA.TABLES").getSingleResult());
+        } catch (Exception ex) {
+            logger.error("Could not retrieve current timestamp from the SQL DB", ex);
+            currentTimestamp = DateTime.now();
+        }
+        return currentTimestamp;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/DatabaseCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/DatabaseCache.java
@@ -1,0 +1,206 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.box.l10n.mojito.entity.ApplicationCache;
+import com.box.l10n.mojito.entity.ApplicationCacheType;
+import com.google.common.base.Preconditions;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+import org.springframework.cache.support.NullValue;
+import org.springframework.core.serializer.support.SerializingConverter;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
+
+import javax.annotation.Nullable;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Implements a cache that is stored in the database.
+ * <p>
+ * The key objects are serialized and an MD5 of the serialized result is used, together with the cache type, as the
+ * identifying key in the database.
+ * The value objects are serialized/deserialized to byte arrays and back.
+ *
+ * @author garion
+ */
+@Configurable
+public class DatabaseCache extends AbstractValueAdaptingCache {
+    /**
+     * logger
+     */
+    static Logger logger = getLogger(DatabaseCache.class);
+
+    private static final byte[] BINARY_NULL_VALUE = (new SerializingConverter()).convert(NullValue.INSTANCE);
+
+    @Autowired
+    ApplicationCacheUpdaterService applicationCacheUpdaterService;
+
+    @Autowired
+    ApplicationCacheTypeRepository applicationCacheTypeRepository;
+
+    @Autowired
+    ApplicationCacheRepository applicationCacheRepository;
+
+    private final String cacheName;
+    private final DatabaseCacheConfiguration cacheConfig;
+
+    private ApplicationCacheType cacheType;
+
+    public DatabaseCache(String cacheName, DatabaseCacheConfiguration cacheConfig) {
+        super(true);
+
+        Preconditions.checkNotNull(cacheName);
+        Preconditions.checkNotNull(cacheConfig);
+
+        this.cacheName = cacheName;
+        this.cacheConfig = cacheConfig;
+
+        logger.debug("DatabaseCache with name: {} and TTL: {} created.", cacheName, cacheConfig.getTtl());
+    }
+
+    @Override
+    public Object lookup(Object key) {
+        checkCacheTypeConfigured();
+
+        Optional<ApplicationCache> maybeCacheResult = applicationCacheRepository.findByIdAndNotExpired(this.cacheType, getCacheKeyMD5(key));
+
+        if (maybeCacheResult.isPresent()) {
+            byte[] bytes = maybeCacheResult.get().getValue();
+
+            // Permanently evict cache entries that cause deserialization failures (e.g.: due to breaking changes in
+            // target class structure).
+            try {
+                Object deserializedValue = deserializeCacheValue(bytes);
+                return this.fromStoreValue(deserializedValue);
+            } catch (Exception e) {
+                logger.error(String.format("Could not deserialize cache entry. Problematic serialized value: %s . Exception: ", Arrays.toString(bytes)), e);
+
+                if (cacheConfig.isEvictEntryOnDeserializationFailure()) {
+                    logger.warn(String.format("The entry failing deserialization will be evicted permanently. Problematic serialized value: %s ", Arrays.toString(bytes)));
+                    evict(key);
+                    return null;
+                }
+
+                throw e;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.cacheName;
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return applicationCacheRepository;
+    }
+
+    @Override
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        //noinspection unchecked
+        T cacheEntry = (T) lookup(key);
+        if (cacheEntry == null) {
+            try {
+                cacheEntry = valueLoader.call();
+                put(key, serializeCacheValue(cacheEntry));
+            } catch (Throwable ex) {
+                throw new ValueRetrievalException(key, valueLoader, ex);
+            }
+        }
+
+        return cacheEntry;
+    }
+
+    @Transactional
+    @Override
+    public void put(Object key, Object value) {
+        checkCacheTypeConfigured();
+
+        long ttlInSeconds = cacheConfig.getTtl().get(ChronoUnit.SECONDS);
+        if (ttlInSeconds <= 0) {
+            applicationCacheUpdaterService.upsertNoExpiryDate(
+                    cacheType.getId(),
+                    getCacheKeyMD5(key),
+                    serializeCacheValue(value));
+        } else {
+            applicationCacheUpdaterService.upsertWithTTL(
+                    cacheType.getId(),
+                    getCacheKeyMD5(key),
+                    serializeCacheValue(value),
+                    ttlInSeconds);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void evict(Object key) {
+        checkCacheTypeConfigured();
+        applicationCacheRepository.deleteByApplicationCacheTypeAndKeyMD5(
+                cacheType, getCacheKeyMD5(key)
+        );
+    }
+
+    @Transactional
+    @Override
+    public void clear() {
+        checkCacheTypeConfigured();
+        applicationCacheRepository.clearCache(cacheType.getId());
+    }
+
+    private void checkCacheTypeConfigured() {
+        if (this.cacheType == null) {
+            this.cacheType = getOrRegisterApplicationCacheType(getName());
+        }
+    }
+
+    private byte[] serializeCacheKey(Object cacheKey) {
+        return cacheConfig.getKeySerializationPair().write(cacheKey);
+    }
+
+    private byte[] serializeCacheValue(Object value) {
+        if (isAllowNullValues() && (value == null || value instanceof NullValue)) {
+            return BINARY_NULL_VALUE;
+        }
+
+        return cacheConfig.getValueSerializationPair().write(value);
+    }
+
+    @Nullable
+    private Object deserializeCacheValue(byte[] value) {
+        if (isAllowNullValues() && ObjectUtils.nullSafeEquals(value, BINARY_NULL_VALUE)) {
+            return NullValue.INSTANCE;
+        }
+
+        return cacheConfig.getValueSerializationPair().read(value);
+    }
+
+    private String getCacheKeyMD5(Object key) {
+        byte[] serializedKey = serializeCacheKey(key);
+        return DigestUtils.md5Hex(serializedKey);
+    }
+
+    /**
+     * Auto-register the cache in the DB if it doesn't already exist.
+     */
+    @Transactional
+    private ApplicationCacheType getOrRegisterApplicationCacheType(String name) {
+        ApplicationCacheType dbCacheType;
+        dbCacheType = applicationCacheTypeRepository.findByName(name);
+
+        if (dbCacheType == null) {
+            dbCacheType = applicationCacheTypeRepository.save(new ApplicationCacheType(name));
+        }
+
+        return dbCacheType;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/DatabaseCacheConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/DatabaseCacheConfiguration.java
@@ -1,0 +1,69 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.google.common.base.Preconditions;
+import org.springframework.boot.convert.DurationUnit;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * This class enables custom configurations for a database-backed cache.
+ * By default, no TTL is configured (an expiry date isn't writen for entries).
+ * Cache evictions is done by {@Link DatabaseCacheEvictionJob}.
+ * The serializer and deserializers for the keys and values are also configurable.
+ *
+ * @author garion
+ */
+public class DatabaseCacheConfiguration {
+
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration ttl;
+
+    private boolean evictEntryOnDeserializationFailure;
+
+    private SerializationPair<Object> keySerializationPair;
+    private SerializationPair<Object> valueSerializationPair;
+
+    public DatabaseCacheConfiguration() {
+        this.ttl = Duration.ZERO;
+        this.evictEntryOnDeserializationFailure = true;
+        this.keySerializationPair = new DefaultSerializationPair();
+        this.valueSerializationPair = new DefaultSerializationPair();
+    }
+
+    public void setTtl(Duration ttl) {
+        Preconditions.checkNotNull(ttl);
+        this.ttl = ttl;
+    }
+
+    public Duration getTtl() {
+        return ttl;
+    }
+
+    public SerializationPair<Object> getKeySerializationPair() {
+        return keySerializationPair;
+    }
+
+    public void setKeySerializationPair(SerializationPair<Object> keySerializationPair) {
+        Preconditions.checkNotNull(keySerializationPair);
+        this.keySerializationPair = keySerializationPair;
+    }
+
+    public SerializationPair<Object> getValueSerializationPair() {
+        return valueSerializationPair;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void setValueSerializationPair(SerializationPair<?> valueSerializationPair) {
+        Preconditions.checkNotNull(valueSerializationPair);
+        this.valueSerializationPair = (SerializationPair<Object>) valueSerializationPair;
+    }
+
+    public boolean isEvictEntryOnDeserializationFailure() {
+        return evictEntryOnDeserializationFailure;
+    }
+
+    public void setEvictEntryOnDeserializationFailure(boolean evictEntryOnDeserializationFailure) {
+        this.evictEntryOnDeserializationFailure = evictEntryOnDeserializationFailure;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/DatabaseCacheEvictionJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/DatabaseCacheEvictionJob.java
@@ -1,0 +1,73 @@
+package com.box.l10n.mojito.service.cache;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SimpleTrigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.quartz.JobDetailFactoryBean;
+import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+/**
+ * Deletes entries from the DatabaseCache for which their expiry date has already occurred.
+ *
+ * @author garion
+ */
+@Profile("!disablescheduling")
+@Configurable
+@DisallowConcurrentExecution
+public class DatabaseCacheEvictionJob implements Job {
+
+    static Logger logger = LoggerFactory.getLogger(DatabaseCacheEvictionJob.class);
+
+    @Autowired
+    ApplicationCacheRepository applicationCacheRepository;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        try {
+            clearAllExpired();
+        } catch (Exception ex) {
+            logger.error("Could not clear expired entries from the cache due to exception: ", ex);
+            throw ex;
+        }
+    }
+
+    @Bean(name = "DatabaseCacheEvictionJob")
+    JobDetailFactoryBean jobDatabaseCacheEvictionJob() {
+        JobDetailFactoryBean jobDetailFactory = new JobDetailFactoryBean();
+        jobDetailFactory.setJobClass(DatabaseCacheEvictionJob.class);
+        jobDetailFactory.setDescription("Remove expired entries from the database cache.");
+        jobDetailFactory.setDurability(true);
+        return jobDetailFactory;
+    }
+
+    @Profile("!disablescheduling")
+    @Bean
+    public SimpleTriggerFactoryBean triggerDatabaseCacheCronEvictionJob(@Qualifier("DatabaseCacheEvictionJob") JobDetail job) {
+        logger.info("Configure triggerDatabaseCacheCronEvictionJob");
+        SimpleTriggerFactoryBean trigger = new SimpleTriggerFactoryBean();
+        trigger.setJobDetail(job);
+        trigger.setRepeatInterval(Duration.ofMinutes(5).toMillis());
+        trigger.setRepeatCount(SimpleTrigger.REPEAT_INDEFINITELY);
+        return trigger;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    private void clearAllExpired() {
+        logger.info("Evicting expired entries from the database cache.");
+        applicationCacheRepository.clearAllExpired();
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/DefaultSerializationPair.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/DefaultSerializationPair.java
@@ -1,0 +1,30 @@
+package com.box.l10n.mojito.service.cache;
+
+import org.springframework.core.serializer.support.DeserializingConverter;
+import org.springframework.core.serializer.support.SerializingConverter;
+
+/**
+ * Implements a {@Link SerializationPair} using Spring's default
+ * serialization and deserialization converters.
+ *
+ * @author garion
+ */
+public class DefaultSerializationPair implements SerializationPair<Object>{
+    private final SerializingConverter serializingConverter;
+    private final DeserializingConverter deserializingConverter;
+
+    public DefaultSerializationPair() {
+        this.serializingConverter = new SerializingConverter();
+        this.deserializingConverter = new DeserializingConverter();
+    }
+
+    @Override
+    public Object read(byte[] bytes) {
+        return deserializingConverter.convert(bytes);
+    }
+
+    @Override
+    public byte[] write(Object element) {
+        return serializingConverter.convert(element);
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/SerializationPair.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/SerializationPair.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.service.cache;
+
+/**
+ * Implementing this interface enables custom serialization
+ * from a custom type to a byte array and vice versa.
+ *
+ * @author garion
+ */
+public interface SerializationPair<T> {
+    T read(byte[] bytes);
+    byte[] write(T element);
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/cache/TieredCache.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/cache/TieredCache.java
@@ -1,0 +1,109 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.google.common.base.Preconditions;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+
+/**
+ * Enables a tiered caching setup where items are stored in both caches and retrieval
+ * is done preferentially from the tier 1 cache first and then on cache miss from tier 2.
+ *
+ * Usually expected to be used with an ephemeral in-process memory cache as tier 1 and a
+ * durable/persistent tier 2 cache.
+ *
+ * @author garion
+ */
+public class TieredCache extends AbstractValueAdaptingCache {
+
+    private final String cacheName;
+    private final Cache tier1Cache;
+    private final Cache tier2Cache;
+
+    public TieredCache(String cacheName, Cache tier1Cache, @Nullable Cache tier2Cache) {
+        super(true);
+
+        Preconditions.checkNotNull(cacheName);
+        Preconditions.checkNotNull(tier1Cache);
+
+        this.cacheName = cacheName;
+        this.tier1Cache = tier1Cache;
+        this.tier2Cache = tier2Cache;
+    }
+
+    @Override
+    public String getName() {
+        return cacheName;
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return tier1Cache;
+    }
+
+    @Override
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        //noinspection unchecked
+        T cacheEntry = (T) lookup(key);
+        if (cacheEntry == null) {
+            try {
+                cacheEntry = valueLoader.call();
+                put(key, cacheEntry);
+            } catch (Throwable ex) {
+                throw new ValueRetrievalException(key, valueLoader, ex);
+            }
+        }
+
+        return cacheEntry;
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        tier1Cache.put(key, value);
+
+        if (tier2Cache != null) {
+            tier2Cache.put(key, value);
+        }
+    }
+
+    @Override
+    public void evict(Object o) {
+        tier1Cache.evict(o);
+
+        if (tier2Cache != null) {
+            tier2Cache.evict(o);
+        }
+    }
+
+    @Override
+    public void clear() {
+        tier1Cache.clear();
+
+        if (tier2Cache != null) {
+            tier2Cache.clear();
+        }
+    }
+
+    @Override
+    protected Object lookup(Object key) {
+        Object cacheHit = null;
+        ValueWrapper tier1CacheValueWrapper = tier1Cache.get(key);
+
+        if (tier1CacheValueWrapper != null) {
+            cacheHit = tier1CacheValueWrapper.get();
+        } else {
+            // In case of a tier 1 cache miss, retrieve from tier 2 and populate tier 1
+            if (tier2Cache != null) {
+                ValueWrapper tier2CacheValueWrapper = tier2Cache.get(key);
+                if (tier2CacheValueWrapper != null) {
+                    cacheHit = tier2CacheValueWrapper.get();
+                    tier1Cache.put(key, cacheHit);
+                }
+            }
+        }
+
+        return cacheHit;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/leveraging/LeveragerByContentAndRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/leveraging/LeveragerByContentAndRepository.java
@@ -6,6 +6,7 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.List;
  *
  * @author garion
  */
-@Component
+@Configurable
 public class LeveragerByContentAndRepository extends AbstractLeverager {
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MTServiceCacheConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MTServiceCacheConfiguration.java
@@ -1,0 +1,93 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Configuration for the tiered cache for the MachineTranslation service.
+ * The second tier cache (database) is optional and can be enabled/disabled.
+ * By default, the TTL is 0 (disabled).
+ *
+ * @author garion
+ */
+@Configuration
+@ConfigurationProperties(prefix = "l10n.mtservice.cache")
+public class MTServiceCacheConfiguration {
+    Database database = new Database();
+    InMemory inMemory = new InMemory();
+
+    public static class Database {
+        boolean enabled = false;
+        private boolean evictEntryOnDeserializationFailure;
+
+        @DurationUnit(ChronoUnit.SECONDS)
+        private Duration ttl = Duration.ZERO;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Duration getTtl() {
+            return ttl;
+        }
+
+        public void setTtl(Duration ttl) {
+            this.ttl = ttl;
+        }
+
+        public boolean isEvictEntryOnDeserializationFailure() {
+            return evictEntryOnDeserializationFailure;
+        }
+
+        public void setEvictEntryOnDeserializationFailure(boolean evictEntryOnDeserializationFailure) {
+            this.evictEntryOnDeserializationFailure = evictEntryOnDeserializationFailure;
+        }
+    }
+
+    public static class InMemory {
+        @DurationUnit(ChronoUnit.SECONDS)
+        private Duration ttl = Duration.ZERO;
+
+        private long maximumSize = Long.MAX_VALUE;
+
+        public long getMaximumSize() {
+            return maximumSize;
+        }
+
+        public void setMaximumSize(long maximumSize) {
+            this.maximumSize = maximumSize;
+        }
+
+        public Duration getTtl() {
+            return ttl;
+        }
+
+        public void setTtl(Duration ttl) {
+            this.ttl = ttl;
+        }
+    }
+
+    public Database getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(Database database) {
+        this.database = database;
+    }
+
+    public InMemory getInMemory() {
+        return inMemory;
+    }
+
+    public void setInMemory(InMemory inMemory) {
+        this.inMemory = inMemory;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TextUnitTranslationGroupDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TextUnitTranslationGroupDTO.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.machinetranslation;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,7 +9,7 @@ import java.util.List;
  *
  * @author garion
  */
-public class TextUnitTranslationGroupDTO {
+public class TextUnitTranslationGroupDTO implements Serializable {
     private String sourceText;
     private List<TranslationDTO> translations = new ArrayList<>();
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TranslationDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TranslationDTO.java
@@ -1,11 +1,13 @@
 package com.box.l10n.mojito.service.machinetranslation;
 
+import java.io.Serializable;
+
 /**
  * Represents an individual translation for one language for a specified source string.
  *
  * @author garion
  */
-public class TranslationDTO {
+public class TranslationDTO implements Serializable {
     private String text;
     private long matchedTextUnitId;
     private long matchedTextUnitVariantId;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TranslationsResponseDTO.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TranslationsResponseDTO.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.service.machinetranslation;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,7 +10,7 @@ import java.util.List;
  *
  * @author garion
  */
-public class TranslationsResponseDTO {
+public class TranslationsResponseDTO implements Serializable {
     private List<TextUnitTranslationGroupDTO> textUnitTranslationGroups = new ArrayList<>();
 
     public List<TextUnitTranslationGroupDTO> getTextUnitTranslations() {

--- a/webapp/src/main/resources/db/migration/V58__Add_ApplicationCache.sql
+++ b/webapp/src/main/resources/db/migration/V58__Add_ApplicationCache.sql
@@ -1,0 +1,25 @@
+-- New tables to cache application data.
+
+-- Details about a specific cache store instance
+CREATE TABLE application_cache_type (
+    id SMALLINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- Cache entries data
+CREATE TABLE application_cache (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    cache_type_id SMALLINT NOT NULL,
+    key_md5 CHAR(32) NOT NULL,
+    value LONGBLOB NULL,
+    created_date datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    expiry_date datetime NULL,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE application_cache ADD CONSTRAINT FK__APPLICATION_CACHE__CACHE_TYPE_ID FOREIGN KEY (cache_type_id) REFERENCES application_cache_type (id);
+ALTER TABLE application_cache ADD CONSTRAINT UK__APPLICATION_CACHE__CACHE_TYPE_ID__KEY_MD5 unique (cache_type_id, key_md5);
+
+-- Index used for Cache cleanup based on TTL
+CREATE INDEX I__APPLICATION_CACHE__EXPIRY_DATE ON application_cache (expiry_date);

--- a/webapp/src/test/java/com/box/l10n/mojito/CachingConfigTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/CachingConfigTest.java
@@ -6,10 +6,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+
+import static com.box.l10n.mojito.CacheType.Names.DEFAULT;
 import static org.junit.Assert.assertEquals;
 
 /**
- *
  * @author jaurambault
  */
 public class CachingConfigTest extends ServiceTestBase {
@@ -23,7 +24,7 @@ public class CachingConfigTest extends ServiceTestBase {
      */
     @After
     @Before
-    @CacheEvict("default")
+    @CacheEvict(DEFAULT)
     public void post() {
 
     }
@@ -34,9 +35,8 @@ public class CachingConfigTest extends ServiceTestBase {
         assertEquals(1, getInt());
     }
 
-    @Cacheable("default")
+    @Cacheable(DEFAULT)
     public int getInt() {
         return ++i;
     }
-
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/cache/DatabaseCacheTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/cache/DatabaseCacheTest.java
@@ -1,0 +1,218 @@
+package com.box.l10n.mojito.service.cache;
+
+import com.box.l10n.mojito.service.DBUtils;
+import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author garion
+ */
+public class DatabaseCacheTest extends ServiceTestBase {
+
+    public final String TEST_CACHE_NAME = "testCacheInDb";
+    public final String KEY = "key";
+    public final String KEY2 = "key2";
+    public final String VALUE = "value";
+    public final String VALUE2 = "value2";
+
+    public DatabaseCacheConfiguration databaseCacheConfiguration = new DatabaseCacheConfiguration();
+
+    @Autowired
+    DBUtils dbUtils;
+
+    DatabaseCache databaseCache;
+
+    @Transactional
+    @Before
+    public void setUp() {
+        if (databaseCache == null) {
+            databaseCacheConfiguration.setKeySerializationPair(new DefaultSerializationPair());
+            databaseCacheConfiguration.setValueSerializationPair(new DefaultSerializationPair());
+            databaseCache = new DatabaseCache(TEST_CACHE_NAME, databaseCacheConfiguration);
+            databaseCache.clear();
+        }
+    }
+
+    @Transactional
+    @Test
+    public void testPutGetWorksCorrectly() {
+        databaseCache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, Objects.requireNonNull(databaseCache.get(KEY)).get());
+    }
+
+    @Transactional
+    @Test
+    public void testPutNullValueWorksCorrectly() {
+        databaseCache.put(KEY, null);
+        Assertions.assertNull(databaseCache.get(KEY));
+    }
+
+    @Transactional
+    @Test
+    public void testPutLookupWorksCorrectly() {
+        databaseCache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, databaseCache.lookup(KEY));
+    }
+
+    @Transactional
+    @Test
+    public void testOverwriteEntryWorksCorrectly() {
+        databaseCache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, databaseCache.lookup(KEY));
+
+        databaseCache.put(KEY, VALUE2);
+        Assertions.assertEquals(VALUE2, databaseCache.lookup(KEY));
+    }
+
+    @Transactional
+    @Test
+    public void testPutComplexObjectWorksCorrectly() {
+        TestKey testKey = new TestKey();
+        TestValue testValue = new TestValue();
+
+        databaseCache.put(testKey, testValue);
+        Assertions.assertEquals(testValue, databaseCache.lookup(testKey));
+    }
+
+    @Transactional
+    @Test
+    public void testEvictWorksCorrectly() {
+        databaseCache.put(KEY, VALUE);
+        databaseCache.put(KEY2, VALUE2);
+        Assertions.assertEquals(VALUE, databaseCache.lookup(KEY));
+        Assertions.assertEquals(VALUE2, databaseCache.lookup(KEY2));
+
+        databaseCache.evict(KEY);
+
+        Assertions.assertNull(databaseCache.lookup(KEY));
+        Assertions.assertEquals(VALUE2, databaseCache.lookup(KEY2));
+    }
+
+    @Transactional
+    @Test
+    public void testClearWorksCorrectly() {
+        databaseCache.put(KEY, VALUE);
+        databaseCache.put(KEY2, VALUE2);
+        Assertions.assertEquals(VALUE, databaseCache.lookup(KEY));
+        Assertions.assertEquals(VALUE2, databaseCache.lookup(KEY2));
+
+        databaseCache.clear();
+
+        Assertions.assertNull(databaseCache.lookup(KEY));
+        Assertions.assertNull(databaseCache.lookup(KEY2));
+        Assertions.assertEquals(-0, ((ApplicationCacheRepository) databaseCache.getNativeCache()).findAll().size());
+    }
+
+    @Transactional
+    @Test
+    public void testEvictEntryOnDeserializationFailure() {
+        SerializationPair<Object> defaultSerializationPair = new DefaultSerializationPair();
+        SerializationPair<Object> mockSerializationPair = mock(DefaultSerializationPair.class);
+
+        when(mockSerializationPair.write(ArgumentMatchers.any())).thenReturn(defaultSerializationPair.write(VALUE));
+
+        when(mockSerializationPair.read(any())).thenThrow(new RuntimeException());
+        databaseCacheConfiguration.setValueSerializationPair(mockSerializationPair);
+
+        DatabaseCache databaseCacheWithMockedDeserializer = new DatabaseCache("databaseCacheWithMockedDeserializer", databaseCacheConfiguration);
+        databaseCacheWithMockedDeserializer.put(KEY, VALUE);
+        Assertions.assertNull(databaseCacheWithMockedDeserializer.lookup(KEY));
+    }
+
+    @Transactional
+    @Test
+    public void testExpiryDateLookup() throws InterruptedException {
+        Duration ttl = Duration.ofSeconds(2);
+        databaseCacheConfiguration.setTtl(ttl);
+        DatabaseCache databaseCacheWith1SecondTTL = new DatabaseCache("databaseCacheWith1SecondTTL", databaseCacheConfiguration);
+
+        databaseCacheWith1SecondTTL.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, databaseCacheWith1SecondTTL.lookup(KEY));
+
+        waitForCondition("wait for TTL expiry to take effect",
+                () -> databaseCacheWith1SecondTTL.lookup(KEY) == null
+        );
+    }
+
+    @Test
+    public void testExpiryBasedEviction() throws InterruptedException {
+        Duration ttl = Duration.ofMillis(1);
+        databaseCacheConfiguration.setTtl(ttl);
+        DatabaseCache databaseCacheWithAggressiveEviction = new DatabaseCache("databaseCacheWithAggressiveEviction", databaseCacheConfiguration);
+
+        // This test is only supported on MySql
+        Assume.assumeTrue(dbUtils.isMysql());
+
+        putKeyValue(databaseCacheWithAggressiveEviction, KEY, VALUE);
+
+        waitForCondition("wait for TTL expiry to take effect",
+                () -> databaseCache.lookup(KEY) == null
+        );
+    }
+
+    @Transactional
+    private void putKeyValue(
+            DatabaseCache databaseCacheWithAggressiveEviction,
+            String key,
+            String value) {
+
+        databaseCacheWithAggressiveEviction.put(key, value);
+    }
+
+    static class TestKey implements Serializable {
+        public String key = "testKey";
+        public List<String> subValues = new ArrayList<>();
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestKey testKey = (TestKey) o;
+            return com.google.common.base.Objects.equal(key, testKey.key) && com.google.common.base.Objects.equal(subValues, testKey.subValues);
+        }
+
+        @Override
+        public int hashCode() {
+            return com.google.common.base.Objects.hashCode(key, subValues);
+        }
+    }
+
+    static class TestValue implements Serializable {
+        public String value;
+        public List<String> subValues = new ArrayList<>();
+
+        public TestValue() {
+            subValues.add("1");
+            subValues.add("2");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestValue testValue = (TestValue) o;
+            return com.google.common.base.Objects.equal(value, testValue.value) && com.google.common.base.Objects.equal(subValues, testValue.subValues);
+        }
+
+        @Override
+        public int hashCode() {
+            return com.google.common.base.Objects.hashCode(value, subValues);
+        }
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/cache/TieredCacheTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/cache/TieredCacheTest.java
@@ -1,0 +1,124 @@
+package com.box.l10n.mojito.service.cache;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+/**
+ * @author garion
+ */
+public class TieredCacheTest {
+    public final String TEST_CACHE_NAME = "tieredCache";
+    public final String KEY = "key";
+    public final String KEY2 = "key2";
+    public final String VALUE = "value";
+    public final String VALUE2 = "value2";
+
+    @Test
+    public void nullTier2CacheWorks() {
+        ConcurrentMapCache t1Cache = new ConcurrentMapCache("t1");
+
+        TieredCache tieredCache = new TieredCache(TEST_CACHE_NAME, t1Cache, null);
+
+        tieredCache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, tieredCache.get(KEY).get());
+        Assertions.assertEquals(VALUE, t1Cache.get(KEY).get());
+
+        tieredCache.put(KEY, VALUE2);
+        Assertions.assertEquals(VALUE2, tieredCache.get(KEY).get());
+        Assertions.assertEquals(VALUE2, t1Cache.get(KEY).get());
+        Assertions.assertEquals(1, t1Cache.getNativeCache().size());
+
+        tieredCache.put(KEY2, VALUE2);
+        Assertions.assertEquals(VALUE2, tieredCache.get(KEY2).get());
+        Assertions.assertEquals(VALUE2, t1Cache.get(KEY2).get());
+        Assertions.assertEquals(2, t1Cache.getNativeCache().size());
+
+        tieredCache.evict(KEY2);
+        Assertions.assertNull(t1Cache.get(KEY2));
+        Assertions.assertEquals(1, t1Cache.getNativeCache().size());
+
+        tieredCache.clear();
+        Assertions.assertNull(t1Cache.get(KEY));
+        Assertions.assertNull(t1Cache.get(KEY2));
+        Assertions.assertEquals(0, t1Cache.getNativeCache().size());
+    }
+
+    @Test
+    public void tieredCacheWorks() {
+        ConcurrentMapCache t1Cache = new ConcurrentMapCache("t1");
+        ConcurrentMapCache t2Cache = new ConcurrentMapCache("t2");
+
+        TieredCache tieredCache = new TieredCache(TEST_CACHE_NAME, t1Cache, t2Cache);
+
+        tieredCache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, tieredCache.get(KEY).get());
+        Assertions.assertEquals(VALUE, t1Cache.get(KEY).get());
+        Assertions.assertEquals(VALUE, t2Cache.get(KEY).get());
+
+        tieredCache.put(KEY, VALUE2);
+        Assertions.assertEquals(VALUE2, tieredCache.get(KEY).get());
+        Assertions.assertEquals(VALUE2, t1Cache.get(KEY).get());
+        Assertions.assertEquals(VALUE2, t2Cache.get(KEY).get());
+        Assertions.assertEquals(1, t1Cache.getNativeCache().size());
+        Assertions.assertEquals(1, t2Cache.getNativeCache().size());
+
+        tieredCache.put(KEY2, VALUE2);
+        Assertions.assertEquals(VALUE2, tieredCache.get(KEY2).get());
+        Assertions.assertEquals(VALUE2, t1Cache.get(KEY2).get());
+        Assertions.assertEquals(VALUE2, t2Cache.get(KEY2).get());
+        Assertions.assertEquals(2, t1Cache.getNativeCache().size());
+        Assertions.assertEquals(2, t2Cache.getNativeCache().size());
+
+        tieredCache.evict(KEY2);
+        Assertions.assertNull(t1Cache.get(KEY2));
+        Assertions.assertNull(t2Cache.get(KEY2));
+        Assertions.assertEquals(1, t1Cache.getNativeCache().size());
+        Assertions.assertEquals(1, t2Cache.getNativeCache().size());
+
+        tieredCache.clear();
+        Assertions.assertNull(t1Cache.get(KEY));
+        Assertions.assertNull(t1Cache.get(KEY2));
+        Assertions.assertNull(t2Cache.get(KEY));
+        Assertions.assertNull(t2Cache.get(KEY2));
+        Assertions.assertEquals(0, t1Cache.getNativeCache().size());
+    }
+
+    @Test
+    public void tieredCacheTier1UpdateWorks() {
+        ConcurrentMapCache t1Cache = new ConcurrentMapCache("t1");
+        ConcurrentMapCache t2Cache = new ConcurrentMapCache("t2");
+
+        TieredCache tieredCache = new TieredCache(TEST_CACHE_NAME, t1Cache, t2Cache);
+
+        t1Cache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, tieredCache.get(KEY).get());
+        Assertions.assertEquals(VALUE, t1Cache.get(KEY).get());
+        Assertions.assertNull(t2Cache.get(KEY));
+    }
+
+    @Test
+    public void tier1CacheMissGetsPopulatedOnGet() {
+        ConcurrentMapCache t1Cache = new ConcurrentMapCache("t1");
+        ConcurrentMapCache t2Cache = new ConcurrentMapCache("t2");
+
+        TieredCache tieredCache = new TieredCache(TEST_CACHE_NAME, t1Cache, t2Cache);
+
+        t2Cache.put(KEY, VALUE);
+        Assertions.assertEquals(VALUE, tieredCache.get(KEY).get());
+        Assertions.assertEquals(VALUE, t1Cache.get(KEY).get());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void missingCacheNameThrows() {
+        ConcurrentMapCache t1Cache = new ConcurrentMapCache("t1");
+        ConcurrentMapCache t2Cache = new ConcurrentMapCache("t2");
+        new TieredCache(null, t1Cache, t2Cache);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void missingTier1CacheThrows() {
+        ConcurrentMapCache t2Cache = new ConcurrentMapCache("t2");
+        new TieredCache(TEST_CACHE_NAME, null, t2Cache);
+    }
+}


### PR DESCRIPTION
Add a JCache compatible cache that stores the entries in the Mojito
database.
Entries can have a TTL associated with them.
Multiple cache types can be stored in the database, in the same data
structure.