### PR TITLE
Updated IOS placeholder regex to ignore % signs in isolation

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
@@ -338,9 +338,31 @@ public class PlaceholderCommentCheckerTest {
     AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
     assetExtractionDiff.setAddedTextunits(addedTUs);
     assetExtractionDiffs.add(assetExtractionDiff);
-
     CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
     Assert.assertFalse(result.isSuccessful());
     Assert.assertTrue(result.getNotificationText().contains("Comment is empty."));
+  }
+
+  @Test
+  public void testIOSPercentageSignNotPlaceholder() {
+    placeholderCommentChecker.setCliCheckerOptions(
+        new CliCheckerOptions(
+            Sets.newHashSet(PRINTF_LIKE_IOS_REGEX),
+            Sets.newHashSet(),
+            ImmutableMap.<String, String>builder().build()));
+    List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+    AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+    assetExtractorTextUnit.setName("Some string id --- Test context");
+    assetExtractorTextUnit.setSource("A source string with a single % percentage sign");
+    assetExtractorTextUnit.setComments("Test comment ");
+    addedTUs.add(assetExtractorTextUnit);
+    List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+    AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+    assetExtractionDiff.setAddedTextunits(addedTUs);
+    assetExtractionDiffs.add(assetExtractionDiff);
+
+    CliCheckResult result = placeholderCommentChecker.run(assetExtractionDiffs);
+    Assert.assertTrue(result.isSuccessful());
+    Assert.assertFalse(result.isHardFail());
   }
 }

--- a/common/src/main/java/com/box/l10n/mojito/regex/PlaceholderRegularExpressions.java
+++ b/common/src/main/java/com/box/l10n/mojito/regex/PlaceholderRegularExpressions.java
@@ -37,7 +37,7 @@ public enum PlaceholderRegularExpressions {
    * '%1$@ld'
    */
   PRINTF_LIKE_IOS_REGEX(
-      "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n|@)(hh|h|l|ll|j|z|t|L|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n)*");
+      "%(?!\\s)(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?(hh|h|l|ll|j|z|t|L)?(%|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n|@)(hh|h|l|ll|j|z|t|L|d|i|u|o|x|X|f|F|e|E|g|G|a|A|c|s|p|n)*");
 
   private String regex;
 


### PR DESCRIPTION
Fix to ignore `%` in isolation being recognised as IOS placeholders, updated regex to ignore `%` followed by a whitespace character