### PR TITLE
Fix unique constraint for commit table to include repository_id

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Commit.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Commit.java
@@ -21,7 +21,7 @@ import javax.persistence.Table;
 @Table(
         name = "commit",
         indexes = {
-                @Index(name = "UK__COMMIT__NAME", columnList = "name", unique = true)
+                @Index(name = "UK__COMMIT__NAME_REPOSITORY_ID", columnList = "name, repository_id", unique = true)
         }
 )
 public class Commit extends AuditableEntity {

--- a/webapp/src/main/resources/db/migration/V60__Add_push_pull_run_tracking.sql
+++ b/webapp/src/main/resources/db/migration/V60__Add_push_pull_run_tracking.sql
@@ -14,7 +14,7 @@ CREATE TABLE commit
     PRIMARY KEY (id)
 );
 ALTER TABLE commit
-    ADD CONSTRAINT UK__COMMIT__NAME unique (name);
+    ADD CONSTRAINT UK__COMMIT__NAME_REPOSITORY_ID unique (name, repository_id);
 ALTER TABLE commit
     ADD CONSTRAINT FK__COMMIT__NAME__REPOSITORY_ID FOREIGN KEY (repository_id) REFERENCES repository (id);
 


### PR DESCRIPTION
Commit names/hashes should be unique in the context of a repository.
