### PR TITLE
Allow customization of Github API endpoint

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClientConfiguration.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClientConfiguration.java
@@ -10,6 +10,8 @@ public class GithubClientConfiguration {
 
   Long tokenTTL = 60000L;
 
+  String endpoint = "https://api.github.com";
+
   public String getAppId() {
     return appId;
   }
@@ -40,5 +42,13 @@ public class GithubClientConfiguration {
 
   public void setTokenTTL(Long tokenTTL) {
     this.tokenTTL = tokenTTL;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 }

--- a/common/src/main/java/com/box/l10n/mojito/github/GithubClients.java
+++ b/common/src/main/java/com/box/l10n/mojito/github/GithubClients.java
@@ -24,7 +24,8 @@ public class GithubClients {
                         e.getValue().getAppId(),
                         e.getValue().getKey(),
                         e.getValue().getOwner(),
-                        e.getValue().getTokenTTL())));
+                        e.getValue().getTokenTTL(),
+                        e.getValue().getEndpoint())));
   }
 
   public GithubClient getClient(String owner) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
@@ -34,7 +34,7 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
   @Override
   public String sendNewMessage(String branchName, String username, List<String> sourceStrings)
       throws BranchNotificationMessageSenderException {
-    logger.debug("sendNewMessage to: {}", "https://github.com/" + branchName);
+    logger.debug("sendNewMessage to: {}", githubClient.getEndpoint() + "/" + branchName);
 
     try {
       GithubBranchDetails branchDetails = new GithubBranchDetails(branchName);
@@ -53,7 +53,7 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
   public String sendUpdatedMessage(
       String branchName, String username, String messageId, List<String> sourceStrings)
       throws BranchNotificationMessageSenderException {
-    logger.debug("sendNewMessage to: {}", "https://github.com/" + branchName);
+    logger.debug("sendNewMessage to: {}", githubClient.getEndpoint() + "/" + branchName);
     try {
       GithubBranchDetails branchDetails = new GithubBranchDetails(branchName);
       githubClient.addCommentToPR(
@@ -70,7 +70,7 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
   @Override
   public void sendTranslatedMessage(String branchName, String username, String messageId)
       throws BranchNotificationMessageSenderException {
-    logger.debug("sendTranslatedMessage to: {}", "https://github.com/" + branchName);
+    logger.debug("sendTranslatedMessage to: {}", githubClient.getEndpoint() + "/" + branchName);
 
     try {
       GithubBranchDetails branchDetails = new GithubBranchDetails(branchName);
@@ -87,7 +87,8 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
   @Override
   public void sendScreenshotMissingMessage(String branchName, String messageId, String username)
       throws BranchNotificationMessageSenderException {
-    logger.debug("sendScreenshotMissingMessage to: {}", "https://github.com/" + branchName);
+    logger.debug(
+        "sendScreenshotMissingMessage to: {}", githubClient.getEndpoint() + "/" + branchName);
 
     try {
       GithubBranchDetails branchDetails = new GithubBranchDetails(branchName);


### PR DESCRIPTION
Allows a custom Github endpoint to be set from configuration, if no configuration is set it defaults to `https://api.github.com`