### PR TITLE
Support pull with REMOVE_TRANSLATED option fro PO files that contain …

### DIFF
--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target/fr/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target/fr/LC_MESSAGES/messages.po
@@ -23,7 +23,7 @@ msgstr ""
 msgctxt "15_min_duration"
 msgid "15 min"
 msgstr "15 min"
-  
+
 #. File lock dialog duration
 #: file.js:6
 msgctxt "1_day_duration"
@@ -41,3 +41,4 @@ msgstr "1 heure"
 msgctxt "1_month_duration"
 msgid "1 month"
 msgstr "1 mois"
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target/ja/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target/ja/LC_MESSAGES/messages.po
@@ -23,7 +23,7 @@ msgstr ""
 msgctxt "15_min_duration"
 msgid "15 min"
 msgstr "15分"
-  
+
 #. File lock dialog duration
 #: file.js:6
 msgctxt "1_day_duration"
@@ -41,3 +41,4 @@ msgstr "1時間"
 msgctxt "1_month_duration"
 msgid "1 month"
 msgstr "1か月"
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target_modified/fr/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target_modified/fr/LC_MESSAGES/messages.po
@@ -35,4 +35,4 @@ msgstr "1 heure"
 msgctxt "1_month_duration"
 msgid "1 month"
 msgstr "1 mois"
- 
+   

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target_modified/ja/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/expected/target_modified/ja/LC_MESSAGES/messages.po
@@ -35,4 +35,4 @@ msgstr "1時間"
 msgctxt "1_month_duration"
 msgid "1 month"
 msgstr "1か月"
- 
+   

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/input/source/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/removeUntranslated/input/source/LC_MESSAGES/messages.pot
@@ -17,7 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
- 
 
 #: file.js:2
 msgctxt "100_character_description_"
@@ -29,12 +28,18 @@ msgstr ""
 msgctxt "15_min_duration"
 msgid "15 min"
 msgstr ""
-  
+
 #. File lock dialog duration
 #: file.js:6
 msgctxt "1_day_duration"
 msgid "1 day"
 msgstr ""
+
+#. Test remove untranslated
+#: file.js:25
+msgctxt "test_remove_untranslated"
+msgid "Test remove"
+msgstr "untranslated"
 
 #. File lock dialog duration
 #: file.js:8
@@ -47,3 +52,11 @@ msgstr ""
 msgctxt "1_month_duration"
 msgid "1 month"
 msgstr ""
+
+#. Test remove untranslated
+#: file.js:20
+msgctxt "test_remove_plural_untranslated"
+msgid "Test remove plural"
+msgid_plural "Test remove plurals"
+msgstr[0] "untranslated"
+msgstr[1] "untranslated"

--- a/common/src/test/java/com/box/l10n/mojito/okapi/filters/POFilterTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/okapi/filters/POFilterTest.java
@@ -1,12 +1,15 @@
 package com.box.l10n.mojito.okapi.filters;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
- *
  * @author jeanaurambault
  */
 public class POFilterTest {
@@ -38,11 +41,11 @@ public class POFilterTest {
 
         POFilter poFilter = new POFilter();
         List<String> usages = new ArrayList<>(poFilter.getUsagesFromSkeleton(skeleton));
-        
+
         assertEquals("core/logic/week_in_review_email_logic.py:49", usages.get(0));
         assertEquals("core/logic/week_in_review_email_logic.py:72", usages.get(1));
     }
-    
+
     @Test
     public void getUsagesFromSkeletonNone() {
         String skeleton = "#. Comments\n"
@@ -57,4 +60,86 @@ public class POFilterTest {
         assertEquals(0, usages.size());
     }
 
+
+    @Test
+    public void removeUntranslatedNone() {
+        String poFile = "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:49\n" +
+                "#: core/logic/week_in_review_email_logic.py:72\n" +
+                "msgid \"repin\"\n" +
+                "msgid_plural \"repins\"\n" +
+                "msgstr[0] \"repin-ru\"\n" +
+                "msgstr[1] \"repins-ru-1\"\n" +
+                "msgstr[2] \"repins-ru-2\"";
+        assertEquals(poFile, POFilter.removeUntranslated(poFile));
+    }
+
+    @Test
+    public void removeUntranslatedPlural() {
+        String poFile = "#. Comments\n"
+                + "#: core/logic/week_in_review_email_logic.py:49\n"
+                + "#: core/logic/week_in_review_email_logic.py:72\n"
+                + "msgid \"repin\"\n"
+                + "msgid_plural \"repins\"\n"
+                + "msgstr[0] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n"
+                + "msgstr[1] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n"
+                + "msgstr[2] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"";
+
+        assertEquals("", POFilter.removeUntranslated(poFile));
+    }
+
+    @Test
+    public void removeUntranslatedMixed() {
+        String poFile = "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:39\n" +
+                "msgid \"Hello\"\n" +
+                "msgstr \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n" +
+                "\n" +
+                "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:39\n" +
+                "msgid \"Bye\"\n" +
+                "msgstr \"Au revoir\"\n" +
+                "\n" +
+                "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:49\n" +
+                "msgid \"repin\"\n" +
+                "msgid_plural \"repins\"\n" +
+                "msgstr[0] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n" +
+                "msgstr[1] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n" +
+                "msgstr[2] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"";
+
+        assertEquals("#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:39\n" +
+                "msgid \"Bye\"\n" +
+                "msgstr \"Au revoir\"\n", POFilter.removeUntranslated(poFile));
+    }
+
+    @Test
+    public void removeUntranslatedMixedNoLine() {
+        String poFile = "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:39\n" +
+                "msgid \"Hello\"\n" +
+                "msgstr \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n" +
+                "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:39\n" +
+                "msgid \"Bye\"\n" +
+                "msgstr \"Au revoir\"\n" +
+                "#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:49\n" +
+                "msgid \"repin\"\n" +
+                "msgid_plural \"repins\"\n" +
+                "msgstr[0] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n" +
+                "msgstr[1] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"\n" +
+                "msgstr[2] \"" + RemoveUntranslatedStrategy.UNTRANSLATED_PLACEHOLDER + "\"";
+
+        assertEquals("#. Comments\n" +
+                "#: core/logic/week_in_review_email_logic.py:39\n" +
+                "msgid \"Bye\"\n" +
+                "msgstr \"Au revoir\"", POFilter.removeUntranslated(poFile));
+    }
+
+    @Test
+    public void removeUntranslatedEOL() {
+        Stream.of("", "\n", "#. Comments", "#. Comments\n").forEach(s -> assertEquals(s, POFilter.removeUntranslated(s)));
+    }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/TMServiceTest.java
@@ -1256,6 +1256,7 @@ public class TMServiceTest extends ServiceTestBase {
      * This test is to test AndroidStrings with REMOVE_UNTRANSLATED inheritance mode with a single item
      * We need a special case in {@link com.box.l10n.mojito.okapi.TranslateStep} to keep the part of the skeleton that
      * contains the begining of the document when skipping the text unit.
+     *
      * @throws Exception
      */
     @Test
@@ -1828,7 +1829,7 @@ public class TMServiceTest extends ServiceTestBase {
                 + "\"MIME-Version: 1.0\\n\"\n"
                 + "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"\n"
                 + "\"Content-Type: text/plain; charset=utf-8\\n\"\n"
-                + "\"Content-Transfer-Encoding: 8bit\\n\"\n"
+                + "\"Content-Transfer-Encoding: 8bit\\n\"\n\n\n"
                 + "#. Comments\n"
                 + "#: core/logic/week_in_review_email_logic.py:49\n"
                 + "msgid \"repin\"\n"
@@ -1839,18 +1840,20 @@ public class TMServiceTest extends ServiceTestBase {
                 + "msgstr \"\"\n";
 
 
-        String expectedLocalizedAsset = "msgid \"\"\n"
-                + "msgstr \"\"\n"
-                + "\"Project-Id-Version: PACKAGE VERSION\\n\"\n"
-                + "\"Report-Msgid-Bugs-To: \\n\"\n"
-                + "\"POT-Creation-Date: 2017-09-15 11:53-0500\\n\"\n"
-                + "\"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n\"\n"
-                + "\"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n\"\n"
-                + "\"Language-Team: LANGUAGE <LL@li.org>\\n\"\n"
-                + "\"MIME-Version: 1.0\\n\"\n"
-                + "\"Plural-Forms: nplurals=1; plural=0;\\n\"\n"
-                + "\"Content-Type: text/plain; charset=utf-8\\n\"\n"
-                + "\"Content-Transfer-Encoding: 8bit\\n\"\n";
+        String expectedLocalizedAsset = "msgid \"\"\n" +
+                "msgstr \"\"\n" +
+                "\"Project-Id-Version: PACKAGE VERSION\\n\"\n" +
+                "\"Report-Msgid-Bugs-To: \\n\"\n" +
+                "\"POT-Creation-Date: 2017-09-15 11:53-0500\\n\"\n" +
+                "\"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n\"\n" +
+                "\"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n\"\n" +
+                "\"Language-Team: LANGUAGE <LL@li.org>\\n\"\n" +
+                "\"MIME-Version: 1.0\\n\"\n" +
+                "\"Plural-Forms: nplurals=1; plural=0;\\n\"\n" +
+                "\"Content-Type: text/plain; charset=utf-8\\n\"\n" +
+                "\"Content-Transfer-Encoding: 8bit\\n\"\n" +
+                "\n" +
+                "\n";
 
         asset = assetService.createAssetWithContent(repo.getId(), "messages.pot", assetContent);
         asset = assetRepository.findById(asset.getId()).orElse(null);
@@ -1866,7 +1869,7 @@ public class TMServiceTest extends ServiceTestBase {
         assetResult.get();
 
         String localizedAsset = tmService.generateLocalized(asset, assetContent, repoLocale, "ja-JP", null, null, Status.ALL, InheritanceMode.REMOVE_UNTRANSLATED);
-        logger.debug("localized=\n{}", localizedAsset);
+        logger.debug("localized=\n{}\nEOL", localizedAsset);
         assertEquals(expectedLocalizedAsset, localizedAsset);
 
         String forImport = "msgid \"\"\n"
@@ -1880,16 +1883,18 @@ public class TMServiceTest extends ServiceTestBase {
                 + "\"MIME-Version: 1.0\\n\"\n"
                 + "\"Plural-Forms: nplurals=1; plural=0;\\n\"\n"
                 + "\"Content-Type: text/plain; charset=utf-8\\n\"\n"
-                + "\"Content-Transfer-Encoding: 8bit\\n\"\n"
+                + "\"Content-Transfer-Encoding: 8bit\\n\"\n\n\n"
                 + "#. Comments\n"
                 + "#: core/logic/week_in_review_email_logic.py:49\n"
                 + "msgid \"repin\"\n"
                 + "msgstr \"repin-jp\"\n";
 
+        logger.debug("formimport=\n{}", forImport);
+
         tmService.importLocalizedAssetAsync(assetId, forImport, repoLocale.getLocale().getId(), StatusForEqualTarget.TRANSLATION_NEEDED, null, null).get();
 
         localizedAsset = tmService.generateLocalized(asset, assetContent, repoLocale, "ja-JP", null, null, Status.ALL, InheritanceMode.REMOVE_UNTRANSLATED);
-        logger.debug("localized after import=\n{}", localizedAsset);
+        logger.info("localized after import=\n{}", localizedAsset);
         assertEquals(forImport, localizedAsset);
     }
 


### PR DESCRIPTION
…plural forms

Previously only singular text unit would be removed from the output. This is using the placeholder and post processing system to remove both singular and plural text units from the PO file.