### PR TITLE
Fix PO Plural support for Croatian

### DIFF
--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
@@ -209,6 +209,7 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
 
     Repository repository = createTestRepoUsingRepoService();
     repositoryService.addRepositoryLocale(repository, "ru-RU");
+    repositoryService.addRepositoryLocale(repository, "hr-HR");
 
     getL10nJCommander()
         .run(
@@ -228,7 +229,7 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
             "-t",
             getInputResourcesTestDir("translations").getAbsolutePath(),
             "-lm",
-            "fr:fr-FR,fr-CA:fr-CA,ja:ja-JP,ru-RU:ru-RU");
+            "fr:fr-FR,fr-CA:fr-CA,ja:ja-JP,ru-RU:ru-RU,hr-HR:hr-HR");
 
     getL10nJCommander()
         .run(
@@ -240,7 +241,7 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
             "-t",
             getTargetTestDir().getAbsolutePath(),
             "-lm",
-            "fr:fr-FR,fr-CA:fr-CA,ja:ja-JP,ru-RU:ru-RU");
+            "fr:fr-FR,fr-CA:fr-CA,ja:ja-JP,ru-RU:ru-RU,hr-HR:hr-HR");
 
     checkExpectedGeneratedResources();
   }

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importPoPlural/expected/hr_HR/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importPoPlural/expected/hr_HR/LC_MESSAGES/messages.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+   
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] "hr0-There is {number} car"
+msgstr[1] "hr1-There are {number} cars"
+msgstr[2] "hr2-There are {number} cars"
+
+#. Okapi bug when followed by a normal string
+#: file.js:24
+msgctxt "somestring ctx"
+msgid "somestring id"
+msgstr "somestring id"

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importPoPlural/input/translations/hr_HR/LC_MESSAGES/messages.po
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importPoPlural/input/translations/hr_HR/LC_MESSAGES/messages.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Test plural
+#: file.js:20
+msgctxt "car"
+msgid "There is {number} car"
+msgid_plural "There are {number} cars"
+msgstr[0] "hr0-There is {number} car"
+msgstr[1] "hr1-There are {number} cars"
+msgstr[2] "hr2-There are {number} cars"

--- a/common/src/main/java/com/box/l10n/mojito/po/PoPluralRule.java
+++ b/common/src/main/java/com/box/l10n/mojito/po/PoPluralRule.java
@@ -43,7 +43,7 @@ public enum PoPluralRule {
       PoFormToCLDRForm.THREE_FORMS_ONE_FEW_MANY, CldrFormsToCopyOnImport.FEW_TO_OTHER),
   THREE_FORMS_SPECIAL_FOR_ENDING_1_AND_234_EXCEPT_114_ONLY3(
       "nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;",
-      PoFormToCLDRForm.THREE_FORMS_ONE_FEW_MANY, CldrFormsToCopyOnImport.NONE),
+      PoFormToCLDRForm.THREE_FORMS_ONE_FEW_OTHER, CldrFormsToCopyOnImport.NONE),
   THREE_FORMS_SPECIAL_FOR_1_2_3_4(
       "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;",
       PoFormToCLDRForm.THREE_FORMS_ONE_FEW_OTHER,

--- a/common/src/test/java/com/box/l10n/mojito/po/PoPluralRuleTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/po/PoPluralRuleTest.java
@@ -135,6 +135,13 @@ public class PoPluralRuleTest {
   }
 
   @Test
+  public void testCroatian() {
+    PoPluralRule rulesForBcp47Tag = PoPluralRule.fromBcp47Tag("hr");
+    Assert.assertEquals(
+        PoPluralRule.THREE_FORMS_SPECIAL_FOR_ENDING_1_AND_234_EXCEPT_114_ONLY3, rulesForBcp47Tag);
+  }
+
+  @Test
   public void testHebrew() {
     PoPluralRule rulesForBcp47Tag = PoPluralRule.fromBcp47Tag("he");
     Assert.assertEquals(PoPluralRule.FOUR_FORMS_FRACTIONAL_DIGITS_OTHER, rulesForBcp47Tag);


### PR DESCRIPTION
- add a test to repro the issue with the CLI
- fix the mapping, Croatian uses 3 forms: one, few, other (and not one, few, many). The forms from the DB used by the text unit searcher where not matching, and so not returning any results.