### PR TITLE
Cleanup hunspell/junit dependency and use test-common everywhere

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -93,6 +93,13 @@
             <groupId>com.gitlab.dumonts</groupId>
             <artifactId>hunspell</artifactId>
             <version>1.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- This is causing issue with JUnit -->
+                    <groupId>com.google.android.tools</groupId>
+                    <artifactId>dx</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -60,22 +60,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>jupiter-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- TODO(spring2) remove -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/restclient/pom.xml
+++ b/restclient/pom.xml
@@ -24,6 +24,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.box.l10n.mojito</groupId>
+            <artifactId>mojito-test-common</artifactId>
+            <version>0.111-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -225,12 +225,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
             <version>0.111-SNAPSHOT</version>


### PR DESCRIPTION
- Remove the Junit/Vintage exclusion from the parent POM. This was added to fix an issue with hunspell. The root cause of the issue is that hunspell brings com.google.android.tools:dx dependency that causes the issue with Junit. Exclude this instead. Excluding Junit in the parent is source of confusion, and we need it too
- spring-boot-starter-test is now only defined in `test-common`, all other module should depend on that. This way we won't have to make double updates when adding test dependency which will need for springboot 2.5 upgrade
- Remove Junit 4 in webapp, it should come fromm test-common now (and as a side effect webapp doesn't share junit with the CLI anymore)