### PR TITLE
Use raw values in GithubClient constructor

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClient.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClient.java
@@ -47,15 +47,19 @@ public class GithubClient {
 
   protected GitHub gitHubClient;
 
-  public GithubClient(GithubClientConfiguration config) {
-    this.appId = config.getAppId();
-    this.key = config.getKey();
-    if (config.getOwner() == null || config.getOwner().isEmpty()) {
+  public GithubClient(String appId, String key, String owner, long tokenTTL) {
+    this.appId = appId;
+    this.key = key;
+    if (owner == null || owner.isEmpty()) {
       throw new GithubException(
           "Github integration requires that the 'owner' property is configured for each client.");
     }
-    this.owner = config.getOwner();
-    this.tokenTTL = config.getTokenTTL();
+    this.owner = owner;
+    this.tokenTTL = tokenTTL;
+  }
+
+  public GithubClient(String appId, String key, String owner) {
+    this(appId, key, owner, 60000L);
   }
 
   private PrivateKey createPrivateKey(String key)

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClientsFactory.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClientsFactory.java
@@ -21,7 +21,14 @@ public class GithubClientsFactory {
   private Map<String, GithubClient> createGithubClients() {
     return githubClientsConfiguration.getGithubClients().entrySet().stream()
         .collect(
-            Collectors.toMap(e -> e.getValue().getOwner(), e -> new GithubClient(e.getValue())));
+            Collectors.toMap(
+                e -> e.getValue().getOwner(),
+                e ->
+                    new GithubClient(
+                        e.getValue().getAppId(),
+                        e.getValue().getKey(),
+                        e.getValue().getOwner(),
+                        e.getValue().getTokenTTL())));
   }
 
   public GithubClient getClient(String owner) {

--- a/common/src/test/java/com/box/l10n/mojito/github/GithubClientTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/github/GithubClientTest.java
@@ -137,11 +137,7 @@ public class GithubClientTest {
 
     @Bean
     public GithubClient getGithubClient() throws NoSuchAlgorithmException, InvalidKeySpecException {
-      GithubClientConfiguration githubClientConfiguration = new GithubClientConfiguration();
-      githubClientConfiguration.owner = "testOwner";
-      githubClientConfiguration.key = "someKey";
-      githubClientConfiguration.appId = "testAppId";
-      GithubClient ghClient = Mockito.spy(new GithubClient(githubClientConfiguration));
+      GithubClient ghClient = Mockito.spy(new GithubClient("testAppId", "someKey", "testOwner"));
       PrivateKey privateKeyMock = Mockito.mock(PrivateKey.class);
       doReturn(privateKeyMock).when(ghClient).getSigningKey();
       return ghClient;


### PR DESCRIPTION
Uses raw values in the GithubClient constructor instead of a GithubClientConfiguration object as this should be used in spring configuration only.