### PR TITLE
Upgrade spring-boot-start-parent to 2.5.14

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -93,6 +93,13 @@
             <groupId>com.gitlab.dumonts</groupId>
             <artifactId>hunspell</artifactId>
             <version>1.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- This is causing issue with JUnit -->
+                    <groupId>com.google.android.tools</groupId>
+                    <artifactId>dx</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>
@@ -137,7 +144,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dspring.config.additional-location=file://${user.home}/.l10n/config/cli/
+                    <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/cli/
                         -Dspring.profiles.active=${user.name},test -Xmx1024m
                     </argLine>
                 </configuration>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -347,7 +347,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Sets the VM argument line used when unit tests are run. -->
-                    <argLine>-Dspring.config.additional-location=file://${user.home}/.l10n/config/common/
+                    <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/common/
                         -Dspring.profiles.active=${user.name},test -Duser.timezone=UTC
                     </argLine>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.5.14</version>
     </parent>
 
     <properties>
@@ -58,22 +58,6 @@
             <artifactId>aspectjrt</artifactId>
             <version>${aspectj.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>jupiter-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- TODO(spring2) remove -->

--- a/restclient/pom.xml
+++ b/restclient/pom.xml
@@ -24,6 +24,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.box.l10n.mojito</groupId>
+            <artifactId>mojito-test-common</artifactId>
+            <version>0.111-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
@@ -70,7 +76,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dspring.config.additional-location=file://${user.home}/.l10n/config/restclient/
+                    <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/restclient/
                         -Dspring.profiles.active=${user.name},test -Xmx1024m
                     </argLine>
                 </configuration>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -35,6 +35,17 @@
             <artifactId>assertj-core</artifactId>
             <version>3.16.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
 </project>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -225,12 +225,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
             <version>0.111-SNAPSHOT</version>
@@ -439,7 +433,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Sets the VM argument line used when unit tests are run. -->
-                    <argLine>-Dspring.config.additional-location=file://${user.home}/.l10n/config/webapp/
+                    <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/webapp/
                         -Dspring.profiles.active=${user.name},test -Xmx1024m -Duser.timezone=UTC
                     </argLine>
 

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -36,8 +36,9 @@ spring.jpa.properties.org.hibernate.envers.track_entities_changed_in_revision=tr
 #spring.jpa.open-in-view=false
 
 spring.datasource.url=jdbc:hsqldb:mem:testdb;DB_CLOSE_DELAY=-1
-spring.datasource.initialization-mode=embedded
-spring.datasource.data=classpath:/db/hsql/data.sql
+spring.sql.init.mode=embedded
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.data-locations=classpath:/db/hsql/data.sql
 spring.datasource.hikari.maximum-pool-size=30
 
 # MANAGEMENT

--- a/webapp/src/test/resources/application-test.properties
+++ b/webapp/src/test/resources/application-test.properties
@@ -1,4 +1,4 @@
-spring.profiles.include=disablescheduling
+spring.profiles.group.disablescheduling=disablescheduling
 
 l10n.boxclient.useConfigsFromProperties=true
 


### PR DESCRIPTION
- Fixes vulnerability from `org.springframework:spring-beans | 5.2.9.RELEASE (CVE-2022-22965)`
    - `org.springframework` package upgraded to `5.3.20`
- Fixes import for `org.junit`
- Mark default app.properties classpaths for tests as optional so as to not break the CI which should instead load app-test.properties 