### PR TITLE
Fixing typo in GithubPRInfoCommand

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommand.java
@@ -78,7 +78,7 @@ public class GithubPRInfoCommand extends Command {
             String.format("Github client with owner '%s' not found.", owner));
       }
       consoleWriterAnsiCodeEnabledFalse
-          .a("MOJTIO_GITHUB_BASE_COMMIT=")
+          .a("MOJITO_GITHUB_BASE_COMMIT=")
           .a(github.getPRBaseCommit(repository, prNumber))
           .println();
       String authorEmail = github.getPRAuthorEmail(repository, prNumber);

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GithubPRInfoCommandTest.java
@@ -55,7 +55,7 @@ public class GithubPRInfoCommandTest {
   @Test
   public void testExecute() {
     githubPRInfoCommand.execute();
-    verify(consoleWriterMock, times(1)).a("MOJTIO_GITHUB_BASE_COMMIT=");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_BASE_COMMIT=");
     verify(consoleWriterMock, times(1)).a("baseSha");
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_EMAIL=");
     verify(consoleWriterMock, times(1)).a("some@email.com");
@@ -68,7 +68,7 @@ public class GithubPRInfoCommandTest {
   public void testExecuteWithChecksSkipped() throws IOException {
     when(ghIssueCommentMock.getBody()).thenReturn("SKIP_I18N_CHECKS");
     githubPRInfoCommand.execute();
-    verify(consoleWriterMock, times(1)).a("MOJTIO_GITHUB_BASE_COMMIT=");
+    verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_BASE_COMMIT=");
     verify(consoleWriterMock, times(1)).a("baseSha");
     verify(consoleWriterMock, times(1)).a("MOJITO_GITHUB_AUTHOR_EMAIL=");
     verify(consoleWriterMock, times(1)).a("some@email.com");


### PR DESCRIPTION
Fixing typo in Github PR info command for the base commit output