### PR TITLE
Relax the plural group identification in MacStringsDict filter

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/MacStringsdictFilterKey.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/MacStringsdictFilterKey.java
@@ -214,7 +214,7 @@ public class MacStringsdictFilterKey extends XMLFilter {
    */
   protected boolean isPluralGroupEnding(IResource resource) {
     String toString = resource.getSkeleton().toString();
-    Pattern p = Pattern.compile("</dict>\n</dict>");
+    Pattern p = Pattern.compile("</dict>\\s*</dict>");
     Matcher matcher = p.matcher(toString);
     return matcher.find();
   }

--- a/common/src/test/java/com/box/l10n/mojito/okapi/filters/MacStringsdictFilterKeyTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/okapi/filters/MacStringsdictFilterKeyTest.java
@@ -1,10 +1,13 @@
 package com.box.l10n.mojito.okapi.filters;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import net.sf.okapi.common.Event;
 import net.sf.okapi.common.EventType;
+import net.sf.okapi.common.resource.DocumentPart;
 import net.sf.okapi.common.resource.TextUnit;
+import net.sf.okapi.common.skeleton.GenericSkeleton;
 import org.junit.Test;
 
 /** @author emagalindan */
@@ -44,6 +47,20 @@ public class MacStringsdictFilterKeyTest {
     String expResult = "line 1\nline 2 \nline 3";
     String result = instance.getNoteFromXMLCommentsInSkeleton(skeleton);
     assertEquals(expResult, result);
+  }
+
+  @Test
+  public void testIsPluralGroupEnding() {
+    MacStringsdictFilterKey instance = new MacStringsdictFilterKey();
+    assertTrue(
+        instance.isPluralGroupEnding(
+            new DocumentPart("id", false, new GenericSkeleton("</dict>\n</dict>"))));
+    assertTrue(
+        instance.isPluralGroupEnding(
+            new DocumentPart("id", false, new GenericSkeleton("</dict>\n   </dict>"))));
+    assertTrue(
+        instance.isPluralGroupEnding(
+            new DocumentPart("id", false, new GenericSkeleton("</dict></dict>"))));
   }
 
   @Test


### PR DESCRIPTION
Now, there can be any amount of whitespace/return line between the </dict> elements