### PR TITLE
Fix for JDK8 changes breaking backwards compatibility

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/App.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/App.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.cli;
 
 import com.box.l10n.mojito.cli.command.L10nJCommander;
 import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner;
@@ -29,6 +30,9 @@ public class App implements CommandLineRunner {
      * @param args
      */
     public static void main(String[] args) {
+
+        XmlParsingConfiguration.disableXPathLimits();
+
         new SpringApplicationBuilder(App.class)
                 .web(WebApplicationType.NONE)
                 .bannerMode(Banner.Mode.OFF)

--- a/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
@@ -17,6 +17,7 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.test.IOTestBase;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import com.google.common.io.Files;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -91,6 +92,8 @@ public class CLITestBase extends IOTestBase {
     public void setPort() {
         logger.debug("Saving port number = {}", port);
         resttemplateConfig.setPort(port);
+
+        XmlParsingConfiguration.disableXPathLimits();
     }
 
     public void resetHost() {

--- a/common/src/main/java/com/box/l10n/mojito/xml/XmlParsingConfiguration.java
+++ b/common/src/main/java/com/box/l10n/mojito/xml/XmlParsingConfiguration.java
@@ -1,0 +1,19 @@
+package com.box.l10n.mojito.xml;
+
+/**
+ * Utility class to configure settings for XML and XPath operations.
+ *
+ * @author garion
+ */
+public class XmlParsingConfiguration {
+
+    /**
+     * Disables XML parsing limits introduced by JDK 8u331 in order to maintain backwards compatibility with
+     * Okapi dependencies. See: https://www.oracle.com/java/technologies/javase/8u331-relnotes.html
+     */
+    public static void disableXPathLimits() {
+        System.setProperty("jdk.xml.xpathExprGrpLimit", "0");
+        System.setProperty("jdk.xml.xpathTotalOpLimit", "0");
+        System.setProperty("jdk.xml.xpathExprOpLimit", "0");
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/Application.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/Application.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito;
 
 import com.box.l10n.mojito.entity.BaseEntity;
 import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -46,6 +47,8 @@ public class Application {
     boolean shouldIndentJacksonOutput;
 
     public static void main(String[] args) throws IOException {
+
+        XmlParsingConfiguration.disableXPathLimits();
 
         SpringApplication springApplication = new SpringApplication(Application.class);
         springApplication.addListeners(new ApplicationPidFileWriter("application.pid"));

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/WSTestBase.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/WSTestBase.java
@@ -8,6 +8,7 @@ import com.box.l10n.mojito.rest.client.exception.LocaleNotFoundException;
 import com.box.l10n.mojito.rest.entity.RepositoryLocale;
 import com.box.l10n.mojito.rest.resttemplate.AuthenticatedRestTemplate;
 import com.box.l10n.mojito.rest.resttemplate.ResttemplateConfig;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -61,6 +62,8 @@ public class WSTestBase {
     public void setPort() {
         logger.debug("Saving port number = {}", port);
         resttemplateConfig.setPort(port);
+
+        XmlParsingConfiguration.disableXPathLimits();
     }
 
     /**


### PR DESCRIPTION
The latest JDK8 release introduced additional XML parsing limitations
that break a lot of the existing code and unit tests.
https://www.oracle.com/java/technologies/javase/8u331-relnotes.html
This change overwriddes the XML parsing limitations added.