### PR TITLE
Add an option in CommitCreateCommand to read the information from Git

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/CommitCreateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/CommitCreateCommand.java
@@ -8,8 +8,17 @@ import com.box.l10n.mojito.rest.client.CommitClient;
 import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.entity.Commit;
 import com.box.l10n.mojito.rest.entity.Repository;
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.fusesource.jansi.Ansi;
 import org.joda.time.DateTime;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +47,6 @@ public class CommitCreateCommand extends Command {
   @Parameter(
       names = {Param.COMMIT_HASH_LONG, Param.COMMIT_HASH_SHORT},
       arity = 1,
-      required = true,
       description = Param.COMMIT_CREATE_DESCRIPTION)
   String commitHash;
 
@@ -52,24 +60,29 @@ public class CommitCreateCommand extends Command {
   @Parameter(
       names = {Param.AUTHOR_NAME_LONG, Param.AUTHOR_NAME_SHORT},
       arity = 1,
-      required = true,
       description = Param.AUTHOR_NAME_DESCRIPTION)
   String authorNameParam;
 
   @Parameter(
       names = {Param.AUTHOR_EMAIL_LONG, Param.AUTHOR_EMAIL_SHORT},
       arity = 1,
-      required = true,
       description = Param.AUTHOR_EMAIL_DESCRIPTION)
   String authorEmailParam;
 
   @Parameter(
       names = {Param.CREATION_DATE_LONG, Param.CREATION_DATE_SHORT},
       arity = 1,
-      required = true,
       description = Param.CREATION_DATE_DESCRIPTION,
       converter = DateTimeConverter.class)
   DateTime creationDateParam;
+
+  @Parameter(
+      names = {"--read-from-git"},
+      description =
+          "To read the commit information (author name, author email, and commit date) from git instead "
+              + "of passing them in as command arguments. '--commit-hash' is optional. If not provided"
+              + " the first commit from 'git log' is used.")
+  boolean readInfoFromGit = false;
 
   @Override
   protected void execute() throws CommandException {
@@ -82,9 +95,21 @@ public class CommitCreateCommand extends Command {
 
     Repository repository = commandHelper.findRepositoryByName(repositoryParam);
 
+    final CommitInfo commitInfo;
+
+    if (readInfoFromGit) {
+      commitInfo = readFromGit();
+    } else {
+      commitInfo = new CommitInfo(commitHash, authorEmailParam, authorNameParam, creationDateParam);
+    }
+
     Commit commit =
         commitClient.createCommit(
-            commitHash, repository.getId(), authorNameParam, authorEmailParam, creationDateParam);
+            commitInfo.hash,
+            repository.getId(),
+            commitInfo.authorName,
+            commitInfo.authorEmail,
+            commitInfo.creationDate);
 
     consoleWriter
         .fg(Ansi.Color.GREEN)
@@ -93,5 +118,71 @@ public class CommitCreateCommand extends Command {
         .fg(Ansi.Color.CYAN)
         .a(commit.getId())
         .println(2);
+  }
+
+  CommitInfo readFromGit() {
+    final CommandDirectories commandDirectories = new CommandDirectories(null);
+    final GitRepository gitRepository = new GitRepository();
+
+    gitRepository.init(commandDirectories.getSourceDirectoryPath().toString());
+
+    try {
+      final RevCommit revCommit;
+
+      if (commitHash != null) {
+        RevWalk walk = new RevWalk(gitRepository.jgitRepository);
+        ObjectId commitObjectId = gitRepository.jgitRepository.resolve(commitHash);
+        if (commitObjectId == null) {
+          throw new CommandException(
+              "The provided commit hash: '" + commitHash + "' cannot be resolved");
+        }
+        revCommit = walk.parseCommit(commitObjectId);
+      } else {
+        revCommit =
+            Streams.stream(new Git(gitRepository.jgitRepository).log().setMaxCount(1).call())
+                .findFirst()
+                .orElseThrow(() -> new CommandException("There is no commits in the log"));
+      }
+
+      final PersonIdent authorIdent = revCommit.getAuthorIdent();
+
+      final CommitInfo commitInfo =
+          new CommitInfo(
+              revCommit.getName(),
+              authorIdent.getEmailAddress(),
+              authorIdent.getName(),
+              Instant.ofEpochSecond(revCommit.getCommitTime()).toDateTime());
+
+      consoleWriter
+          .a("Read from Git - hash: '")
+          .a(commitInfo.hash)
+          .a("', author email: '")
+          .a(commitInfo.authorEmail)
+          .a("', author name: '")
+          .a(commitInfo.authorName)
+          .a("', date: '")
+          .a(commitInfo.creationDate)
+          .println();
+
+      return commitInfo;
+
+    } catch (IOException | GitAPIException ioException) {
+      throw new CommandException("Can't retreive information from Git", ioException);
+    }
+  }
+
+  static final class CommitInfo {
+
+    String hash;
+    String authorEmail;
+    String authorName;
+    DateTime creationDate;
+
+    public CommitInfo(String hash, String authorEmail, String authorName, DateTime creationDate) {
+      this.hash = hash;
+      this.authorEmail = authorEmail;
+      this.authorName = authorName;
+      this.creationDate = creationDate;
+    }
   }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
@@ -196,4 +196,11 @@ public class CLITestBase extends IOTestBase {
       Thread.sleep(numberAttempt * 100);
     }
   }
+
+  /** GitActions has an even differnt type of checkout than Travis, just skip for now */
+  protected boolean isGitActions() {
+    Boolean githubActions = Boolean.valueOf(System.getenv("GITHUB_ACTIONS"));
+    logger.info("Github actions: {}", githubActions);
+    return githubActions;
+  }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GitBlameCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GitBlameCommandTest.java
@@ -46,13 +46,6 @@ public class GitBlameCommandTest extends CLITestBase {
    */
   boolean shallowClone = true;
 
-  /** GitActions has an even differnt type of checkout than Travis, just skip for now */
-  boolean isGitActions() {
-    Boolean githubActions = Boolean.valueOf(System.getenv("GITHUB_ACTIONS"));
-    logger.info("Github actions: {}", githubActions);
-    return githubActions;
-  }
-
   @Test
   public void android() throws Exception {
     Assume.assumeFalse(isGitActions());


### PR DESCRIPTION
Use --read-from-git option to read the commit information from Git. The commit hash is optional. If not provided, the first commit from 'git log' is used.