### PR TITLE
Add assetMapping option to the PushCommand

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 8.0.292

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommandHelper.java
@@ -329,4 +329,13 @@ public class CommandHelper {
         return assetContent;
     }
 
+    public String getMappedSourcePath(Map<String, String> assetMapping, String sourcePath) {
+        if (assetMapping != null && assetMapping.get(sourcePath) != null) {
+            String mapping = assetMapping.get(sourcePath);
+            logger.debug("Use asset mapping from: {} to {}", sourcePath, mapping);
+            sourcePath = mapping;
+        }
+        return sourcePath;
+    }
+
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PullCommand.java
@@ -263,13 +263,7 @@ public class PullCommand extends Command {
     LocalizedAssetBody getLocalizedAsset(Repository repository, FileMatch sourceFileMatch, RepositoryLocale repositoryLocale, String outputBcp47tag, List<String> filterOptions) throws CommandException {
         consoleWriter.a(" - Processing locale: ").fg(Color.CYAN).a(repositoryLocale.getLocale().getBcp47Tag()).print();
 
-        String sourcePath = sourceFileMatch.getSourcePath();
-
-        if (assetMapping != null && assetMapping.get(sourcePath) != null) {
-            String mapping = assetMapping.get(sourcePath);
-            logger.debug("Use asset mapping from: {} to {}", sourcePath, mapping);
-            sourcePath = mapping;
-        }
+        String sourcePath = commandHelper.getMappedSourcePath(assetMapping, sourceFileMatch.getSourcePath());
 
         Asset assetByPathAndRepositoryId;
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -65,6 +66,9 @@ public class PushCommand extends Command {
     @Parameter(names = Param.PUSH_TYPE_LONG, arity = 1, required = false, description = Param.PUSH_TYPE_DESCRIPTION)
     PushService.PushType pushType = PushService.PushType.NORMAL;
 
+    @Parameter(names = {"--asset-mapping", "-am"}, required = false, description = "Asset mapping, format: \"local1:remote1;local2:remote2\"", converter = AssetMappingConverter.class)
+    Map<String, String> assetMapping;
+
     @Autowired
     RepositoryClient repositoryClient;
 
@@ -93,11 +97,10 @@ public class PushCommand extends Command {
                     String sourcePath = sourceFileMatch.getSourcePath();
 
                     String assetContent = commandHelper.getFileContentWithXcodePatch(sourceFileMatch);
-
                     SourceAsset sourceAsset = new SourceAsset();
                     sourceAsset.setBranch(branchName);
                     sourceAsset.setBranchCreatedByUsername(branchCreatedBy);
-                    sourceAsset.setPath(sourcePath);
+                    sourceAsset.setPath(commandHelper.getMappedSourcePath(assetMapping, sourcePath));
                     sourceAsset.setContent(assetContent);
                     sourceAsset.setExtractedContent(false);
                     sourceAsset.setRepositoryId(repository.getId());


### PR DESCRIPTION
Add the same option than the one available in the PullCommand. This allows to push a local file with a name different from the asset path in Mojito