### PR TITLE
UTC fix for Push, Pull run recording and delta generation

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/delta/DeltaService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/delta/DeltaService.java
@@ -18,7 +18,10 @@ import org.joda.time.DateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -35,6 +38,7 @@ import java.util.stream.Stream;
  */
 @Service
 public class DeltaService {
+
     CommitService commitService;
 
     RepositoryService repositoryService;
@@ -138,7 +142,8 @@ public class DeltaService {
                 // Remove milliseconds as the Mojito DB does not store dates with sub-second precision.
                 .map(dateTime -> dateTime.withMillisOfSecond(0))
                 .orElse(new DateTime(0));
-        Date sqlTranslationsFromDate = new Date(translationsFromDate.toDate().getTime());
+        Instant fromDateInstant = Instant.ofEpochMilli(translationsFromDate.getMillis());
+        Timestamp sqlTranslationsFromDate = Timestamp.valueOf(LocalDateTime.ofInstant(fromDateInstant, ZoneOffset.UTC));
 
         List<TextUnitVariantDelta> variants = tmTextUnitVariantRepository.findDeltasForRuns(
                 repository.getId(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pullrun/PullRunAssetService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -61,9 +63,10 @@ public class PullRunAssetService {
     }
 
     void saveTextUnitVariantsMultiRowBatch(PullRunAsset pullRunAsset, Long localeId, List<Long> uniqueTmTextUnitVariantIds, Instant now) {
+        String createdTime = Timestamp.valueOf(LocalDateTime.ofInstant(now, ZoneOffset.UTC)).toString();
         String sql = "insert into pull_run_text_unit_variant(pull_run_asset_id, locale_id, tm_text_unit_variant_id, created_date) values "
                 + uniqueTmTextUnitVariantIds.stream().map(tuvId -> String.format("(%s, %s, %s, '%s') ",
-                pullRunAsset.getId(), localeId, tuvId, Timestamp.from(now))).collect(Collectors.joining(","));
+                pullRunAsset.getId(), localeId, tuvId, createdTime)).collect(Collectors.joining(","));
         jdbcTemplate.update(sql);
     }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/pushrun/PushRunService.java
@@ -18,6 +18,8 @@ import javax.persistence.EntityManager;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -124,9 +126,10 @@ public class PushRunService {
     }
 
     void saveTextUnits(PushRunAsset pushRunAsset, List<Long> textUnitIds, Instant now) {
+        String createdTime = Timestamp.valueOf(LocalDateTime.ofInstant(now, ZoneOffset.UTC)).toString();
         String sql = "insert into push_run_asset_tm_text_unit(push_run_asset_id, tm_text_unit_id, created_date) values" +
                 textUnitIds.stream()
-                        .map(tuId -> String.format("(%s, %s, '%s') ", pushRunAsset.getId(), tuId, Timestamp.from(now)))
+                        .map(tuId -> String.format("(%s, %s, '%s') ", pushRunAsset.getId(), tuId, createdTime))
                         .collect(Collectors.joining(","));
 
         jdbcTemplate.update(sql);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMTextUnitVariantRepository.java
@@ -6,7 +6,7 @@ import com.box.l10n.mojito.entity.PushRun;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
 
-import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.List;
 
 import org.joda.time.DateTime;
@@ -59,8 +59,8 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
             "and a.deleted = false " +
             "and tuv.locale in :locales " +
             "and tuv.includedInLocalizedFile = true " +
-            "and tuv.createdDate >= :fromDate " +
-            "and tuv.createdDate < :toDate " +
+            "and tucv.lastModifiedDate >= :fromDate " +
+            "and tucv.lastModifiedDate < :toDate " +
             "order by tuv.id asc ")
     Page<TextUnitVariantDelta> findAllUsedForRepositoryAndLocalesInDateRange(
             @Param("repository") Repository repository,
@@ -159,7 +159,7 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
                     "                   and previous_tuv.text_unit_id = base_tu.id " +
                     "where " +
                     "   latest_tuv.included_in_localized_file = true " + // Exclude rejected translations
-                    "   and base_tucv.created_date >= :translationsFromDate " +
+                    "   and base_tucv.last_modified_date >= :translationsFromDate " +
                     "   and (previous_tuv.id is null " +
                     "       or (latest_tuv.id != previous_tuv.id and latest_tuv.content_md5 != previous_tuv.content_md5)) "
     )
@@ -168,5 +168,5 @@ public interface TMTextUnitVariantRepository extends JpaRepository<TMTextUnitVar
             @Param("localeIds") List<Long> localeIds,
             @Param("pushRunIds") List<Long> pushRunIds,
             @Param("pullRunIds") List<Long> pullRunIds,
-            @Param("translationsFromDate") Date translationsFromDate);
+            @Param("translationsFromDate") Timestamp translationsFromDate);
 }


### PR DESCRIPTION
Store push and pun run records in UTC format.
Use UTC when querying for state-based deltas.
Use current text unit variant's last_modified_date for date filtering
instead of created_date as existing variants get updated with new
translations keeping the created_date the same on the current variants
table.