### PR TITLE
Added GithubClient and GithubPRInfoCommand

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
@@ -1,0 +1,110 @@
+package com.box.l10n.mojito.cli.command;
+
+import static com.box.l10n.mojito.cli.command.utils.DiffInfoUtils.getUsernameForAuthorEmail;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.github.GithubClient;
+import com.box.l10n.mojito.github.GithubException;
+import java.io.IOException;
+import java.util.List;
+import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.ReactionContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * Command to export Github Pull Request info to a list of environment variables
+ *
+ * @author maallen
+ */
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"github-pr-to-env-variables"},
+    commandDescription = "Get PR info: base commit")
+public class GithubPRInfoCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(GithubPRInfoCommand.class);
+
+  protected static final String SKIP_I18N_CHECKS_FLAG = "SKIP_I18N_CHECKS";
+
+  @Qualifier("ansiCodeEnabledFalse")
+  @Autowired
+  ConsoleWriter consoleWriterAnsiCodeEnabledFalse;
+
+  @Autowired(required = false)
+  GithubClient githubClient;
+
+  @Parameter(
+      names = {"--repository"},
+      arity = 1,
+      required = true,
+      description = "Github repository name")
+  String repository;
+
+  @Parameter(
+      names = {"--pr-number"},
+      arity = 1,
+      required = true,
+      description = "The Github PR number")
+  Integer prNumber;
+
+  @Override
+  public void execute() throws CommandException {
+
+    if (githubClient == null) {
+      throw new CommandException(
+          "Github must be configured with properties: l10n.github.appId, l10n.github.key and l10n.github.owner");
+    }
+
+    try {
+      consoleWriterAnsiCodeEnabledFalse
+          .a("MOJTIO_GITHUB_BASE_COMMIT=")
+          .a(githubClient.getPRBaseCommit(repository, prNumber))
+          .println();
+      String authorEmail = githubClient.getPRAuthorEmail(repository, prNumber);
+      consoleWriterAnsiCodeEnabledFalse.a("MOJITO_GITHUB_AUTHOR_EMAIL=").a(authorEmail).println();
+      consoleWriterAnsiCodeEnabledFalse
+          .a("MOJITO_GITHUB_AUTHOR_USERNAME=")
+          .a(getUsernameForAuthorEmail(authorEmail))
+          .println();
+      List<GHIssueComment> prComments = githubClient.getPRComments(repository, prNumber);
+      if (isSkipChecks(prComments)) {
+        addReactionToSkipChecksComment(prComments);
+        consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=true").println();
+      } else {
+        consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=false").println();
+      }
+    } catch (GithubException e) {
+      throw new CommandException(e);
+    }
+  }
+
+  private static boolean isSkipChecks(List<GHIssueComment> prComments) {
+    return prComments.stream()
+        .anyMatch(ghIssueComment -> ghIssueComment.getBody().contains(SKIP_I18N_CHECKS_FLAG));
+  }
+
+  private static void addReactionToSkipChecksComment(List<GHIssueComment> prComments) {
+    prComments.stream()
+        .filter(ghIssueComment -> ghIssueComment.getBody().contains(SKIP_I18N_CHECKS_FLAG))
+        .findFirst()
+        .map(ghIssueComment -> addReactionToComment(ghIssueComment));
+  }
+
+  private static GHIssueComment addReactionToComment(GHIssueComment ghIssueComment) {
+    try {
+      ghIssueComment.createReaction(ReactionContent.PLUS_ONE);
+      return ghIssueComment;
+    } catch (IOException e) {
+      logger.error("Error adding reaction to PR comment: " + e.getMessage());
+    }
+    return ghIssueComment;
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommand.java
@@ -1,5 +1,7 @@
 package com.box.l10n.mojito.cli.command;
 
+import static com.box.l10n.mojito.cli.command.utils.DiffInfoUtils.getUsernameForAuthorEmail;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.box.l10n.mojito.cli.console.ConsoleWriter;
@@ -94,15 +96,5 @@ public class PhabricatorDiffInfoCommand extends Command {
     } else {
       consoleWriterAnsiCodeEnabledFalse.a("MOJITO_SKIP_I18N_CHECKS=false").println();
     }
-  }
-
-  String getUsernameForAuthorEmail(String email) {
-    String username = null;
-
-    if (email != null) {
-      username = email.replaceFirst("(.*)@.*$", "$1");
-    }
-
-    return username;
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/utils/DiffInfoUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/utils/DiffInfoUtils.java
@@ -1,0 +1,14 @@
+package com.box.l10n.mojito.cli.command.utils;
+
+public class DiffInfoUtils {
+
+  public static String getUsernameForAuthorEmail(String email) {
+    String username = null;
+
+    if (email != null) {
+      username = email.replaceFirst("(.*)@.*$", "$1");
+    }
+
+    return username;
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
@@ -1,0 +1,80 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.github.GithubClient;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.ReactionContent;
+import org.mockito.Mockito;
+
+public class GithubPRInfoCommandTest {
+
+  GithubClient githubMock;
+
+  ConsoleWriter consoleWriterMock;
+
+  GHIssueComment ghIssueCommentMock;
+
+  GithubPRInfoCommand githubPRInfoCommand;
+
+  @Before
+  public void setup() {
+    githubMock = Mockito.mock(GithubClient.class);
+    consoleWriterMock = Mockito.mock(ConsoleWriter.class);
+    ghIssueCommentMock = Mockito.mock(GHIssueComment.class);
+    githubPRInfoCommand = new GithubPRInfoCommand();
+    githubPRInfoCommand.repository = "testRepo";
+    githubPRInfoCommand.prNumber = 1;
+    githubPRInfoCommand.githubClient = githubMock;
+    githubPRInfoCommand.consoleWriterAnsiCodeEnabledFalse = consoleWriterMock;
+
+    when(githubMock.getPRBaseCommit("testRepo", 1)).thenReturn("baseSha");
+    when(githubMock.getPRAuthorEmail("testRepo", 1)).thenReturn("some@email.com");
+    List<GHIssueComment> mockComments = Lists.newArrayList(ghIssueCommentMock);
+    when(ghIssueCommentMock.getBody()).thenReturn("some comment");
+    when(githubMock.getPRComments("testRepo", 1)).thenReturn(mockComments);
+    when(consoleWriterMock.a(isA(String.class))).thenReturn(consoleWriterMock);
+    when(consoleWriterMock.println()).thenReturn(consoleWriterMock);
+  }
+
+  @Test
+  public void testExecute() {
+    githubPRInfoCommand.execute();
+    verify(consoleWriterMock, times(1)).a("MOJTIO_GITHUB_BASE_COMMIT=");
+    verify(consoleWriterMock, times(1)).a("baseSha");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_EMAIL=");
+    verify(consoleWriterMock, times(1)).a("some@email.com");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
+    verify(consoleWriterMock, times(1)).a("some");
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=false");
+  }
+
+  @Test
+  public void testExecuteWithChecksSkipped() throws IOException {
+    when(ghIssueCommentMock.getBody()).thenReturn("SKIP_I18N_CHECKS");
+    githubPRInfoCommand.execute();
+    verify(consoleWriterMock, times(1)).a("MOJTIO_GITHUB_BASE_COMMIT=");
+    verify(consoleWriterMock, times(1)).a("baseSha");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_EMAIL=");
+    verify(consoleWriterMock, times(1)).a("some@email.com");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_USERNAME=");
+    verify(consoleWriterMock, times(1)).a("some");
+    verify(consoleWriterMock, times(1)).a("MOJITO_SKIP_I18N_CHECKS=true");
+    verify(ghIssueCommentMock, times(1)).createReaction(ReactionContent.PLUS_ONE);
+  }
+
+  @Test(expected = CommandException.class)
+  public void testGithubClientNotAvailable() {
+    githubPRInfoCommand.githubClient = null;
+    githubPRInfoCommand.execute();
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PhabricatorDiffInfoCommandTest.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.cli.command;
 
 import static com.box.l10n.mojito.cli.command.PhabricatorDiffInfoCommand.SKIP_I18N_CHECKS_FLAG;
+import static com.box.l10n.mojito.cli.command.utils.DiffInfoUtils.getUsernameForAuthorEmail;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.times;
@@ -19,23 +20,21 @@ public class PhabricatorDiffInfoCommandTest {
   @Test
   public void testGetUsernameForAuthorEmailNull() {
     PhabricatorDiffInfoCommand phabricatorDiffInfoCommand = new PhabricatorDiffInfoCommand();
-    String usernameForAuthorEmail = phabricatorDiffInfoCommand.getUsernameForAuthorEmail(null);
+    String usernameForAuthorEmail = getUsernameForAuthorEmail(null);
     assertEquals(null, usernameForAuthorEmail);
   }
 
   @Test
   public void testGetUsernameForAuthorEmail() {
     PhabricatorDiffInfoCommand phabricatorDiffInfoCommand = new PhabricatorDiffInfoCommand();
-    String usernameForAuthorEmail =
-        phabricatorDiffInfoCommand.getUsernameForAuthorEmail("username@test.com");
+    String usernameForAuthorEmail = getUsernameForAuthorEmail("username@test.com");
     assertEquals("username", usernameForAuthorEmail);
   }
 
   @Test
   public void testGetUsernameForAuthorInvalid() {
     PhabricatorDiffInfoCommand phabricatorDiffInfoCommand = new PhabricatorDiffInfoCommand();
-    String usernameForAuthorEmail =
-        phabricatorDiffInfoCommand.getUsernameForAuthorEmail("notanemail");
+    String usernameForAuthorEmail = getUsernameForAuthorEmail("notanemail");
     assertEquals("notanemail", usernameForAuthorEmail);
   }
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -297,6 +297,30 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-aspects</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>${github.api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClient.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClient.java
@@ -1,0 +1,249 @@
+package com.box.l10n.mojito.github;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.io.IOException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
+import java.util.List;
+import org.apache.commons.codec.binary.Base64;
+import org.kohsuke.github.GHAppInstallationToken;
+import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GithubClient {
+
+  /**
+   * Maximum allowed Github JWT is 10 minutes
+   *
+   * @see <a
+   *     https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app<a/>
+   */
+  private static final long MAX_GITHUB_JWT_TTL = 10 * 60000;
+
+  private static Logger logger = LoggerFactory.getLogger(GithubClient.class);
+
+  private final String appId;
+
+  private final String owner;
+
+  private final long tokenTTL;
+
+  private final String key;
+
+  private GithubJWT githubJWT;
+
+  private PrivateKey signingKey;
+
+  protected GHAppInstallationToken githubAppInstallationToken;
+
+  protected GitHub gitHubClient;
+
+  public GithubClient(String appId, String key, String owner, Long tokenTTL) {
+    this.appId = appId;
+    this.key = key;
+    if (owner == null || owner.isEmpty()) {
+      throw new GithubException(
+          "Github integration requires that the 'l10n.github.owner' property is configured.");
+    }
+    this.owner = owner;
+    this.tokenTTL = tokenTTL;
+  }
+
+  private PrivateKey createPrivateKey(String key)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    byte[] encodedKey = Base64.decodeBase64(key);
+    PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(encodedKey);
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    return keyFactory.generatePrivate(spec);
+  }
+
+  public void addCommentToPR(String repository, int prNumber, String comment) {
+    String repoFullPath = getRepositoryPath(repository);
+    try {
+      getGithubClient(repository)
+          .getRepository(getRepositoryPath(repository))
+          .getPullRequest(prNumber)
+          .comment(comment);
+    } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+      logger.error(
+          String.format(
+              "Error adding comment to PR %d in repository '%s': %s",
+              prNumber, repoFullPath, e.getMessage()),
+          e);
+    }
+  }
+
+  public String getPRBaseCommit(String repository, int prNumber) {
+    String repoFullPath = getRepositoryPath(repository);
+
+    try {
+      return getGithubClient(repository)
+          .getRepository(repoFullPath)
+          .getPullRequest(prNumber)
+          .getBase()
+          .getSha();
+    } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+      String message =
+          String.format(
+              "Error retrieving base commit for PR %d in repository '%s': %s",
+              prNumber, repoFullPath, e.getMessage());
+      logger.error(message, e);
+      throw new GithubException(message, e);
+    }
+  }
+
+  public String getPRAuthorEmail(String repository, int prNumber) {
+    String repoFullPath = getRepositoryPath(repository);
+
+    try {
+      return getGithubClient(repository)
+          .getRepository(repoFullPath)
+          .getPullRequest(prNumber)
+          .getUser()
+          .getEmail();
+    } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+      String message =
+          String.format(
+              "Error getting author email for PR %d in repository '%s': %s",
+              prNumber, repoFullPath, e.getMessage());
+      logger.error(message, e);
+      throw new GithubException(message, e);
+    }
+  }
+
+  public void addLabelToPR(String repository, int prNumber, String labelName) {
+    String repoFullPath = getRepositoryPath(repository);
+    try {
+      getGithubClient(repository)
+          .getRepository(repoFullPath)
+          .getPullRequest(prNumber)
+          .addLabels(labelName);
+    } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+      String message =
+          String.format(
+              "Error adding label '%s' to PR %d in repository '%s': %s",
+              labelName, prNumber, repoFullPath, e.getMessage());
+      logger.error(message, e);
+      throw new GithubException(message, e);
+    }
+  }
+
+  public void removeLabelFromPR(String repository, int prNumber, String labelName) {
+    String repoFullPath = getRepositoryPath(repository);
+    try {
+      getGithubClient(repository)
+          .getRepository(repoFullPath)
+          .getPullRequest(prNumber)
+          .removeLabel(labelName);
+    } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+      String message =
+          String.format(
+              "Error removing label '%s' from PR %d in repository '%s': %s",
+              labelName, prNumber, repoFullPath, e.getMessage());
+      logger.error(message, e);
+      throw new GithubException(message, e);
+    }
+  }
+
+  public List<GHIssueComment> getPRComments(String repository, int prNumber) {
+    String repoFullPath = getRepositoryPath(repository);
+    try {
+      return getGithubClient(repository)
+          .getRepository(repoFullPath)
+          .getPullRequest(prNumber)
+          .getComments();
+    } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+      String message =
+          String.format(
+              "Error retrieving comments for PR %d in repository '%s': %s",
+              prNumber, repoFullPath, e.getMessage());
+      logger.error(message, e);
+      throw new GithubException(message, e);
+    }
+  }
+
+  protected GHAppInstallationToken getGithubAppInstallationToken(String repository)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    if (githubAppInstallationToken == null
+        || githubAppInstallationToken.getExpiresAt().getTime()
+            <= System.currentTimeMillis() - 30000) {
+      // Existing installation token has less than 30 seconds before expiry, get new token
+      GitHub gitHub = new GitHubBuilder().withJwtToken(getGithubJWT(tokenTTL).getToken()).build();
+      githubAppInstallationToken =
+          gitHub.getApp().getInstallationByRepository(owner, repository).createToken().create();
+    }
+
+    return githubAppInstallationToken;
+  }
+
+  protected GitHub createGithubClient(String repository)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    return new GitHubBuilder()
+        .withAppInstallationToken(getGithubAppInstallationToken(repository).getToken())
+        .build();
+  }
+
+  private String getRepositoryPath(String repository) {
+    return owner != null && !owner.isEmpty() ? owner + "/" + repository : repository;
+  }
+
+  private GithubJWT getGithubJWT(long ttlMillis)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+    Date now = new Date(System.currentTimeMillis());
+
+    if (githubJWT != null && now.getTime() <= (githubJWT.getExpiryTime().getTime() - 30000)) {
+      return githubJWT;
+    } else {
+      // Existing JWT has less than 30 seconds before expiry, create new token
+      githubJWT = createGithubJWT(ttlMillis, now);
+    }
+
+    return githubJWT;
+  }
+
+  private GithubJWT createGithubJWT(long ttlMillis, Date now)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+    JwtBuilder builder =
+        Jwts.builder()
+            .setIssuedAt(now)
+            .setIssuer(appId)
+            .signWith(getSigningKey(), SignatureAlgorithm.RS256);
+
+    Date expiry = new Date(now.getTime() + ttlMillis);
+    if (ttlMillis > MAX_GITHUB_JWT_TTL) {
+      long expMillis = now.getTime() + MAX_GITHUB_JWT_TTL;
+      expiry = new Date(expMillis);
+    }
+    builder.setExpiration(expiry);
+
+    return new GithubJWT(builder.compact(), expiry);
+  }
+
+  protected PrivateKey getSigningKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    if (signingKey == null) {
+      signingKey = createPrivateKey(key);
+    }
+
+    return signingKey;
+  }
+
+  private GitHub getGithubClient(String repository)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    if (gitHubClient == null || !gitHubClient.isCredentialValid()) {
+      gitHubClient = createGithubClient(repository);
+    }
+
+    return gitHubClient;
+  }
+}

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClientConfiguration.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClientConfiguration.java
@@ -1,0 +1,59 @@
+package com.box.l10n.mojito.github;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("l10n.github")
+public class GithubClientConfiguration {
+
+  String appId;
+
+  String key;
+
+  String owner;
+
+  Long tokenTTL = 60000L;
+
+  @ConditionalOnProperty("l10n.github.key")
+  @Bean
+  GithubClient getGithubClient() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    return new GithubClient(appId, key, owner, tokenTTL);
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public void setAppId(String appId) {
+    this.appId = appId;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public Long getTokenTTL() {
+    return tokenTTL;
+  }
+
+  public void setTokenTTL(Long tokenTTL) {
+    this.tokenTTL = tokenTTL;
+  }
+}

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubException.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubException.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.github;
+
+public class GithubException extends RuntimeException {
+
+  public GithubException(String message) {
+    super(message);
+  }
+
+  public GithubException(String message, Throwable e) {
+    super(message, e);
+  }
+}

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubJWT.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubJWT.java
@@ -1,0 +1,23 @@
+package com.box.l10n.mojito.github;
+
+import java.util.Date;
+
+public class GithubJWT {
+
+  private final String token;
+
+  private final Date expiryTime;
+
+  public GithubJWT(String token, Date expiryTime) {
+    this.token = token;
+    this.expiryTime = expiryTime;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public Date getExpiryTime() {
+    return expiryTime;
+  }
+}

--- a/common/src/test/java/com/box/l10n/mojito/github/GithubClientTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/github/GithubClientTest.java
@@ -1,0 +1,176 @@
+package com.box.l10n.mojito.github;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.List;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHAppInstallationToken;
+import org.kohsuke.github.GHCommitPointer;
+import org.kohsuke.github.GHIssueComment;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {GithubClientTest.class, GithubClientTest.TestConfig.class})
+@EnableConfigurationProperties
+public class GithubClientTest {
+
+  @Autowired(required = false)
+  GithubClient githubClient;
+
+  @Autowired TestConfig testConfig;
+
+  @Mock GitHub gitHubMock;
+
+  @Mock GHAppInstallationToken ghAppInstallationTokenMock;
+
+  @Mock GHRepository ghRepoMock;
+
+  @Mock GHPullRequest ghPullRequestMock;
+
+  @Mock GHCommitPointer ghCommitPointerMock;
+
+  @Mock GHUser ghUserMock;
+
+  @Before
+  public void setup() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    Assume.assumeNotNull(githubClient);
+    githubClient.gitHubClient = gitHubMock;
+    githubClient.githubAppInstallationToken = ghAppInstallationTokenMock;
+    when(gitHubMock.isCredentialValid()).thenReturn(true);
+    when(gitHubMock.getRepository(isA(String.class))).thenReturn(ghRepoMock);
+    when(ghRepoMock.getPullRequest(isA(Integer.class))).thenReturn(ghPullRequestMock);
+    when(ghPullRequestMock.getBase()).thenReturn(ghCommitPointerMock);
+    when(ghCommitPointerMock.getSha()).thenReturn("mockSha");
+    when(ghPullRequestMock.getUser()).thenReturn(ghUserMock);
+    when(ghUserMock.getEmail()).thenReturn("some@email.com");
+  }
+
+  @Test
+  public void testGetPRBaseCommit() throws IOException {
+    assertEquals("mockSha", githubClient.getPRBaseCommit("testRepo", 1));
+    verify(gitHubMock, times(1)).getRepository("testOwner/testRepo");
+    verify(ghRepoMock, times(1)).getPullRequest(1);
+  }
+
+  @Test
+  public void testAddCommentToPR() throws IOException {
+    githubClient.addCommentToPR("testRepo", 1, "Test comment");
+    verify(gitHubMock, times(1)).getRepository("testOwner/testRepo");
+    verify(ghRepoMock, times(1)).getPullRequest(1);
+    verify(ghPullRequestMock, times(1)).comment("Test comment");
+  }
+
+  @Test
+  public void testGetAuthorEmail() throws IOException {
+    assertEquals("some@email.com", githubClient.getPRAuthorEmail("testRepo", 1));
+    verify(gitHubMock, times(1)).getRepository("testOwner/testRepo");
+    verify(ghRepoMock, times(1)).getPullRequest(1);
+    verify(ghPullRequestMock, times(1)).getUser();
+    verify(ghUserMock, times(1)).getEmail();
+  }
+
+  @Test
+  public void testAddLabelToPR() throws IOException {
+    githubClient.addLabelToPR("testRepo", 1, "translations-needed");
+    verify(gitHubMock, times(1)).getRepository("testOwner/testRepo");
+    verify(ghRepoMock, times(1)).getPullRequest(1);
+    verify(ghPullRequestMock, times(1)).addLabels("translations-needed");
+  }
+
+  @Test
+  public void testRemoveLabelFromPR() throws IOException {
+    githubClient.removeLabelFromPR("testRepo", 1, "translations-needed");
+    verify(gitHubMock, times(1)).getRepository("testOwner/testRepo");
+    verify(ghRepoMock, times(1)).getPullRequest(1);
+    verify(ghPullRequestMock, times(1)).removeLabel("translations-needed");
+  }
+
+  @Test
+  public void testGetPRComments() throws IOException {
+    List<GHIssueComment> comments = Lists.newArrayList(new GHIssueComment(), new GHIssueComment());
+    when(ghPullRequestMock.getComments()).thenReturn(comments);
+
+    assertEquals(comments, githubClient.getPRComments("testRepo", 1));
+    verify(gitHubMock, times(1)).getRepository("testOwner/testRepo");
+    verify(ghRepoMock, times(1)).getPullRequest(1);
+    verify(ghPullRequestMock, times(1)).getComments();
+  }
+
+  @Test
+  public void testClientRefreshWhenCredsInvalid()
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    assertEquals("mockSha", githubClient.getPRBaseCommit("testRepo", 1));
+    when(gitHubMock.isCredentialValid()).thenReturn(false);
+    doReturn(gitHubMock).when(githubClient).createGithubClient(isA(String.class));
+    assertEquals("mockSha", githubClient.getPRBaseCommit("testRepo", 1));
+    verify(githubClient, times(1)).createGithubClient("testRepo");
+  }
+
+  @Configuration
+  @ConfigurationProperties("l10n.github")
+  static class TestConfig {
+
+    String owner = "testOwner";
+
+    String key = "someKey";
+
+    String appId = "testAppId";
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public void setOwner(String owner) {
+      this.owner = owner;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public void setKey(String key) {
+      this.key = key;
+    }
+
+    public String getAppId() {
+      return appId;
+    }
+
+    public void setAppId(String appId) {
+      this.appId = appId;
+    }
+
+    @Bean
+    public GithubClient getGithubClient() throws NoSuchAlgorithmException, InvalidKeySpecException {
+      GithubClient ghClient = Mockito.spy(new GithubClient(appId, key, owner, 60000L));
+      PrivateKey privateKeyMock = Mockito.mock(PrivateKey.class);
+      doReturn(privateKeyMock).when(ghClient).getSigningKey();
+      return Mockito.spy(new GithubClient(appId, key, owner, 60000L));
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
         <immutables-value.version>2.8.2</immutables-value.version>
         <!-- google-java-format 1.7 is the last version that supports JVM 8 -->
         <plugin.version.google-java-format>1.7</plugin.version.google-java-format>
+        <jjwt.version>0.10.5</jjwt.version>
+        <github.api.version>1.313</github.api.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Added client to access Github as a Github app, required configuration is the Github app key, the github app id and the owner of the repository where the app is installed.

Added github-pr-to-env-variables cli command to retrieve PR information such as base commit, author email & read comments for `SKIP_I18N_CHECKS` and to set environment variables with the retrieved data.