### PR TITLE
Added handling for delta translation in chrome extension

### DIFF
--- a/webapp/src/main/resources/public/js/ict/Ict.js
+++ b/webapp/src/main/resources/public/js/ict/Ict.js
@@ -92,9 +92,8 @@ class Ict {
             node = node.parentNode;
         }
 
-
-        var mtRequired = this.mtEnabled && textUnits[0]['isTranslated'] === 'false';
-        var eventListenerClassName = mtRequired ? "mojito-ict-string-mt" : "mojito-ict-string-active"
+        var mtRequired = this.mtEnabled && textUnits[0]['translationType'] === 'MT_REQUIRED';
+        var eventListenerClassName = mtRequired ? "mojito-ict-string-mt" : textUnits[0]['translationType'] === 'DELTA_OTA' ? "mojito-ict-string-delta-active" : "mojito-ict-string-active";
 
         if (!node.classList.contains("mojito-ict-string")) {
             try {

--- a/webapp/src/main/resources/public/js/ict/IctMetadataBuilder.js
+++ b/webapp/src/main/resources/public/js/ict/IctMetadataBuilder.js
@@ -2,19 +2,19 @@ import TagsBlockEncoder from './TagsBlockEncoder';
 
 class IctMetadataBuilder {
 
-    getTranslationWithMetadata(repositoryName, assetName, textUnitName, localeName, stack, translation, isTranslated) {
-        var textUnitMetadata = this.getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack, isTranslated);
+    getTranslationWithMetadata(repositoryName, assetName, textUnitName, localeName, stack, translation, translationType) {
+        var textUnitMetadata = this.getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack, translationType);
         var textUnitMetadataAsTagsBlock = TagsBlockEncoder.unicodeToTagsBlock(textUnitMetadata);
         return this.getStartDelimiter() + textUnitMetadataAsTagsBlock + this.getMiddleDelimiter() + translation + this.getEndDelimiter();
     }
 
-    getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack, isTranslated) {
+    getTextUnitMetadata(repositoryName, assetName, textUnitName, localeName, stack, translationType) {
         return repositoryName + this.getInnerDelimiter()
                 + (assetName ? assetName : "") + this.getInnerDelimiter()
                 + textUnitName + this.getInnerDelimiter()
                 + localeName + this.getInnerDelimiter()
                 + stack + this.getInnerDelimiter()
-                + isTranslated;
+                + translationType;
     }
 
     getStartDelimiter() {

--- a/webapp/src/main/resources/public/js/ict/IctMetadataExtractor.js
+++ b/webapp/src/main/resources/public/js/ict/IctMetadataExtractor.js
@@ -37,8 +37,8 @@ class IctMetadataExtractor {
                         textUnit['textUnitName'] = splitTextUnitMetadata[2];
                         textUnit['locale'] = splitTextUnitMetadata[3];
                         textUnit['stack'] = splitTextUnitMetadata[4];
-                        // For backwards compatibility check array length, if less than 5 set isTranslated to true
-                        textUnit['isTranslated'] = splitTextUnitMetadata.length > 5 ? splitTextUnitMetadata[5] : 'true';
+                        // For backwards compatibility check array length, if less than 5 set translationType to 'NATIVE'
+                        textUnit['translationType'] = splitTextUnitMetadata.length > 5 ? splitTextUnitMetadata[5] : 'NATIVE';
 
                     } catch (e) {
                         console.log("Can't extract ict metadata from string: ", string, e);

--- a/webapp/src/main/resources/public/js/ict/IctModal.js
+++ b/webapp/src/main/resources/public/js/ict/IctModal.js
@@ -21,6 +21,7 @@ class ModalTextUnit extends React.Component {
         return (
             <div className={className} 
                  onClick={() => this.props.onSelect(textUnit)}>
+                {textUnit.translationType === 'DELTA_OTA' && <div className="mbs">This text unit is being served from the Mojito Delta API.</div> }
                 {textUnit.isMachineTranslated && <div className="mbs">This text unit has been machine translated.</div> }
                 <div className="mbs">
                     <Label className="mbs clickable label label-primary mrs">

--- a/webapp/src/main/resources/sass/ict.scss
+++ b/webapp/src/main/resources/sass/ict.scss
@@ -2,6 +2,10 @@
     border: 1px solid green !important;
 }
 
+.mojito-ict-string-delta-active {
+    border: 1px solid blue !important;
+}
+
 .mojito-ict-string-mt {
     border: 1px solid orange !important;
 }


### PR DESCRIPTION
Updated chrome extension to support displaying dellta translations with a different colour box on hover and to indicate in the associated text unit modal that the translation is being served via the new Mojito Delta API introduced in  #835 