### PR TITLE
Accept any basename in MacStringsFileType and MacStringsdictFileType

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/MacStringsFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/MacStringsFileType.java
@@ -15,7 +15,7 @@ public class MacStringsFileType extends FileType {
 
   public MacStringsFileType() {
     this.sourceFileExtension = "strings";
-    this.baseNamePattern = ".*?Localizable|InfoPlist";
+    this.baseNamePattern = ".+?";
     this.subPath = "lproj";
     this.sourceFilePatternTemplate =
         "{"

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/MacStringsdictFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/MacStringsdictFileType.java
@@ -15,7 +15,7 @@ public class MacStringsdictFileType extends FileType {
 
   public MacStringsdictFileType() {
     this.sourceFileExtension = "stringsdict";
-    this.baseNamePattern = "Localizable";
+    this.baseNamePattern = ".+?";
     this.subPath = "lproj";
     this.sourceFilePatternTemplate =
         "{"


### PR DESCRIPTION
Before we were limiting to Localizable and InfoPlist but this prevent locailzation of some widgets. We're most likely fine making the basename be anything