### PR TITLE
Added screenshot API method to retrieve screenshot id

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/screenshot/ScreenshotWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/screenshot/ScreenshotWS.java
@@ -67,6 +67,20 @@ public class ScreenshotWS {
         limit);
   }
 
+  @RequestMapping(
+      value = "/api/screenshots/{screenShotRunId}/{screenshotName}",
+      method = RequestMethod.GET)
+  public Long getScreenshotIdByScreenshotRunAndName(
+      @PathVariable Long screenShotRunId, @PathVariable String screenshotName) {
+    Screenshot screenshot =
+        screenshotService.getScreenshotByScreenshotRunAndName(screenShotRunId, screenshotName);
+    if (screenshot == null) {
+      throw new ScreenshotWithNameAndScreenshotRunIdNotFoundException(
+          screenshotName, screenShotRunId);
+    }
+    return screenshot.getId();
+  }
+
   @RequestMapping(value = "/api/screenshots/{id}", method = RequestMethod.PUT)
   public void updateScreenshot(@PathVariable Long id, @RequestBody Screenshot screenshot) {
     screenshot.setId(id);

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/screenshot/ScreenshotWithNameAndScreenshotRunIdNotFoundException.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/screenshot/ScreenshotWithNameAndScreenshotRunIdNotFoundException.java
@@ -1,0 +1,18 @@
+package com.box.l10n.mojito.rest.screenshot;
+
+import com.ibm.icu.text.MessageFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ScreenshotWithNameAndScreenshotRunIdNotFoundException extends RuntimeException {
+
+  public ScreenshotWithNameAndScreenshotRunIdNotFoundException(String name, Long screenshotRunId) {
+    super(getMessage(name, screenshotRunId));
+  }
+
+  static String getMessage(String name, Long screenshotRunId) {
+    return MessageFormat.format(
+        "Screenshot with name {0} in run {1} not found", name, screenshotRunId);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotRepository.java
@@ -18,6 +18,9 @@ public interface ScreenshotRepository
   Screenshot findByScreenshotRunAndNameAndLocale(
       ScreenshotRun screenshotRun, String name, Locale locale);
 
+  Screenshot findScreenshotByScreenshotRunAndName(
+      ScreenshotRun screenshotRunId, String screenshotName);
+
   @Query(
       value =
           "select s from #{#entityName} s "

--- a/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/screenshot/ScreenshotService.java
@@ -353,6 +353,13 @@ public class ScreenshotService {
     return screenshotsByTextUnit;
   }
 
+  public Screenshot getScreenshotByScreenshotRunAndName(
+      Long screenshotRunId, String screenshotName) {
+    ScreenshotRun screenshotRun = new ScreenshotRun();
+    screenshotRun.setId(screenshotRunId);
+    return screenshotRepository.findScreenshotByScreenshotRunAndName(screenshotRun, screenshotName);
+  }
+
   private Predicate getPredicateForSearchType(
       SearchType searchType, CriteriaBuilder builder, Path<String> searchPath, String searchValue) {
 


### PR DESCRIPTION
Added API method to retrieve screenshot id given a screenshot run id and screenshot name, to be utilized by clients wanting to use the delete screenshot functionality introduced in PR #874 via the API instead of the UI.