### PR TITLE
Fixing infinite loop in spell checker

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
@@ -154,8 +154,7 @@ public class SpellCliChecker extends AbstractCliChecker {
         int index = stringWithoutPlaceholders.indexOf("{");
         while(index != -1 && stringWithoutPlaceholders.contains("}")) {
             int associatedClosingBraceIndex = getEndOfPlaceholderIndex(stringWithoutPlaceholders, index);
-            String tmp = stringWithoutPlaceholders.substring(index, associatedClosingBraceIndex + 1 < stringWithoutPlaceholders.length()? associatedClosingBraceIndex + 1 : associatedClosingBraceIndex).replaceAll("\\{", "\\\\{").replaceAll("\\}", "\\\\}");
-            stringWithoutPlaceholders = stringWithoutPlaceholders.replaceAll(tmp, "");
+            stringWithoutPlaceholders = stringWithoutPlaceholders.substring(0,index) + stringWithoutPlaceholders.substring(associatedClosingBraceIndex + 1);
             index = stringWithoutPlaceholders.indexOf("{");
         }
         return stringWithoutPlaceholders;

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
@@ -171,6 +171,23 @@ public class SpellCliCheckerTest {
     }
 
     @Test
+    public void testBracketedPlaceholderWithRegexSpecialCharacter() {
+        List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+        AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+        assetExtractorTextUnit.setSource("Searching for {recommended_terms[0]}?");
+        addedTUs.add(assetExtractorTextUnit);
+        List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+        AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+        assetExtractionDiff.setAddedTextunits(addedTUs);
+        assetExtractionDiffs.add(assetExtractionDiff);
+
+        CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+        assertTrue(result.isSuccessful());
+        assertTrue(result.getNotificationText().isEmpty());
+        assertFalse(result.isHardFail());
+    }
+
+    @Test
     public void testAddingStringsToDictionaryAppendsSuggestedUpdateOnFailure() throws Exception {
         List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
         AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();


### PR DESCRIPTION
Fixes infinite loop in spell checker when placeholder string contains regex special characters. Removes the `replaceAll` usage and now removes from the string based off of opening and closing brace indexes