### PR TITLE
Make the commit saving functionality idempotent.

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/CommitCreateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/CommitCreateCommandTest.java
@@ -8,6 +8,8 @@ import com.box.l10n.mojito.entity.Commit;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.service.commit.CommitService;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +60,66 @@ public class CommitCreateCommandTest extends CLITestBase {
     assertEquals(commitHash, createdCommit.getName());
     assertEquals(authorEmail, createdCommit.getAuthorEmail());
     assertEquals(authorName, createdCommit.getAuthorName());
-    assertEquals(creationDate, createdCommit.getSourceCreationDate());
+    assertEquals(creationDate.withMillisOfSecond(0).getMillis(), createdCommit.getSourceCreationDate().withMillisOfSecond(0).getMillis());
+  }
+
+  @Test
+  public void testCommitCreateIsIdempotent() throws Exception {
+    Repository repository = createTestRepoUsingRepoService();
+
+    String commitHash = "ABC456";
+    String authorEmail = "authorEmail";
+    String authorName = "authorName";
+    DateTime creationDate = DateTime.now();
+
+    L10nJCommander l10nJCommanderFirstRun = getL10nJCommander();
+    l10nJCommanderFirstRun.run(
+        "commit-create",
+        "-r",
+        repository.getName(),
+        Param.COMMIT_HASH_LONG,
+        commitHash,
+        Param.AUTHOR_EMAIL_LONG,
+        authorEmail,
+        Param.AUTHOR_NAME_LONG,
+        authorName,
+        Param.CREATION_DATE_LONG,
+        creationDate.toString());
+    assertEquals(0, l10nJCommanderFirstRun.getExitCode());
+
+    L10nJCommander l10nJCommanderSecondRun = getL10nJCommander();
+    l10nJCommanderSecondRun.run(
+        "commit-create",
+        "-r",
+        repository.getName(),
+        Param.COMMIT_HASH_LONG,
+        commitHash,
+        Param.AUTHOR_EMAIL_LONG,
+        authorEmail,
+        Param.AUTHOR_NAME_LONG,
+        authorName,
+        Param.CREATION_DATE_LONG,
+        creationDate.toString());
+    assertEquals(0, l10nJCommanderSecondRun.getExitCode());
+
+    List<Commit> commits =
+        commitService
+            .getCommits(
+                repository.getId(),
+                Collections.singletonList(commitHash),
+                null,
+                null,
+                null,
+                null,
+                Pageable.unpaged())
+            .stream()
+            .collect(Collectors.toList());
+    assertEquals(1, commits.size());
+    Commit createdCommit = commits.stream().findFirst().get();
+
+    assertEquals(commitHash, createdCommit.getName());
+    assertEquals(authorEmail, createdCommit.getAuthorEmail());
+    assertEquals(authorName, createdCommit.getAuthorName());
+    assertEquals(creationDate.withMillisOfSecond(0).getMillis(), createdCommit.getSourceCreationDate().withMillisOfSecond(0).getMillis());
   }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PushCommandTest.java
@@ -458,7 +458,7 @@ public class PushCommandTest extends CLITestBase {
 
     String commitHash = "ABC123";
     Commit commit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitHash, "authorEmail", "authorName", DateTime.now());
     assertNull(
         commitRepository

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/commit/CommitWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/commit/CommitWS.java
@@ -8,6 +8,7 @@ import com.box.l10n.mojito.rest.PageView;
 import com.box.l10n.mojito.rest.View;
 import com.box.l10n.mojito.rest.repository.RepositoryWithIdNotFoundException;
 import com.box.l10n.mojito.service.commit.CommitService;
+import com.box.l10n.mojito.service.commit.SaveCommitMismatchedExistingDataException;
 import com.box.l10n.mojito.service.pullrun.PullRunWithNameNotFoundException;
 import com.box.l10n.mojito.service.pushrun.PushRunWithNameNotFoundException;
 import com.box.l10n.mojito.service.repository.RepositoryNameNotFoundException;
@@ -180,13 +181,13 @@ public class CommitWS {
   @JsonView(View.Commit.class)
   @RequestMapping(value = "/api/commits", method = RequestMethod.POST)
   public Commit createCommit(@RequestBody CommitBody commitBody)
-      throws RepositoryWithIdNotFoundException {
+      throws RepositoryWithIdNotFoundException, SaveCommitMismatchedExistingDataException {
     Repository repository =
         repositoryRepository
             .findById(commitBody.getRepositoryId())
             .orElseThrow(() -> new RepositoryWithIdNotFoundException(commitBody.getRepositoryId()));
 
-    return commitService.saveCommit(
+    return commitService.getOrCreateCommit(
         repository,
         commitBody.getCommitName(),
         commitBody.getAuthorEmail(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/commit/SaveCommitMismatchedExistingDataException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/commit/SaveCommitMismatchedExistingDataException.java
@@ -1,0 +1,17 @@
+package com.box.l10n.mojito.service.commit;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** @author garion */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class SaveCommitMismatchedExistingDataException extends Exception {
+
+  public SaveCommitMismatchedExistingDataException(
+      String repositoryId, String existingValue, String newValue) {
+    super(
+        String.format(
+            "Could not save the commit as one with the same name and repository already exits, however the following field has a different existing value: %s . Existing value: %s . New value: %s .",
+            repositoryId, existingValue, newValue));
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/commit/CommitServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/commit/CommitServiceTest.java
@@ -47,7 +47,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     Commit retrievedCommit =
@@ -71,7 +71,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     Assert.assertNotNull(createdCommit);
@@ -82,13 +82,29 @@ public class CommitServiceTest extends ServiceTestBase {
     Assert.assertEquals(sourceCreationTime, createdCommit.getSourceCreationDate());
   }
 
-  @Test(expected = DataIntegrityViolationException.class)
-  public void testSaveCommitDuplicateNameAndRepoThrowsException() throws Exception {
+  public void testSaveCommitWithIdenticalDataReturnsSameCommit() throws Exception {
     Repository repository =
         repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
 
-    commitService.saveCommit(repository, "n1", "ae1", "an1", DateTime.now());
-    commitService.saveCommit(repository, "n1", "ae2", "an2", DateTime.now());
+    String commitName = "commitName";
+    String authorEmail = "authorEmail";
+    String authorName = "authorName";
+    DateTime creationTime = DateTime.now();
+    Commit commit1 = commitService.getOrCreateCommit(repository, commitName, authorEmail, authorName, creationTime);
+    Commit commit2 = commitService.getOrCreateCommit(repository, commitName, authorEmail, authorName, creationTime);
+    Assert.assertEquals(commit1.getId(), commit2.getId());
+  }
+
+  @Test(expected = SaveCommitMismatchedExistingDataException.class)
+  public void testSaveCommitDuplicateNameAndRepoWithDifferentDateThrows() throws Exception {
+    Repository repository =
+        repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+
+    String commitName = "commitName";
+    String authorEmail = "authorEmail";
+    String authorName = "authorName";
+    commitService.getOrCreateCommit(repository, commitName, authorEmail, authorName, DateTime.now());
+    commitService.getOrCreateCommit(repository, commitName, authorEmail, authorName, DateTime.now().plusHours(3));
   }
 
   @Test
@@ -98,8 +114,8 @@ public class CommitServiceTest extends ServiceTestBase {
     Repository repositoryB =
         repositoryService.createRepository(testIdWatcher.getEntityName("repository") + 'B');
 
-    commitService.saveCommit(repositoryA, "n1", "ae1", "an1", DateTime.now());
-    commitService.saveCommit(repositoryB, "n1", "ae2", "an2", DateTime.now());
+    commitService.getOrCreateCommit(repositoryA, "n1", "ae1", "an1", DateTime.now());
+    commitService.getOrCreateCommit(repositoryB, "n1", "ae2", "an2", DateTime.now());
   }
 
   @Test
@@ -113,7 +129,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     Optional<Commit> commitWithoutPush =
@@ -145,11 +161,11 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommitA =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameA, authorEmail, authorName, sourceCreationTime);
 
     Commit createdCommitB =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameB, authorEmail, authorName, sourceCreationTime);
 
     Optional<Commit> commitWithoutPush =
@@ -190,11 +206,11 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommitA =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameA, authorEmail, authorName, sourceCreationTime);
 
     Commit createdCommitB =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameB, authorEmail, authorName, sourceCreationTime);
 
     Optional<Commit> commitWithoutPush =
@@ -234,7 +250,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     Optional<Commit> commitWithoutPull =
@@ -266,11 +282,11 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommitA =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameA, authorEmail, authorName, sourceCreationTime);
 
     Commit createdCommitB =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameB, authorEmail, authorName, sourceCreationTime);
 
     Optional<Commit> commitWithoutPull =
@@ -311,11 +327,11 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommitA =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameA, authorEmail, authorName, sourceCreationTime);
 
     Commit createdCommitB =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitNameB, authorEmail, authorName, sourceCreationTime);
 
     Optional<Commit> commitWithoutPull =
@@ -355,7 +371,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     PushRun pushRun = new PushRun();
@@ -381,7 +397,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     PushRun pushRun = new PushRun();
@@ -408,7 +424,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     PullRun pullRun = new PullRun();
@@ -434,7 +450,7 @@ public class CommitServiceTest extends ServiceTestBase {
     DateTime sourceCreationTime = DateTime.now();
 
     Commit createdCommit =
-        commitService.saveCommit(
+        commitService.getOrCreateCommit(
             repository, commitName, authorEmail, authorName, sourceCreationTime);
 
     PullRun pullRun = new PullRun();


### PR DESCRIPTION
New requests to save commits with identical data as existing commits
will return the existing commit instead of an error.

In the case of a partial data match where the the repository and name
match, but any other data doesn't, an error will be returned back.