### PR TITLE
Document the TUIDS mapping in LeveragingCommand

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/LeveragingCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/LeveragingCommand.java
@@ -62,7 +62,9 @@ public class LeveragingCommand extends Command {
     CopyTmConfig.Mode mode = CopyTmConfig.Mode.MD5;
 
     @Parameter(names = {"--tuids-mapping"}, required = false,
-            description = "Text unit mapping for TUIDS mode (source to target tmTextUnit id), format: \"1001:2001;1002:2002\"",
+            description = "Text unit mapping (by tmTextUnitId) for TUIDS mode, format: \"1001:2001;1002:2002\" " +
+                    "(\"source_tm_text_unit_id:target_tm_text_unit_id;...\" with source_tm_text_unit_id unique. " +
+                    "Use multiple calls to copy the same source to multiple targets)",
             converter = TmTextUnitMappingConverter.class)
     Map<Long, Long> sourceToTargetTmTextUnitMapping;
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/TmTextUnitMappingConverterTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/TmTextUnitMappingConverterTest.java
@@ -1,12 +1,15 @@
 package com.box.l10n.mojito.cli.command;
 
 import com.beust.jcommander.ParameterException;
+import com.box.l10n.mojito.cli.command.param.Param;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 
 public class TmTextUnitMappingConverterTest {
@@ -25,6 +28,14 @@ public class TmTextUnitMappingConverterTest {
         assertEquals(2001L, convert.get(1001L).longValue());
         assertEquals(2002L, convert.get(1002L).longValue());
         assertEquals(2, convert.size());
+    }
+
+    @Test
+    public void multimapUnsupported() {
+        TmTextUnitMappingConverter tmTextUnitMappingConverter = new TmTextUnitMappingConverter();
+        Assertions.assertThatThrownBy(() -> tmTextUnitMappingConverter.convert("1001:2001;1001:2002"))
+                .isInstanceOf(ParameterException.class)
+                .hasMessage("Invalid source to target textunit id mapping [1001:2001;1001:2002]");
     }
 
     @Test(expected = ParameterException.class)


### PR DESCRIPTION
Since we use a map "source to target" this prevent to have multiple times the source string to be copied to different targets.

We'd need a multimap, or a map "target to source" to support copying source to multiple target.

For now, just document and test the current behavior