### PR TITLE
Add placeholder protection

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/CustomModelType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/CustomModelType.java
@@ -1,0 +1,21 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+/**
+ * Defines a list of custom domain trained machine translation engines that can
+ * be used with the corresponding MT APIs.
+ *
+ * @author garion
+ */
+public enum CustomModelType {
+    NONE("");
+
+    private final String value;
+
+    CustomModelType(String customModel) {
+        value = customModel;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MachineTranslationConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MachineTranslationConfiguration.java
@@ -25,15 +25,19 @@ public class MachineTranslationConfiguration {
     static class MicrosoftEngineConfiguration {
 
         final MicrosoftMTEngineConfiguration microsoftMTEngineConfiguration;
+        final PlaceholderEncoder placeholderEncoder;
 
-        public MicrosoftEngineConfiguration(MicrosoftMTEngineConfiguration microsoftMTEngineConfiguration) {
+        public MicrosoftEngineConfiguration(
+                MicrosoftMTEngineConfiguration microsoftMTEngineConfiguration,
+                PlaceholderEncoder placeholderEncoder) {
             this.microsoftMTEngineConfiguration = microsoftMTEngineConfiguration;
+            this.placeholderEncoder = placeholderEncoder;
         }
 
         @Bean
         public MicrosoftMTEngine microsoftMTEngine() {
             logger.info("Configure microsoftMTEngine");
-            return new MicrosoftMTEngine(microsoftMTEngineConfiguration);
+            return new MicrosoftMTEngine(microsoftMTEngineConfiguration, placeholderEncoder);
         }
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MachineTranslationEngine.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MachineTranslationEngine.java
@@ -17,6 +17,7 @@ public interface MachineTranslationEngine {
             List<String> textSources,
             String sourceBcp47Tag,
             List<String> targetBcp47Tags,
-            String sourceMimeType,
-            String customModel);
+            TextType sourceTextType,
+            String customModel,
+            boolean isFunctionalProtectionEnabled);
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MachineTranslationService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/MachineTranslationService.java
@@ -38,8 +38,8 @@ public class MachineTranslationService {
 
     final TranslationMerger translationMerger;
 
-    public MachineTranslationService(
-            MachineTranslationEngine machineTranslationEngine, TranslationMerger translationMerger) {
+    public MachineTranslationService(MachineTranslationEngine machineTranslationEngine,
+                                     TranslationMerger translationMerger) {
         this.machineTranslationEngine = machineTranslationEngine;
         this.translationMerger = translationMerger;
     }
@@ -112,22 +112,25 @@ public class MachineTranslationService {
     @Cacheable(MACHINE_TRANSLATION)
     ImmutableMap<String, ImmutableList<TranslationDTO>> getMachineTranslationBySourceText(String sourceBcp47Tag, List<String> targetBcp47Tags, List<String> textSources, Boolean skipFunctionalProtection) {
 
+        boolean isFunctionalProtectionEnabled = true;
+
+        if (skipFunctionalProtection != null && skipFunctionalProtection) {
+            logger.debug("Skipping placeholder protection/encoding!");
+            isFunctionalProtectionEnabled = false;
+        }
+
         ImmutableMap<String, ImmutableList<TranslationDTO>> result;
 
         if (textSources.isEmpty()) {
             result = ImmutableMap.of();
         } else {
-            // TODO(garion): Implement functional protection / placeholder processing
-            if (skipFunctionalProtection != null && skipFunctionalProtection) {
-                logger.debug("function / placeholder protection");
-            }
-
             result = machineTranslationEngine.getTranslationsBySourceText(
                     textSources,
                     sourceBcp47Tag,
                     targetBcp47Tags,
-                    null,
-                    null);
+                    TextType.HTML,
+                    CustomModelType.NONE.getValue(),
+                    isFunctionalProtectionEnabled);
         }
 
         return result;

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/NoOpEngine.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/NoOpEngine.java
@@ -25,7 +25,13 @@ public class NoOpEngine implements MachineTranslationEngine {
     }
 
     @Override
-    public ImmutableMap<String, ImmutableList<TranslationDTO>> getTranslationsBySourceText(List<String> textSources, String sourceBcp47Tag, List<String> targetBcp47Tags, String sourceMimeType, String customModel) {
+    public ImmutableMap<String, ImmutableList<TranslationDTO>> getTranslationsBySourceText(
+            List<String> textSources,
+            String sourceBcp47Tag,
+            List<String> targetBcp47Tags,
+            TextType sourceTextType,
+            String customModel,
+            boolean isFunctionalProtectionEnabled) {
         logger.debug("NoOpEngine translate() operation called.");
 
         return textSources.stream()

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderEncoder.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderEncoder.java
@@ -1,0 +1,60 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Encodes placeholders to ensure that they will be protected during the (machine) translation process.
+ * The placeholders patterns are defined in {@Link PlaceholderPatternType}.
+ * Any string matching that pattern will get wrapped into a <span translate="no">pattern</span> block.
+ *
+ * @author garion
+ */
+@Component
+public class PlaceholderEncoder {
+
+    public Pattern getPlaceholderPattern() {
+        String placeholderRegex = Arrays.stream(PlaceholderPatternType.values())
+                .map(PlaceholderPatternType::getValue)
+                .collect(Collectors.joining("|"));
+
+        return Pattern.compile(placeholderRegex);
+    }
+
+    public List<String> encode(List<String> textSources) {
+        return textSources.stream()
+                .map(this::encode)
+                .collect(Collectors.toList());
+    }
+
+    public String encode(String textSource) {
+        Matcher matcher = getPlaceholderPattern().matcher(textSource);
+
+        StringBuffer stringBuffer = new StringBuffer();
+        while (matcher.find()) {
+            String match = matcher.group();
+            matcher.appendReplacement(
+                    stringBuffer,
+                    Matcher.quoteReplacement("<span translate=\"no\">" + match + "</span>"));
+        }
+        matcher.appendTail(stringBuffer);
+
+        return stringBuffer.toString();
+    }
+
+    public List<String> decode(List<String> textSources) {
+        return textSources.stream()
+                .map(this::decode)
+                .collect(Collectors.toList());
+    }
+
+    public String decode(String textSource) {
+        // Note: ensure that matching is enabled across lines as well by using (?s), for content containing end lines.
+        return textSource.replaceAll("<span translate=\"no\">(?s)(.*?)</span>", "$1");
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderPatternType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderPatternType.java
@@ -1,0 +1,31 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+/**
+ * List of regex patterns to identify common placeholder patterns.
+ * Note: the order is important as earlier defined patterns will take precedence over latter-defined ones.
+ *
+ * @author garion
+ */
+public enum PlaceholderPatternType {
+    GETTEXT_STRING("%s"),
+    IOS_STRING("%@"),
+    GETTEXT_NUMBER("%,d"),
+    MESSAGE_FORMAT_EMPTY("\\{\\}"),
+    MESSAGE_FORMAT_DOUBLE_EMPTY("\\{\\{\\}\\}"),
+    GETTEXT_POSITIONAL_NUMBER("%(\\d*?)d"),
+    GETTEXT_NAMED("([$%])\\(+(.*?)\\)+(s|d)"),
+    MESSAGE_FORMAT_NAMED("\\{\\{?[A-Za-z0-9_ .\\[\\]]+?\\}\\}?"),
+    IOS_POSITIONAL("%(\\d+)\\$(@|i|s)"),
+    IOS_FLOAT("%\\.(\\d*)f"),
+    IOS_DOUBLE("%(\\d+)\\$,?d");
+
+    private final String regexValue;
+
+    PlaceholderPatternType(String regexPattern) {
+        this.regexValue = regexPattern;
+    }
+
+    public String getValue() {
+        return regexValue;
+    }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TextType.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/machinetranslation/TextType.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+/**
+ * Custom types for the machine translation operations.
+ * Most engines support separate plain text and html mime types.
+ *
+ * @author garion
+ */
+public enum TextType {
+    TEXT,
+    HTML
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderEncoderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderEncoderTest.java
@@ -1,0 +1,233 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class PlaceholderEncoderTest {
+
+    PlaceholderEncoder placeholderEncoder = new PlaceholderEncoder();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "  \n\t ",
+            "test",
+            "<<>>",
+            "<<",
+            "{}",
+            "{{}}",
+            "&lt;",
+            "{{namedPlaceholder}}",
+            "<b>bolded</b>",
+            "%1s",
+            "%@",
+            "<tag/>",
+            "<tag1>text</tag1>",
+            "<tag1>text \t\n text2</tag1>",
+            "<tag2",
+            "<tag1><tag2></tag1></tag2>"
+    })
+    void testEncodeDecodeSameAsOriginal(String text) {
+        assertEquals(text, placeholderEncoder.decode(placeholderEncoder.encode(text)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "<span translate=\"no\"></span>",
+            "<span translate=\"no\">    </span>",
+            "<span translate=\"no\">  text \n \t text2 </span>",
+            "<span translate=\"no\">some translation</span>"
+    })
+    void testDecodeTranslationSpanRemoved(String text) {
+        String spanText = "<span translate=\"no\">" + text + "</span>";
+        assertEquals(text, placeholderEncoder.decode(spanText));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{}",
+            "{{}}",
+            "{param}",
+            "{{param}}",
+            "%s",
+            "%@",
+            "%d",
+            "%,d",
+            "$(string)s",
+            "%1$@",
+            "%1$i",
+            "%1$s",
+            "%.2f",
+            "%1$d"
+    })
+    void testEncode(String text) {
+        String spanText = "<span translate=\"no\">" + text + "</span>";
+        assertEquals(spanText, placeholderEncoder.encode(text));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "<span translate=\"no\">text</span>",
+            "<span translate=\"no\">{{}}</span>",
+            "<span translate=\"no\">{param}</span>",
+            "<span translate=\"no\">{{param}}</span>",
+            "<span translate=\"no\">%s</span>",
+            "<span translate=\"no\">%@</span>",
+            "<span translate=\"no\">%d</span>",
+            "<span translate=\"no\">%,d</span>",
+            "<span translate=\"no\">$(string)s</span>",
+            "<span translate=\"no\">%1$@</span>",
+            "<span translate=\"no\">%1$i</span>",
+            "<span translate=\"no\">%1$i</span>",
+            "<span translate=\"no\">1$s</span>",
+            "<span translate=\"no\">%.2f</span>",
+            "<span translate=\"no\">%1$d</span>"
+    })
+    void testDecode(String text) {
+        assertEquals(
+                text.replace("<span translate=\"no\">", "").replaceAll("</span>", ""),
+                placeholderEncoder.decode(text));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // %s
+            "%s",
+
+            // %@
+            "%@",
+
+            // %,d
+            "%,d",
+
+            // "\\{\\}",
+            "{}",
+
+            // \{\{\}\}
+            "{{}}",
+
+            // %(\d*?)d
+            "%d",
+            "%d",
+            "%12d",
+
+            // \$\(?(.*?)\)?(s|d)
+            "$(string)s",
+            "$(_string)s",
+            "$(count)d",
+
+            // \{\{?[A-Za-z0-9_ .\[\]]+?\}\}?
+            "{name}",
+            "{{0}}",
+            "{{ 0 }}",
+            "{users[2].name}",
+            "{{ curly Brackets }}",
+            "{{curly_Brackets}}",
+            "{{curly.Brackets}}",
+
+            // %(\d+)\$(@|i|s)
+            "%1$@",
+            "%20$@",
+            "%4$i",
+            "%20$i",
+            "%2$s",
+            "%20$s",
+
+            // %\.(\d*)f
+            "%.f",
+            "%.2f",
+
+            // %(\d+)\$,?d
+            "%1$d",
+            "%1$,d",
+    })
+    public void testUnifiedPattern(String sourceString) {
+        Matcher matcher = placeholderEncoder.getPlaceholderPattern().matcher(sourceString);
+        Assertions.assertTrue(matcher.matches());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%(tes",
+            "%d s",
+            "%d and %d images",
+            "%(s",
+            "% in 30 days"
+    })
+    public void testDontMatchFullText(String sourceString) {
+        Matcher matcher = placeholderEncoder.getPlaceholderPattern().matcher(sourceString);
+        Assertions.assertFalse(matcher.matches());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getSourceStringAndExpectedSingleMatch")
+    void testSubstringMatch(String sourceString, String expectedFirstMatch, Integer expectedMatchCount) {
+        Matcher matcher = placeholderEncoder.getPlaceholderPattern().matcher(sourceString);
+
+        if (expectedMatchCount != null && expectedMatchCount > 0) {
+            Assertions.assertTrue(matcher.find());
+            Assertions.assertEquals(expectedFirstMatch, matcher.group());
+
+            int count = 1;
+            while (matcher.find()) {
+                count++;
+            }
+            Assertions.assertEquals(expectedMatchCount.intValue(), count);
+        } else {
+            Assertions.assertFalse(matcher.find());
+        }
+    }
+
+    private static Stream<Arguments> getSourceStringAndExpectedSingleMatch() {
+        return Stream.of(
+                arguments("a test %s s d", "%s", 1),
+                arguments("a test %ssd", "%s", 1),
+                arguments("another test %ds", "%d", 1),
+                arguments("select $(abcs)d", "$(abcs)d", 1),
+                arguments("string %d s string", "%d", 1),
+                arguments("%d and %d img", "%d", 2),
+                arguments("test %(settings)s sd", "%(settings)s", 1),
+                arguments("% more values", "", 0),
+                arguments("% increase", "", 0),
+                arguments("is up 10%. And starting", "", 0),
+                arguments("up 10% in 10 days", "", 0),
+                arguments("% of something", "", 0),
+                arguments("{name}{name2}", "{name}", 2),
+                arguments("{{name}}{{name2}}", "{{name}}", 2),
+                arguments("test %@a@ b@", "%@", 1),
+                arguments("test 1$@ %1$@1$@a", "%1$@", 1),
+                arguments("$usd $(strings)sss $s", "$(strings)s", 1),
+                arguments("$usd $(counted)dddd $d", "$(counted)d", 1),
+                arguments("%f %increase %.f % f % . f", "%.f", 1),
+                arguments("$usd %100 %1$d % 100 $d", "%1$d", 1),
+                arguments("$usd %100 %1$,d % 100 $d", "%1$,d", 1),
+                arguments("$'{}': {}", "{}", 2),
+                arguments("{  a {{'{{text}}'}} b }", "{{text}}", 1),
+                arguments("get {{ '{{number}}' }} more", "{{number}}", 1)
+        );
+    }
+
+    @Test
+    @Ignore
+    public void testPrintEscapedRegex() {
+        System.out.println("Raw Regex pattern:");
+        System.out.println(Arrays.stream(PlaceholderPatternType.values())
+                .map(PlaceholderPatternType::getValue)
+                .collect(Collectors.joining("|"))
+                .replaceAll(",", "\\x{002C}")
+        );
+    }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderPatternTypeTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/machinetranslation/PlaceholderPatternTypeTest.java
@@ -1,0 +1,202 @@
+package com.box.l10n.mojito.service.machinetranslation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PlaceholderPatternTypeTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%s",
+            "%s ",
+            " %s ",
+            " test %s test",
+            " test \n\t %s "
+    })
+    public void testGettextStringPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.GETTEXT_STRING.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertEquals("%s", matcher.group());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%@",
+            "%@ ",
+            " %@ ",
+            " test %@ test",
+            " test \n\t %@ "
+    })
+    public void testIOSStringPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.IOS_STRING.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertEquals("%@", matcher.group());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%,d",
+            "%,d ",
+            " %,d ",
+            " test %,d test",
+            " test \n\t %,d \n\t test "
+    })
+    public void testGetTextNumberPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.GETTEXT_NUMBER.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertEquals("%,d", matcher.group());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{}",
+            "{} ",
+            " {} ",
+            " test {} test",
+            " test \n\t {} \n\t test "
+    })
+    public void testMessageFormatEmptyPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.MESSAGE_FORMAT_EMPTY.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertEquals("{}", matcher.group());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{{}}",
+            "{{}} ",
+            " {{}} ",
+            " test {{}} test",
+            " test \n\t {{}} \n\t test "
+    })
+    public void testMessageFormatDoubleEmptyPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.MESSAGE_FORMAT_DOUBLE_EMPTY.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertEquals("{{}}", matcher.group());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%d",
+            "%d numbers",
+            " %1d first placeholder",
+            " test %2d test",
+            " test \n\t  %20d \n\t test "
+    })
+    public void testGetTextPositionalNumberPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.GETTEXT_POSITIONAL_NUMBER.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertTrue(matcher.group().startsWith("%"));
+        Assertions.assertTrue(matcher.group().endsWith("d"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%(text)s",
+            "%(number)d",
+            "$(text)s",
+            "$(number)d",
+            "first named %(text)s placeholder",
+            "first named %(number)d placeholder",
+            " test \n\t %(text)s \n\t test ",
+            " test \n\t %(number)d \n\t test "
+    })
+    public void testGetTextNamedPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.GETTEXT_NAMED.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertTrue(matcher.group().startsWith("%") || matcher.group().startsWith("$"));
+        Assertions.assertTrue(matcher.group().endsWith("s") || matcher.group().endsWith("d"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{var1}",
+            "{{var_2}}",
+            "var {name}",
+            "number {{0}}",
+            "{{ 0 }}",
+            "{users[2].name}",
+            "test {{ curlyBrackets }}",
+            "space within {{ curly Brackets }}",
+            "underscore {{curly_Brackets}}",
+            "array access {{curlyBrackets[2].element}}",
+            "dot syntax {{curly.Brackets}}"
+    })
+    public void testMessageFormatNamedPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.MESSAGE_FORMAT_NAMED.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertTrue(matcher.group().startsWith("{"));
+        Assertions.assertTrue(matcher.group().endsWith("}"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%1$@",
+            "%2$@",
+            "%3$@",
+            "%4$@",
+            "%20$@",
+            "%1$i",
+            "%2$i",
+            "%3$i",
+            "%4$i",
+            "%20$i",
+            "%1$s",
+            "%2$s",
+            "%3$s",
+            "%4$s",
+            "%20$s",
+            "test \n\t %2$@ \n\t test",
+            "test \n\t %2$i \n\t test",
+            "test \n\t %2$s \n\t test"
+    })
+    public void testIOSPositionalPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.IOS_POSITIONAL.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertTrue(matcher.group().startsWith("%"));
+        Assertions.assertTrue(matcher.group().endsWith("@")
+                || matcher.group().endsWith("i")
+                || matcher.group().endsWith("s"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%.f",
+            "%.2f",
+            "test \n\t %.3f \n\t test",
+    })
+    public void testIOSFloatPattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.IOS_FLOAT.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertTrue(matcher.group().startsWith("%"));
+        Assertions.assertTrue(matcher.group().endsWith("f"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "%1$d",
+            "%1$,d",
+            "test \n\t %3$,d \n\t test",
+    })
+    public void testIOSDoublePattern(String text) {
+        Pattern pattern = Pattern.compile(PlaceholderPatternType.IOS_DOUBLE.getValue());
+        Matcher matcher = pattern.matcher(text);
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertTrue(matcher.group().startsWith("%"));
+        Assertions.assertTrue(matcher.group().endsWith("d"));
+    }
+}


### PR DESCRIPTION
Add placeholder protection implementation for the Microsoft MT engine.
Add common placeholders patterns for commonly used platforms.
Any string that match that pattern will get wrapped into a
<span translate="no">pattern</span> block.