### PR TITLE
Added machine translation retrieval to chrome extension

### DIFF
--- a/webapp/src/main/resources/public/js/app.js
+++ b/webapp/src/main/resources/public/js/app.js
@@ -85,7 +85,7 @@ function instrumentMessagesForIct(messages, locale) {
 
     Object.keys(messages).map((key) => {
         let stack = new Error().stack; // stack is useless here but for tests
-        messages[key] = IctMetadataBuilder.getTranslationWithMetadata("mojito", null, key, locale, stack, messages[key]);
+        messages[key] = IctMetadataBuilder.getTranslationWithMetadata("mojito", null, key, locale, stack, messages[key], true);
     });
 }
 

--- a/webapp/src/main/resources/public/js/ict/Ict.js
+++ b/webapp/src/main/resources/public/js/ict/Ict.js
@@ -92,44 +92,40 @@ class Ict {
             node = node.parentNode;
         }
 
-        var mtRequired = textUnits[0]['isTranslated'] === 'false';
-        if (this.mtEnabled && mtRequired){
-            if (!node.classList.contains("mojito-ict-string")) {
-                try {
-                    node.className += " mojito-ict-string";
-                } catch (e) {
-                }
 
-                node.addEventListener("mouseenter", (e) => {
-                    e.target.classList.add("mojito-ict-string-mt");
-                });
+        var mtRequired = this.mtEnabled && textUnits[0]['isTranslated'] === 'false';
+        var eventListenerClassName = mtRequired ? "mojito-ict-string-mt" : "mojito-ict-string-active"
 
-                node.addEventListener("mouseleave", (e) => {
-                    e.target.classList.remove("mojito-ict-string-mt");
-                });
+        if (!node.classList.contains("mojito-ict-string")) {
+            try {
+                node.className += " mojito-ict-string";
+            } catch (e) {
             }
 
-            chrome.runtime.sendMessage(textUnits[0], function (response){
+            node.addEventListener("mouseenter", (e) => {
+                e.target.classList.add(eventListenerClassName);
+            });
+
+            node.addEventListener("mouseleave", (e) => {
+                e.target.classList.remove(eventListenerClassName);
+            });
+        }
+
+        if (mtRequired) {
+            chrome.runtime.sendMessage(textUnits[0], function (response) {
                 if (response.data && node.textContent !== response.data) {
-                    textUnits[0]['isMachineTranslated'] = true
-                    node.textContent = response.data;
+                    if (node.nodeType === Node.ELEMENT_NODE && node.getAttribute('placeholder')) {
+                        node.setAttribute('placeholder', response.data)
+                    } else {
+                        var spanMT = document.createElement('span');
+                        spanMT.innerHTML = "<span style=\"color:#FF9966\">*</span>"
+                        spanMT.setAttribute('id', 'mojito-mt')
+                        textUnits[0]['isMachineTranslated'] = true
+                        node.textContent = response.data;
+                        node.appendChild(spanMT)
+                    }
                 }
-            })
-        } else {
-            if (!node.classList.contains("mojito-ict-string")) {
-                try {
-                    node.className += " mojito-ict-string";
-                } catch (e) {
-                }
-
-                node.addEventListener("mouseenter", (e) => {
-                    e.target.classList.add("mojito-ict-string-active");
-                });
-
-                node.addEventListener("mouseleave", (e) => {
-                    e.target.classList.remove("mojito-ict-string-active");
-                });
-            }
+            });
         }
 
         node.addEventListener("click", (e) => onClick(e, textUnits));

--- a/webapp/src/main/resources/public/js/ict/Ict.js
+++ b/webapp/src/main/resources/public/js/ict/Ict.js
@@ -85,7 +85,7 @@ class Ict {
         return string;
     }
 
-    wrapNode(node, onClick) {
+    wrapNode(node, onClick, addMTCSS) {
         var textUnits = IctMetadataExtractor.getTextUnits(this.getStringFromNode(node));
 
         if (node.nodeType === Node.TEXT_NODE) {
@@ -117,12 +117,12 @@ class Ict {
                     if (node.nodeType === Node.ELEMENT_NODE && node.getAttribute('placeholder')) {
                         node.setAttribute('placeholder', response.data)
                     } else {
-                        var spanMT = document.createElement('span');
-                        spanMT.innerHTML = "<span style=\"color:#FF9966\">*</span>"
-                        spanMT.setAttribute('id', 'mojito-mt')
                         textUnits[0]['isMachineTranslated'] = true
                         node.textContent = response.data;
-                        node.appendChild(spanMT)
+                        node.classList.add("mojito-mt-ict-string-static");
+                        node.addEventListener("click", (e) => addMTCSS(e, node))
+                        node.addEventListener("mouseenter", (e) => addMTCSS(e, node))
+                        node.addEventListener("mouseleave", (e) => addMTCSS(e, node))
                     }
                 }
             });
@@ -161,10 +161,14 @@ class Ict {
         }
     }
 
+    addMTCSS(e, node) {
+        node.classList.add("mojito-mt-ict-string-static");
+    }
+
     processNode(node) {
         var hasMetaData = IctMetadataExtractor.hasMetadata(this.getStringFromNode(node));
         if (hasMetaData) {
-            this.wrapNode(node, this.onClickBehavior.bind(this));
+            this.wrapNode(node, this.onClickBehavior.bind(this), this.addMTCSS.bind(this));
             this.removeTagsBlockFromNode(node);
         }
     }

--- a/webapp/src/main/resources/public/js/ict/IctMetadataBuilder.js
+++ b/webapp/src/main/resources/public/js/ict/IctMetadataBuilder.js
@@ -2,18 +2,19 @@ import TagsBlockEncoder from './TagsBlockEncoder';
 
 class IctMetadataBuilder {
 
-    getTranslationWithMetadata(repositoryName, assetName, textUnitName, localeName, stack, translation) {
-        var textUnitMetadata = this.getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack);
+    getTranslationWithMetadata(repositoryName, assetName, textUnitName, localeName, stack, translation, isTranslated) {
+        var textUnitMetadata = this.getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack, isTranslated);
         var textUnitMetadataAsTagsBlock = TagsBlockEncoder.unicodeToTagsBlock(textUnitMetadata);
         return this.getStartDelimiter() + textUnitMetadataAsTagsBlock + this.getMiddleDelimiter() + translation + this.getEndDelimiter();
     }
 
-    getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack) {
+    getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack, isTranslated) {
         return repositoryName + this.getInnerDelimiter()
                 + (assetName ? assetName : "") + this.getInnerDelimiter()
                 + textUnitName + this.getInnerDelimiter()
                 + localeName + this.getInnerDelimiter()
-                + stack;
+                + stack + this.getInnerDelimiter()
+                + isTranslated;
     }
 
     getStartDelimiter() {

--- a/webapp/src/main/resources/public/js/ict/IctMetadataExtractor.js
+++ b/webapp/src/main/resources/public/js/ict/IctMetadataExtractor.js
@@ -31,16 +31,19 @@ class IctMetadataExtractor {
 
                     try {
                         var decodedTextUnitMedata = TagsBlockDecoder.tagsBlockToUnicode(textUnitMetadata);
-                        var spitTextUnitMetadata = decodedTextUnitMedata.split(IctMetadataBuilder.getInnerDelimiter());
-                        textUnit['repositoryName'] = spitTextUnitMetadata[0];
-                        textUnit['assetName'] = spitTextUnitMetadata[1];
-                        textUnit['textUnitName'] = spitTextUnitMetadata[2];
-                        textUnit['locale'] = spitTextUnitMetadata[3];
-                        textUnit['stack'] = spitTextUnitMetadata[4];
+                        var splitTextUnitMetadata = decodedTextUnitMedata.split(IctMetadataBuilder.getInnerDelimiter());
+                        textUnit['repositoryName'] = splitTextUnitMetadata[0];
+                        textUnit['assetName'] = splitTextUnitMetadata[1];
+                        textUnit['textUnitName'] = splitTextUnitMetadata[2];
+                        textUnit['locale'] = splitTextUnitMetadata[3];
+                        textUnit['stack'] = splitTextUnitMetadata[4];
+                        // For backwards compatibility check array length, if less than 5 set isTranslated to true
+                        textUnit['isTranslated'] = splitTextUnitMetadata.length > 5 ? splitTextUnitMetadata[5] : 'true';
+
                     } catch (e) {
                         console.log("Can't extract ict metadata from string: ", string, e);
                     }
-
+                    
                     textUnits.push(textUnit);
                     break;
             }

--- a/webapp/src/main/resources/public/js/ict/IctModal.js
+++ b/webapp/src/main/resources/public/js/ict/IctModal.js
@@ -21,7 +21,7 @@ class ModalTextUnit extends React.Component {
         return (
             <div className={className} 
                  onClick={() => this.props.onSelect(textUnit)}>
-                {textUnit.isMachineTranslated && <div className="mbs">This text unit has been machine translated. Please wait for final translations before committing your changes!</div> }
+                {textUnit.isMachineTranslated && <div className="mbs">This text unit has been machine translated.</div> }
                 <div className="mbs">
                     <Label className="mbs clickable label label-primary mrs">
                         {textUnit.locale}            

--- a/webapp/src/main/resources/public/js/ict/IctModal.js
+++ b/webapp/src/main/resources/public/js/ict/IctModal.js
@@ -21,6 +21,7 @@ class ModalTextUnit extends React.Component {
         return (
             <div className={className} 
                  onClick={() => this.props.onSelect(textUnit)}>
+                {textUnit.isMachineTranslated && <div className="mbs">This text unit has been machine translated. Please wait for final translations before committing your changes!</div> }
                 <div className="mbs">
                     <Label className="mbs clickable label label-primary mrs">
                         {textUnit.locale}            

--- a/webapp/src/main/resources/public/js/ict/chrome-ict-popup.js
+++ b/webapp/src/main/resources/public/js/ict/chrome-ict-popup.js
@@ -42,6 +42,17 @@ const IctPopup = function (props) {
                 <FormControl type="text" value={props.headerValue} onChange={(e) => props.onHeaderValueChanged(e.target.value)} />
               </Col>
             </FormGroup>
+
+            <FormGroup controlId="formHorizontalMTEnabled">
+                <Col componentClass={ControlLabel} sm={2}>
+                    Machine Translation
+                </Col>
+                <ToggleButtonGroup className="mtm mbm" name="state" type="radio" value={props.mtEnabled}
+                                   onChange={props.onMTEnabledChanged} >
+                    <ToggleButton name="state" value={true}>On</ToggleButton>
+                    <ToggleButton name="state" value={false}>Off</ToggleButton>
+                </ToggleButtonGroup>
+            </FormGroup>
         </Form>
     </div>;
 }
@@ -56,6 +67,7 @@ class IctPopupContainer extends React.Component {
             enabled: false,
             headerName: '',
             headerValue: '',
+            mtEnabled: false,
         };
         
         this.loadStateFromStorage();
@@ -107,16 +119,28 @@ class IctPopupContainer extends React.Component {
         });
     }
 
+    onMTEnabledChanged(mtEnabled) {
+        this.setState({
+            mtEnabled: mtEnabled
+        });
+
+        chrome.storage.sync.set({
+            mtEnabled: mtEnabled
+        });
+    }
+
     render() {
         return <IctPopup
                     mojitoBaseUrl={this.state.mojitoBaseUrl}
                     enabled={this.state.enabled}
                     headerName={this.state.headerName}
                     headerValue={this.state.headerValue}
+                    mtEnabled={this.state.mtEnabled}
                     onMojitoBaseUrlChanged={url => this.onMojitoBaseUrlChanged(url)}
                     onHeaderNameChanged={name => this.onHeaderNameChanged(name)}
                     onHeaderValueChanged={value => this.onHeaderValueChanged(value)}
                     onEnabledChanged={enabled => this.onEnabledChanged(enabled)}
+                    onMTEnabledChanged={mtEnabled => this.onMTEnabledChanged(mtEnabled)}
                 />;
                     
     }

--- a/webapp/src/main/resources/public/js/ict/chrome-ict.js
+++ b/webapp/src/main/resources/public/js/ict/chrome-ict.js
@@ -6,8 +6,9 @@ var ict = new Ict(enMessages, 'en');
 
 var config = {
     enabled: false,
+    mtEnabled: false,
     mojitoBaseUrl: '',
-    actionButtons: [],
+    actionButtons: []
 };
 
 chrome.storage.sync.get(config, (items) => {
@@ -16,6 +17,7 @@ chrome.storage.sync.get(config, (items) => {
         ict.activate();
         ict.setMojitoBaseUrl(items.mojitoBaseUrl);
         ict.setActionButtons(items.actionButtons);
+        ict.setMTEnabled(items.mtEnabled);
     }
 });
 
@@ -33,6 +35,10 @@ chrome.storage.onChanged.addListener((changes) => {
 
         if (key === 'actionButtons') {
             ict.setActionButtons(config.actionButtons);
+        }
+
+        if (key === 'mtEnabled' && config[key]) {
+            ict.setMTEnabled(config.mtEnabled)
         }
     }
 });

--- a/webapp/src/main/resources/sass/ict.scss
+++ b/webapp/src/main/resources/sass/ict.scss
@@ -2,6 +2,10 @@
     border: 1px solid green !important;
 }
 
+.mojito-ict-string-mt {
+    border: 1px solid orange !important;
+}
+
 .mojito-ict-popup {
     width: 300px;
 }

--- a/webapp/src/main/resources/sass/ict.scss
+++ b/webapp/src/main/resources/sass/ict.scss
@@ -6,6 +6,12 @@
     border: 1px solid orange !important;
 }
 
+.mojito-mt-ict-string-static:after {
+    content: " MT";
+    color: orange;
+    font-size: 8px;
+}
+
 .mojito-ict-popup {
     width: 300px;
 }


### PR DESCRIPTION
Added functionality to the chrome extension to retrieve machine translations for flagged strings by calling to a remote endpoint that takes the requested locale and message as query parameters in a url.

The MT url format should be provided in the background configuration with `{mt_locale}` and `{mt_message}` as placeholders in the url which will be replaced with the locale and message required for machine translation.