### PR TITLE
Truncate the Branch TextUnit View in Mojito Workbench with large text unit counts

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/BranchStatistic.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/BranchStatistic.java
@@ -27,6 +27,19 @@ import javax.persistence.*;
               @NamedAttributeNode(value = "screenshots"),
               @NamedAttributeNode(value = "repository"),
             }))
+@NamedEntityGraph(
+    name = "BranchStatisticGraphWithoutTextUnits",
+    attributeNodes = {
+      @NamedAttributeNode(value = "branch", subgraph = "branchGraph"),
+    },
+    subgraphs = {
+      @NamedSubgraph(
+          name = "branchGraph",
+          attributeNodes = {
+            @NamedAttributeNode(value = "screenshots"),
+            @NamedAttributeNode(value = "repository"),
+          })
+    })
 public class BranchStatistic extends BaseEntity {
 
   @JsonView(View.BranchStatistic.class)

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticSpecification.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticSpecification.java
@@ -127,16 +127,4 @@ public class BranchStatisticSpecification {
       }
     };
   }
-
-  public static SingleParamSpecification<BranchStatistic> totalCountLessThanOrEqualsTo(
-      final long count) {
-
-    return new SingleParamSpecification<BranchStatistic>(count) {
-      @Override
-      public Predicate toPredicate(
-          Root<BranchStatistic> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-        return builder.lessThanOrEqualTo(root.get(BranchStatistic_.totalCount), count);
-      }
-    };
-  }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/BranchStatisticWS.java
@@ -8,7 +8,6 @@ import static com.box.l10n.mojito.rest.repository.BranchStatisticSpecification.c
 import static com.box.l10n.mojito.rest.repository.BranchStatisticSpecification.deletedEquals;
 import static com.box.l10n.mojito.rest.repository.BranchStatisticSpecification.empty;
 import static com.box.l10n.mojito.rest.repository.BranchStatisticSpecification.search;
-import static com.box.l10n.mojito.rest.repository.BranchStatisticSpecification.totalCountLessThanOrEqualsTo;
 import static com.box.l10n.mojito.specification.Specifications.ifParamNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.data.jpa.domain.Specification.where;
@@ -22,6 +21,7 @@ import com.box.l10n.mojito.service.branch.BranchStatisticRepository;
 import com.box.l10n.mojito.service.branch.SparseBranchStatisticRepository;
 import com.fasterxml.jackson.annotation.JsonView;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +64,7 @@ public class BranchStatisticWS {
       @RequestParam(value = "createdAfter", required = false) DateTime createdAfter,
       @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
     // Two phase querying: 1. retrieve BranchStatistic IDs for pagination first
+    // Retrieve all the Branch Statistic Ids without the totalCountLte filter:
     Page<Long> branchStatisticIds =
         sparseBranchStatisticRepository.findAllWithIdOnly(
             where(ifParamNotNull(createdByUserNameEquals(createdByUserName)))
@@ -73,15 +74,38 @@ public class BranchStatisticWS {
                 .and(ifParamNotNull(deletedEquals(deleted)))
                 .and(ifParamNotNull(empty(empty)))
                 .and(ifParamNotNull(createdBefore(createdBefore)))
-                .and(ifParamNotNull(createdAfter(createdAfter)))
-                .and(totalCountLessThanOrEqualsTo(totalCountLte)),
+                .and(ifParamNotNull(createdAfter(createdAfter))),
             pageable);
+
+    // Retrieve the branch statistics where the total text unit count is greater than the limit,
+    // by filtering the branchStatisticIds less than the limit.
+    List<BranchStatistic> branchStatisticsWithoutTextUnits =
+        branchStatisticRepository.findAllGreaterThanById(
+            branchStatisticIds.getContent(), totalCountLte);
+
+    // Set the BranchTextUnitStatistics to null as the branch has a large number of text Units.
+    branchStatisticsWithoutTextUnits.forEach(
+        branchStatistic -> {
+          branchStatistic.setBranchTextUnitStatistics(null);
+        });
+
+    List<Long> branchStatisticIdsWithoutTextUnits =
+        branchStatisticsWithoutTextUnits.stream()
+            .map(BranchStatistic::getId)
+            .collect(Collectors.toList());
+
+    List<Long> branchStatisticIdsWithLessThan =
+        branchStatisticIds.getContent().stream()
+            .filter(i -> !branchStatisticIdsWithoutTextUnits.contains(i))
+            .collect(Collectors.toList());
 
     // 2. Hydrate BranchStatistic entities for JSON response using eager loading to avoid N+1
     // queries
     List<BranchStatistic> branchStatistics =
-        branchStatisticRepository.findByIdIn(branchStatisticIds.getContent(), pageable.getSort());
+        branchStatisticRepository.findByIdIn(branchStatisticIdsWithLessThan, pageable.getSort());
 
+    // Merge the two lists:
+    branchStatistics.addAll(branchStatisticsWithoutTextUnits);
     PageImpl<BranchStatistic> page =
         new PageImpl<>(
             branchStatistics,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/BranchStatisticRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 /** @author jeanaurambault */
@@ -16,6 +17,12 @@ public interface BranchStatisticRepository
 
   @EntityGraph(value = "BranchStatisticGraph", type = EntityGraph.EntityGraphType.LOAD)
   List<BranchStatistic> findByIdIn(List<Long> branchStatisticIds, Sort sort);
+
+  @EntityGraph(
+      value = "BranchStatisticGraphWithoutTextUnits",
+      type = EntityGraph.EntityGraphType.LOAD)
+  @Query("select bs " + "from BranchStatistic bs " + "where bs.id in ?1 and bs.totalCount > ?2")
+  List<BranchStatistic> findAllGreaterThanById(List<Long> branchStatisticIds, Long totalCountLte);
 
   BranchStatistic findByBranch(Branch branch);
 }

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -70,6 +70,9 @@ branches.searchResults.tooltip.withscreenshots=See screenshots
 # Tooltip shown on the button to open the screenshoot review modal when no screenshot has been added
 branches.searchResults.tooltip.noscreenshots=No screenshots yet
 
+# Message displayed when there's more than 30000 text units.
+branches.searchResults.truncated=Results cannot be shown as the branch contains high number of Text Units (more than 30,000).
+
 # upload reminder
 upload.screenshot.prompt=Please choose image and upload screenshot
 

--- a/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.js
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesSearchResults.js
@@ -71,9 +71,14 @@ class BranchesSearchResults extends React.Component {
 
         rows.push(this.renderBranchStatisticSummary(branchStatistic));
 
-        branchStatistic.branchTextUnitStatistics.map((branchTextUnitStatistic) => {
-            rows.push(this.renderBranchTextUnitStatistic(branchStatistic, branchTextUnitStatistic));
-        });
+        if (branchStatistic.isTruncated === false){
+            branchStatistic.branchTextUnitStatistics.map((branchTextUnitStatistic) => {
+                rows.push(this.renderBranchTextUnitStatistic(branchStatistic, branchTextUnitStatistic));
+            });
+        }
+        else {
+            rows.push(this.renderBranchTruncatedNotification(branchStatistic));
+        }
 
         rows.push(this.renderBranchStatisticSeparator(branchStatistic));
 
@@ -267,6 +272,14 @@ class BranchesSearchResults extends React.Component {
         return (
             <Collapse key={`renderBranchStatisticSeparator-${branchStatistic.id}`} in={this.isBranchStatisticOpen(branchStatistic)}>
                 <Row className="mbl"></Row>
+            </Collapse>
+        );
+    }
+
+    renderBranchTruncatedNotification(branchStatistic) {
+        return (
+            <Collapse key={`renderBranchStatisticSeparator-${branchStatistic.id}`} in={this.isBranchStatisticOpen(branchStatistic)}>
+                <Row className="mbl"><FormattedMessage id="branches.searchResults.truncated"></FormattedMessage></Row>
             </Collapse>
         );
     }

--- a/webapp/src/main/resources/public/js/sdk/entity/BranchStatisticsContent.js
+++ b/webapp/src/main/resources/public/js/sdk/entity/BranchStatisticsContent.js
@@ -1,5 +1,6 @@
 import Branch from "./Branch"
 import BranchTextUnitStatistics from "./BranchTextUnitStatistics";
+const totalCountLte = 30000;
 
 export default class BranchStatisticsContent {
     constructor() {
@@ -18,7 +19,7 @@ export default class BranchStatisticsContent {
 
         /**
          *
-         * @type {branchStatisticsContent[]}
+         * @type {BranchTextUnitStatistics[]}
          */
         this.branchTextUnitStatistics = [];
 
@@ -34,19 +35,29 @@ export default class BranchStatisticsContent {
          */
         this.totalCount = null;
 
+        /**
+         *
+         * @type {boolean}
+         */
+        this.isTruncated = false;
+
     }
 
     static toContent(json) {
         let result = new BranchStatisticsContent();
-
         if (json) {
             result.id = json.id;
             result.branch = Branch.toBranch(json.branch);
-            result.branchTextUnitStatistics = BranchTextUnitStatistics.toBranchTextUnitStatisticsList(json.branchTextUnitStatistics);
             result.forTranslationCount = json.forTranslationCount;
             result.totalCount = json.totalCount;
-        }
 
+            if (result.totalCount > totalCountLte){
+                result.isTruncated = true;
+            }
+            else {
+                result.branchTextUnitStatistics = BranchTextUnitStatistics.toBranchTextUnitStatisticsList(json.branchTextUnitStatistics);
+            }
+        }
 
         return result;
     }


### PR DESCRIPTION
Truncate the Branch TextUnit View in Mojito Workbench with large text unit counts
- Retrieve the branches with greater than 30,000 text units without retrieving the TextUnit table
- Show the branches with the high count in the workbench, with the message 'Results cannot be shown as the branch contains high number of Text Units (more than 30,000).'

![Screenshot 2022-09-13 at 16 54 13](https://user-images.githubusercontent.com/104581098/189952313-3362ea53-10d6-43e9-af79-67a73c8f979d.png)
