### PR TITLE
Exit with an error code if the JCommander parsing fails

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
@@ -115,6 +115,7 @@ public class L10nJCommander {
       } else {
         usage(parsedCommand);
       }
+      exitWithError();
     } else {
       logger.debug("Execute commands for parsed command: {}", parsedCommand);
       Command command = getCommand(parsedCommand);


### PR DESCRIPTION
Before it was only showing the help info but we also need to fail the command