### PR TITLE
Show break lines in the workbench for comments and target comment

### DIFF
--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -930,7 +930,7 @@ let TextUnit = createReactClass({
                             <Col md={6}>
                                 <Row>
                                     {this.renderSource()}
-                                    <div className="plx em color-gray-light2">{this.props.textUnit.getComment()}</div>
+                                    <div className="plx em color-gray-light2 textunit-comment">{this.props.textUnit.getComment()}</div>
                                 </Row>
                             </Col>
                             <Col md={6}>

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -467,6 +467,10 @@ div.textunit label {
     right: 0;
 }
 
+.textunit-comment {
+    white-space: pre-wrap;
+}
+
 div.textunit div.targetstring-container {
     float: left;
     width: 90%;
@@ -483,6 +487,7 @@ div.targetstring-container textarea {
 
 .git-blame-info {
     word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 .git-blame-unused {


### PR DESCRIPTION
applies to the comment in the workbench main page and in the text unit info for the target comment

fixes #904