### PR TITLE
Redirect test output to file to reduce build log noise

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -147,6 +147,8 @@
                     <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/cli/
                         -Dspring.profiles.active=${user.name},test -Xmx1024m
                     </argLine>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
                 </configuration>
             </plugin>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -374,6 +374,8 @@
                     <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/common/
                         -Dspring.profiles.active=${user.name},test -Duser.timezone=UTC
                     </argLine>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/common/src/test/resources/logback.xml
+++ b/common/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.box.l10n.mojito.common" level="INFO" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+
+</configuration>

--- a/restclient/pom.xml
+++ b/restclient/pom.xml
@@ -79,6 +79,8 @@
                     <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/restclient/
                         -Dspring.profiles.active=${user.name},test -Xmx1024m
                     </argLine>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/restclient/src/test/resources/logback.xml
+++ b/restclient/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.box.l10n.mojito.restclient" level="INFO" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+
+</configuration>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -436,7 +436,8 @@
                     <argLine>-Dspring.config.additional-location=optional:file://${user.home}/.l10n/config/webapp/
                         -Dspring.profiles.active=${user.name},test -Xmx1024m -Duser.timezone=UTC
                     </argLine>
-
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
                     <rerunFailingTestsCount>1</rerunFailingTestsCount>
 
                     <!--<excludedGroups>com.box.l10n.mojito.test.category.BoxSDKTest</excludedGroups>-->

--- a/webapp/src/test/resources/logback.xml
+++ b/webapp/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.box.l10n.mojito.webapp" level="INFO" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+
+</configuration>


### PR DESCRIPTION
Redirect test output to file so that volume of console logging in the build is reduced. T

Logs from each individual test are available in the target directory @ `target/test-reports/<FullyQualifiedTestFileName>.txt` to aid debugging any test failures that may occur.

If a test fails the error will also still be outputted to the console.