### PR TITLE
Fix 'Duplicate Key' exceptions in SpellChecker

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -42,6 +43,7 @@ public class PlaceholderCommentChecker extends AbstractCliChecker {
         return getAddedTextUnits(assetExtractionDiffs).stream()
                 .map(assetExtractorTextUnit -> getPlaceholderCommentCheckResult(placeholderDescriptionChecks, assetExtractorTextUnit))
                 .filter(result -> !result.getFailures().isEmpty())
+                .distinct()
                 .collect(Collectors.toMap(PlaceholderCommentCheckResult::getSource, PlaceholderCommentCheckResult::getFailures));
     }
 
@@ -120,6 +122,19 @@ public class PlaceholderCommentChecker extends AbstractCliChecker {
 
         public String getSource() {
             return source;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PlaceholderCommentCheckResult result = (PlaceholderCommentCheckResult) o;
+            return Objects.equals(failures, result.failures) && Objects.equals(source, result.source);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(failures, source);
         }
     }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -63,6 +64,19 @@ public class SpellCliChecker extends AbstractCliChecker {
         public void setSuccessful(boolean successful) {
             this.isSuccessful = successful;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SpellCliCheckerResult that = (SpellCliCheckerResult) o;
+            return isSuccessful == that.isSuccessful && Objects.equals(source, that.source) && Objects.equals(suggestionMap, that.suggestionMap);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(source, suggestionMap, isSuccessful);
+        }
     }
 
 
@@ -106,6 +120,7 @@ public class SpellCliChecker extends AbstractCliChecker {
         return sourceStrings.stream()
                 .map(sourceString -> getSpellCliCheckerResult(sourceString))
                 .filter(result -> !result.isSuccessful())
+                .distinct()
                 .collect(Collectors.toMap(SpellCliCheckerResult::getSource, SpellCliCheckerResult::getSuggestionMap));
 
     }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
@@ -66,6 +66,29 @@ public class PlaceholderCommentCheckerTest {
     }
 
     @Test
+    public void testMissingIdenticalPlaceholderDescriptionInMultipleString() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setName("Some string id --- Test context");
+        assetExtractorTextUnit.setSource("A source string with a single {placeholder}.");
+        assetExtractorTextUnit.setComments("Test comment ");
+        addedTUs.add(assetExtractorTextUnit);
+        AssetExtractorTextUnit assetExtractorTextUnit2 = new AssetExtractorTextUnit();
+        assetExtractorTextUnit2.setName("Some string id --- Test context");
+        assetExtractorTextUnit2.setSource("A source string with a single {placeholder}.");
+        assetExtractorTextUnit2.setComments("Test comment ");
+        addedTUs.add(assetExtractorTextUnit2);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+        Assert.assertFalse(result.isSuccessful());
+        Assert.assertFalse(result.isHardFail());
+    }
+
+    @Test
     public void testMultiplePlaceholderDescriptionsInComment() {
         List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
         AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
@@ -284,6 +284,27 @@ public class SpellCliCheckerTest {
     }
 
     @Test
+    public void testMultipleIdenticalErrorsInMultipleIdenticalStrings() throws Exception {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit1 = new AssetExtractorTextUnit();
+        assetExtractorTextUnit1.setSource("A source string with identicl identicl identicl errors.");
+        AssetExtractorTextUnit assetExtractorTextUnit2 = new AssetExtractorTextUnit();
+        assetExtractorTextUnit2.setSource("A source string with identicl identicl identicl errors.");
+        addedTUs.add(assetExtractorTextUnit1);
+        addedTUs.add(assetExtractorTextUnit2);
+        when(hunspellMock.spell("identicl")).thenReturn(false);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertFalse(result.isSuccessful());
+        assertTrue(result.getNotificationText().contains("* 'identicl'"));
+        assertEquals(1, result.getNotificationText().chars().filter(c -> c == '*').count());
+    }
+
+    @Test
     public void testMultipleConfiguredPlaceholderRegexesAreNotSpellChecked() throws Exception {
         List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
         AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();


### PR DESCRIPTION
Fixes Duplicate Key exceptions in cli checkers that collate multiple errors per string if 2 strings exist with identical content