### PR TITLE
Run all integration tests using a MySQL test container instead of HSQL

### DIFF
--- a/cli/src/test/resources/application.properties
+++ b/cli/src/test/resources/application.properties
@@ -1,4 +1,7 @@
 info.build.version=@project.version@
 
+spring.flyway.enabled=true
+spring.datasource.url=jdbc:tc:mysql:5.7://localhost:3306/mojito?characterEncoding=UTF-8&useUnicode=true&TC_INITSCRIPT=db/mysql/test_init.sql
+
 l10n.console-writer.ansi-code-enabled=false
 l10n.console-writer.output-type=ANSI_LOGGER

--- a/docs/_docs/guides/open-source-contributors.md
+++ b/docs/_docs/guides/open-source-contributors.md
@@ -242,7 +242,20 @@ For example to create Demo data, you can now run: `mojito demo-create -n DemoCLI
 Alternatively, install the CLI using the [install scripts]({{ site.url }}/docs/guides/install/#cli-install-script).
 
 ## Run Unit Tests
-   
+
+
+### Testcontainers
+By default, if no datasource is configured in the application.properties file, integration tests rely on 
+[Testcontainers](https://www.testcontainers.org/)
+to 
+provide a configured
+MySql instance in a test-scoped container.
+
+For that to work,  you will need Docker installed and running on the local machine. 
+
+See [general Docker requirements](https://www.testcontainers.org/supported_docker_environment/) for Testcontainers.
+
+### Test command
 ```sh
 cd ${PROJECT_DIR}
 mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,24 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.17.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.17.1</version>
+        </dependency>
+
         <!-- TODO(spring2) remove -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -227,7 +227,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/webapp/src/main/resources/db/mysql/test_init.sql
+++ b/webapp/src/main/resources/db/mysql/test_init.sql
@@ -1,0 +1,1 @@
+ALTER DATABASE `mojito` CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_bin';

--- a/webapp/src/test/java/com/box/l10n/mojito/db/MySQLIntegrationTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/db/MySQLIntegrationTest.java
@@ -1,0 +1,25 @@
+package com.box.l10n.mojito.db;
+
+import com.box.l10n.mojito.aws.s3.AmazonS3Configuration;
+import com.box.l10n.mojito.aws.s3.AmazonS3ConfigurationProperties;
+import com.box.l10n.mojito.service.DBUtils;
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorageConfigurationProperties;
+import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorageTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {DBUtils.class})
+public class MySQLIntegrationTest {
+    @Autowired
+    DBUtils dbUtils;
+
+    @Test
+    public void testIntegrationTestsRunOnMysql() {
+        Assert.assertTrue(dbUtils.isMysql());
+    }
+}

--- a/webapp/src/test/resources/application-test.properties
+++ b/webapp/src/test/resources/application-test.properties
@@ -1,5 +1,8 @@
 spring.profiles.include=disablescheduling
 
+spring.flyway.enabled=true
+spring.datasource.url=jdbc:tc:mysql:5.7://localhost:3306/mojito?characterEncoding=UTF-8&useUnicode=true&TC_INITSCRIPT=db/mysql/test_init.sql
+
 l10n.boxclient.useConfigsFromProperties=true
 
 # we use LDAP to test the user creation from UserDetailsContextMapperImpl flow


### PR DESCRIPTION
Replace HSQL with MySQL for higher fidelity integration tests and to
be able to also test native queries and platform-specific functionality.