### PR TITLE
Added icons to extraction check failure notifications

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderPhabricator.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderPhabricator.java
@@ -48,12 +48,16 @@ public class ExtractionCheckNotificationSenderPhabricator
       sb.append(
           results.stream()
               .map(
-                  check ->
-                      "**"
-                          + check.getCheckName()
-                          + "**"
-                          + getDoubleNewLines()
-                          + check.getNotificationText())
+                  check -> {
+                    PhabricatorIcon icon =
+                        check.isHardFail() ? PhabricatorIcon.STOP : PhabricatorIcon.WARNING;
+                    return icon
+                        + " **"
+                        + check.getCheckName()
+                        + "**"
+                        + getDoubleNewLines()
+                        + check.getNotificationText();
+                  })
               .collect(Collectors.joining(System.lineSeparator())));
       sb.append(
           getDoubleNewLines() + "**" + "Please correct the above issues in a new commit." + "**");

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderSlack.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderSlack.java
@@ -72,13 +72,16 @@ public class ExtractionCheckNotificationSenderSlack extends ExtractionCheckNotif
     sb.append(
         failures.stream()
             .map(
-                check ->
-                    "*"
-                        + check.getCheckName()
-                        + "*"
-                        + getDoubleNewLines()
-                        + check.getNotificationText()
-                        + getDoubleNewLines())
+                check -> {
+                  String emoji = check.isHardFail() ? ":stop:" : ":warning:";
+                  return emoji
+                      + " *"
+                      + check.getCheckName()
+                      + "*"
+                      + getDoubleNewLines()
+                      + check.getNotificationText()
+                      + getDoubleNewLines();
+                })
             .collect(Collectors.joining(System.lineSeparator())));
     sb.append(getDoubleNewLines() + "*" + "Please correct the above issues in a new commit." + "*");
     String message =

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderPhabricatorTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderPhabricatorTest.java
@@ -68,6 +68,7 @@ public class ExtractionCheckNotificationSenderPhabricatorTest {
     Assert.assertTrue(messageCaptor.getValue().contains(PhabricatorIcon.WARNING.toString()));
     Assert.assertTrue(messageCaptor.getValue().contains("Test Check"));
     Assert.assertTrue(messageCaptor.getValue().contains("Some notification text"));
+    Assert.assertTrue(messageCaptor.getValue().contains(PhabricatorIcon.WARNING.toString()));
   }
 
   @Test
@@ -107,6 +108,7 @@ public class ExtractionCheckNotificationSenderPhabricatorTest {
     Assert.assertTrue(messageCaptor.getValue().contains("Test Check"));
     Assert.assertTrue(messageCaptor.getValue().contains("Some notification text"));
     Assert.assertTrue(messageCaptor.getValue().contains("This is a hard failure message"));
+    Assert.assertTrue(messageCaptor.getValue().contains(PhabricatorIcon.STOP.toString()));
   }
 
   @Test

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderSlackTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderSlackTest.java
@@ -85,6 +85,7 @@ public class ExtractionCheckNotificationSenderSlackTest {
     Assert.assertTrue(attachment.getText().contains("*i18n source string checks failed*"));
     Assert.assertTrue(attachment.getText().contains("Test Check"));
     Assert.assertTrue(attachment.getText().contains("Some notification text"));
+    Assert.assertTrue(attachment.getText().contains(":warning:"));
   }
 
   @Test
@@ -129,6 +130,7 @@ public class ExtractionCheckNotificationSenderSlackTest {
     Assert.assertTrue(attachment.getText().contains("Test Check"));
     Assert.assertTrue(attachment.getText().contains("Some notification text"));
     Assert.assertTrue(attachment.getText().contains("This is a hard failure message."));
+    Assert.assertTrue(attachment.getText().contains(":stop:"));
   }
 
   @Test


### PR DESCRIPTION
Adds icons to the the check names for Phabricator & Slack notifications.:warning: is used for soft failures, 🛑  icon for hard failures