### PR TITLE
Added GithubExtractionDiffNotificationCommand 

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/AbstractExtractionDiffNotificationCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/AbstractExtractionDiffNotificationCommand.java
@@ -1,0 +1,44 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffPaths;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffService;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffStatistics;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionPaths;
+import com.box.l10n.mojito.cli.command.extraction.MissingExtractionDirectoryExcpetion;
+
+public abstract class AbstractExtractionDiffNotificationCommand extends Command {
+
+  public ExtractionDiffStatistics getExtractionDiffStatistics(
+      ExtractionDiffService extractionDiffService,
+      String inputDirectory,
+      String currentExtractionName,
+      String baseExtractionName,
+      String outputDirectory,
+      String extractionDiffName) {
+    ExtractionPaths baseExtractionPaths = new ExtractionPaths(inputDirectory, baseExtractionName);
+    ExtractionPaths currentExtractionPaths =
+        new ExtractionPaths(inputDirectory, currentExtractionName);
+    ExtractionDiffPaths extractionDiffPaths =
+        ExtractionDiffPaths.builder()
+            .outputDirectory(outputDirectory)
+            .diffExtractionName(extractionDiffName)
+            .baseExtractorPaths(baseExtractionPaths)
+            .currentExtractorPaths(currentExtractionPaths)
+            .build();
+
+    ExtractionDiffStatistics extractionDiffStatistics = null;
+    try {
+      extractionDiffStatistics =
+          extractionDiffService.computeExtractionDiffStatistics(extractionDiffPaths);
+    } catch (MissingExtractionDirectoryExcpetion missingExtractionDirectoryExcpetion) {
+      throw new CommandException(
+          "Can't compute extraction diff statistics", missingExtractionDirectoryExcpetion);
+    }
+
+    return extractionDiffStatistics;
+  }
+
+  public boolean shouldSendNotification(ExtractionDiffStatistics extractionDiffStatistics) {
+    return extractionDiffStatistics.getRemoved() > 0 || extractionDiffStatistics.getAdded() > 0;
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest.java
@@ -1,0 +1,216 @@
+package com.box.l10n.mojito.cli.command;
+
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffService;
+import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffStatistics;
+import com.box.l10n.mojito.github.GithubClient;
+import com.box.l10n.mojito.github.GithubClients;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class GithubExtractionDiffNotificationCommandTest extends CLITestBase {
+
+  @Test
+  public void getMessageInfo() {
+    GithubExtractionDiffNotificationCommand githubExtractionDiffNotificationCommand =
+        new GithubExtractionDiffNotificationCommand();
+    assertEquals(
+        ":information_source: 0 strings removed and 1 string added (from 10 to 11)",
+        githubExtractionDiffNotificationCommand.getMessage(
+            ExtractionDiffStatistics.builder().added(1).removed(0).base(10).current(11).build()));
+  }
+
+  @Test
+  public void getMessageWarning() {
+    GithubExtractionDiffNotificationCommand githubExtractionDiffNotificationCommand =
+        new GithubExtractionDiffNotificationCommand();
+    assertEquals(
+        ":warning: 10 strings removed and 8 strings added (from 20 to 18)",
+        githubExtractionDiffNotificationCommand.getMessage(
+            ExtractionDiffStatistics.builder().added(8).removed(10).base(20).current(18).build()));
+  }
+
+  @Test
+  public void getMessageError() {
+    GithubExtractionDiffNotificationCommand githubExtractionDiffNotificationCommand =
+        new GithubExtractionDiffNotificationCommand();
+    assertEquals(
+        ":stop_sign: 200 strings removed and 0 strings added (from 500 to 300)",
+        githubExtractionDiffNotificationCommand.getMessage(
+            ExtractionDiffStatistics.builder()
+                .added(0)
+                .removed(200)
+                .base(500)
+                .current(300)
+                .build()));
+  }
+
+  @Test
+  public void withTemplate() {
+    GithubExtractionDiffNotificationCommand githubExtractionDiffNotificationCommand =
+        new GithubExtractionDiffNotificationCommand();
+    githubExtractionDiffNotificationCommand.messageTemplate =
+        "{baseMessage}. Check [[https://build.org/1234|build]].";
+    assertEquals(
+        ":stop_sign: 200 strings removed and 0 strings added (from 500 to 300). Check [[https://build.org/1234|build]].",
+        githubExtractionDiffNotificationCommand.getMessage(
+            ExtractionDiffStatistics.builder()
+                .added(0)
+                .removed(200)
+                .base(500)
+                .current(300)
+                .build()));
+  }
+
+  @Test
+  public void shouldSendNotification() {
+    GithubExtractionDiffNotificationCommand githubExtractionDiffNotificationCommand =
+        new GithubExtractionDiffNotificationCommand();
+    assertTrue(
+        githubExtractionDiffNotificationCommand.shouldSendNotification(
+            ExtractionDiffStatistics.builder()
+                .added(0)
+                .removed(200)
+                .base(500)
+                .current(300)
+                .build()));
+  }
+
+  @Test
+  public void shouldNotSendNotification() {
+    GithubExtractionDiffNotificationCommand githubExtractionDiffNotificationCommand =
+        new GithubExtractionDiffNotificationCommand();
+    assertFalse(
+        githubExtractionDiffNotificationCommand.shouldSendNotification(
+            ExtractionDiffStatistics.builder().added(0).removed(0).base(500).current(300).build()));
+  }
+
+  @Test
+  public void sendNotification() throws Exception {
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source1").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source1",
+            "-fo",
+            "sometestoption=value1");
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source2").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source2",
+            "-fo",
+            "sometestoption=value1");
+
+    getL10nJCommander()
+        .run(
+            "extract-diff",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1");
+
+    L10nJCommander l10nJCommander = getL10nJCommander();
+    GithubExtractionDiffNotificationCommand command =
+        l10nJCommander.getCommand(GithubExtractionDiffNotificationCommand.class);
+    GithubClients githubClientsFactoryMock = Mockito.mock(GithubClients.class);
+    GithubClient githubClientMock = Mockito.mock(GithubClient.class);
+    command.githubClientsFactory = githubClientsFactoryMock;
+    Mockito.when(githubClientsFactoryMock.getClient(isA(String.class)))
+        .thenReturn(githubClientMock);
+
+    l10nJCommander.run(
+        "github-extraction-diff-notif",
+        "-pr",
+        "1",
+        "-go",
+        "owner",
+        "-gr",
+        "testRepo",
+        "-i",
+        getTargetTestDir("extractions").getAbsolutePath(),
+        "-o",
+        getTargetTestDir("extraction-diffs").getAbsolutePath(),
+        "-c",
+        "source2",
+        "-b",
+        "source1",
+        "-mt",
+        "{baseMessage} in pr: ${PR_NUMBER}. Check [[https://build.org/${BUILD_NUMBER}|build]] for extraction details.");
+
+    Mockito.verify(githubClientMock, Mockito.times(1))
+        .addCommentToPR(
+            "testRepo",
+            1,
+            ":warning: 5 strings removed and 2 strings added (from 10 to 7) in pr: ${PR_NUMBER}. Check [[https://build.org/${BUILD_NUMBER}|build]] for extraction details.");
+    assertTrue(
+        outputCapture
+            .toString()
+            .contains(
+                ":warning: 5 strings removed and 2 strings added (from 10 to 7) in pr: ${PR_NUMBER}. Check [[https://build.org/${BUILD_NUMBER}|build]] for extraction details."));
+    checkExpectedGeneratedResources();
+  }
+
+  @Test
+  public void noNotifications() throws Exception {
+
+    L10nJCommander l10nJCommander = getL10nJCommander();
+    GithubExtractionDiffNotificationCommand command =
+        l10nJCommander.getCommand(GithubExtractionDiffNotificationCommand.class);
+    GithubClients githubClientsFactoryMock = Mockito.mock(GithubClients.class);
+    GithubClient githubClientMock = Mockito.mock(GithubClient.class);
+    command.githubClientsFactory = githubClientsFactoryMock;
+    Mockito.when(githubClientsFactoryMock.getClient(isA(String.class)))
+        .thenReturn(githubClientMock);
+    command.extractionDiffService = Mockito.mock(ExtractionDiffService.class);
+    Mockito.when(command.extractionDiffService.computeExtractionDiffStatistics(any()))
+        .thenReturn(ExtractionDiffStatistics.builder().build());
+
+    l10nJCommander.run(
+        "github-extraction-diff-notif",
+        "-pr",
+        "1",
+        "-go",
+        "owner",
+        "-gr",
+        "testRepo",
+        "-i",
+        getTargetTestDir("extractions").getAbsolutePath(),
+        "-o",
+        getTargetTestDir("extraction-diffs").getAbsolutePath(),
+        "-c",
+        "source2",
+        "-b",
+        "source1",
+        "-mt",
+        "{baseMessage} in pr: ${PR_NUMBER}. Check [[https://build.org/${BUILD_NUMBER}|build]] for extraction details.",
+        "-oid",
+        "{objectId}");
+
+    Mockito.verify(githubClientMock, Mockito.never())
+        .addCommentToPR(anyString(), anyInt(), anyString());
+    assertTrue(outputCapture.toString().contains("No need to send notification"));
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extraction-diffs/source2_source1/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extraction-diffs/source2_source1/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,34 @@
+{
+  "currentFilterConfigIdOverride" : null,
+  "currentFilterOptions" : [ "sometestoption=value1" ],
+  "addedTextunits" : [ {
+    "name" : "1 day update --- 1_day_duration_update",
+    "source" : "1 day update",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  } ],
+  "removedTextunits" : [ {
+    "name" : "1 day --- 1_day_duration",
+    "source" : "1 day",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  }, {
+    "name" : "1 hour --- 1_hour_duration",
+    "source" : "1 hour",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  }, {
+    "name" : "1 month --- 1_month_duration",
+    "source" : "1 month",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:10" ]
+  } ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extraction-diffs/source2_source1/LC_MESSAGES/messages2.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extraction-diffs/source2_source1/LC_MESSAGES/messages2.pot.json
@@ -1,0 +1,27 @@
+{
+  "currentFilterConfigIdOverride" : null,
+  "currentFilterOptions" : [ "sometestoption=value1" ],
+  "addedTextunits" : [ {
+    "name" : "1 hour update --- 1_hour_duration_update",
+    "source" : "1 hour update",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  } ],
+  "removedTextunits" : [ {
+    "name" : "1 hour --- 1_hour_duration",
+    "source" : "1 hour",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  }, {
+    "name" : "1 month --- 1_month_duration",
+    "source" : "1 month",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:10" ]
+  } ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source1/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source1/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,41 @@
+{
+  "name" : "source1",
+  "textunits" : [ {
+    "name" : "100 character description: --- 100_character_description_",
+    "source" : "100 character description:",
+    "comments" : null,
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:2" ]
+  }, {
+    "name" : "15 min --- 15_min_duration",
+    "source" : "15 min",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:4" ]
+  }, {
+    "name" : "1 day --- 1_day_duration",
+    "source" : "1 day",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  }, {
+    "name" : "1 hour --- 1_hour_duration",
+    "source" : "1 hour",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  }, {
+    "name" : "1 month --- 1_month_duration",
+    "source" : "1 month",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:10" ]
+  } ],
+  "filterConfigIdOverride" : null,
+  "filterOptions" : [ "sometestoption=value1" ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source1/LC_MESSAGES/messages2.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source1/LC_MESSAGES/messages2.pot.json
@@ -1,0 +1,41 @@
+{
+  "name" : "source1",
+  "textunits" : [ {
+    "name" : "100 character description: --- 100_character_description_",
+    "source" : "100 character description:",
+    "comments" : null,
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:2" ]
+  }, {
+    "name" : "15 min --- 15_min_duration",
+    "source" : "15 min",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:4" ]
+  }, {
+    "name" : "1 day --- 1_day_duration",
+    "source" : "1 day",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  }, {
+    "name" : "1 hour --- 1_hour_duration",
+    "source" : "1 hour",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  }, {
+    "name" : "1 month --- 1_month_duration",
+    "source" : "1 month",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:10" ]
+  } ],
+  "filterConfigIdOverride" : null,
+  "filterOptions" : [ "sometestoption=value1" ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source2/LC_MESSAGES/messages.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source2/LC_MESSAGES/messages.pot.json
@@ -1,0 +1,27 @@
+{
+  "name" : "source2",
+  "textunits" : [ {
+    "name" : "100 character description: --- 100_character_description_",
+    "source" : "100 character description:",
+    "comments" : null,
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:2" ]
+  }, {
+    "name" : "15 min --- 15_min_duration",
+    "source" : "15 min",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:4" ]
+  }, {
+    "name" : "1 day update --- 1_day_duration_update",
+    "source" : "1 day update",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  } ],
+  "filterConfigIdOverride" : null,
+  "filterOptions" : [ "sometestoption=value1" ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source2/LC_MESSAGES/messages2.pot.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/expected/extractions/source2/LC_MESSAGES/messages2.pot.json
@@ -1,0 +1,34 @@
+{
+  "name" : "source2",
+  "textunits" : [ {
+    "name" : "100 character description: --- 100_character_description_",
+    "source" : "100 character description:",
+    "comments" : null,
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:2" ]
+  }, {
+    "name" : "15 min --- 15_min_duration",
+    "source" : "15 min",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:4" ]
+  }, {
+    "name" : "1 day --- 1_day_duration",
+    "source" : "1 day",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:6" ]
+  }, {
+    "name" : "1 hour update --- 1_hour_duration_update",
+    "source" : "1 hour update",
+    "comments" : "File lock dialog duration",
+    "pluralForm" : null,
+    "pluralFormOther" : null,
+    "usages" : [ "file.js:8" ]
+  } ],
+  "filterConfigIdOverride" : null,
+  "filterOptions" : [ "sometestoption=value1" ]
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,50 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source1/LC_MESSAGES/messages2.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source1/LC_MESSAGES/messages2.pot
@@ -1,0 +1,50 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration"
+msgid "1 hour"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:10
+msgctxt "1_month_duration"
+msgid "1 month"
+msgstr ""
+

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration_update"
+msgid "1 day update"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source2/LC_MESSAGES/messages2.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/GithubExtractionDiffNotificationCommandTest_IO/sendNotification/input/source2/LC_MESSAGES/messages2.pot
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#: file.js:2
+msgctxt "100_character_description_"
+msgid "100 character description:"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:4
+msgctxt "15_min_duration"
+msgid "15 min"
+msgstr ""
+  
+#. File lock dialog duration
+#: file.js:6
+msgctxt "1_day_duration"
+msgid "1 day"
+msgstr ""
+
+#. File lock dialog duration
+#: file.js:8
+msgctxt "1_hour_duration_update"
+msgid "1 hour update"
+msgstr ""

--- a/common/src/main/java/com/box/l10n/mojito/thirdpartynotification/github/GithubIcon.java
+++ b/common/src/main/java/com/box/l10n/mojito/thirdpartynotification/github/GithubIcon.java
@@ -1,0 +1,22 @@
+package com.box.l10n.mojito.thirdpartynotification.github;
+
+public enum GithubIcon {
+  INFO(":information_source:"),
+  WARNING(":warning:"),
+  STOP(":stop_sign:");
+
+  String str;
+
+  GithubIcon(String str) {
+    this.str = str;
+  }
+
+  public String getStr() {
+    return str;
+  }
+
+  @Override
+  public String toString() {
+    return str;
+  }
+}


### PR DESCRIPTION
Added `GithubExtractionDiffNotificationCommand` which reports the number of strings added/removed from a PR as a comment.

Refactored `PhabricatorExtractionDiffNotificationCommand` to extend from a new abstract class `AbstractExtractionDiffNotificationCommand` to avoid code duplication across the two implementations