### PR TITLE
Change customized spring-session query for springboot 2.5 upgrade

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/security/user/session/CustomCreateSessionAttributeInsertQueryConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/security/user/session/CustomCreateSessionAttributeInsertQueryConfiguration.java
@@ -20,6 +20,10 @@ import org.springframework.util.StringUtils;
  * of the existing row if a duplicate key is encountered.
  *
  * <b>NOTE:</b>This custom insert query should only be used with a MySQL database.
+ * <p>
+ * Updated later for springboot 2.5 upgrade and actual change in spring session:
+ * https://github.com/spring-projects/spring-session/commit/e721efeb850ac6ceddb45942e1a51d7d34056b0c.
+ * <p>
  */
 @Configuration
 @ConditionalOnProperty(value = "l10n.spring.session.use-custom-mysql-create-session-attribute-query", havingValue = "true")
@@ -27,11 +31,9 @@ public class CustomCreateSessionAttributeInsertQueryConfiguration extends JdbcHt
 
     static Logger logger = LoggerFactory.getLogger(CustomCreateSessionAttributeInsertQueryConfiguration.class);
 
-    private static final String CREATE_SESSION_ATTRIBUTE_QUERY_ON_DUPLICATE_KEY_UPDATE =
-        "INSERT INTO %TABLE_NAME%_ATTRIBUTES(SESSION_PRIMARY_ID, ATTRIBUTE_NAME,  ATTRIBUTE_BYTES) "
-                + "SELECT PRIMARY_ID, ?, ? "
-                + "FROM %TABLE_NAME% "
-                + "WHERE SESSION_ID = ? ON DUPLICATE KEY UPDATE ATTRIBUTE_BYTES=VALUES(ATTRIBUTE_BYTES)";
+    private static final String CREATE_SESSION_ATTRIBUTE_QUERY_ON_DUPLICATE_KEY_UPDATE = ""
+            + "INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
+            + "VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE ATTRIBUTE_BYTES=VALUES(ATTRIBUTE_BYTES)";
 
     @Autowired
     DBUtils dbUtils;

--- a/webapp/src/test/java/com/box/l10n/mojito/service/security/user/session/CustomCreateSessionAttributeInsertQueryConfigurationTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/security/user/session/CustomCreateSessionAttributeInsertQueryConfigurationTest.java
@@ -43,10 +43,8 @@ public class CustomCreateSessionAttributeInsertQueryConfigurationTest {
     @Autowired
     JdbcIndexedSessionRepository jdbcIndexedSessionRepository;
 
-    String requiredString = "INSERT INTO test_table_ATTRIBUTES(SESSION_PRIMARY_ID, ATTRIBUTE_NAME,  ATTRIBUTE_BYTES) "
-            + "SELECT PRIMARY_ID, ?, ? "
-            + "FROM test_table "
-            + "WHERE SESSION_ID = ? ON DUPLICATE KEY UPDATE ATTRIBUTE_BYTES=VALUES(ATTRIBUTE_BYTES)";
+    String requiredString = "INSERT INTO test_table_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
+            + "VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE ATTRIBUTE_BYTES=VALUES(ATTRIBUTE_BYTES)";
 
     @Test
     public void testCustomSessionAttributeQueryIsSetOnSessionRepository() throws IllegalAccessException {


### PR DESCRIPTION
spring-session query was changed in
https://github.com/spring-projects/spring-session/commit/e721efeb850ac6ceddb45942e1a51d7d34056b0c.

Update the query to work with the new spring-session version, still keeping the de-duping logic.