### PR TITLE
Fix tests by fixing Java version

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -10,7 +10,8 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8.0.292
       - name: Maven install, test skipped
         run: mvn install -DskipTests
       - name: Maven test


### PR DESCRIPTION
New version of Java adds limit on XML processing and this is causing issue with Okapi ITS filter.

For now, fix the Java version until we find a better solution with Okapi.

2022-04-21T14:21:58.8979585Z net.sf.okapi.common.exceptions.OkapiException: javax.xml.xpath.XPathExpressionException: javax.xml.transform.TransformerException: JAXP0801002: the compiler encountered an XPath expression containing '101' operators that exceeds the '100' limit set by 'FEATURE_SECURE_PROCESSING'.
2022-04-21T14:21:58.8980885Z at org.w3c.its.ITSEngine.processLocalRules(ITSEngine.java:2443)
2022-04-21T14:21:58.8981889Z at org.w3c.its.ITSEngine.applyRules(ITSEngine.java:1257)
2022-04-21T14:21:58.8982460Z at net.sf.okapi.filters.its.ITSFilter.applyRules(ITSFilter.java:217)
2022-04-21T14:21:58.8982975Z at net.sf.okapi.filters.its.ITSFilter.open(ITSFilter.java:256)
2022-04-21T14:21:58.8983466Z at net.sf.okapi.filters.its.ITSFilter.open(ITSFilter.java:200)