### PR TITLE
Add batching for repository MT and configurable limit

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepositoryMachineTranslationCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepositoryMachineTranslationCommand.java
@@ -47,6 +47,14 @@ public class RepositoryMachineTranslationCommand extends Command {
       description = "List of locales (bcp47 tags) to machine translate")
   List<String> locales;
 
+  @Parameter(
+      names = {"--source-text-max-count"},
+      arity = 1,
+      description =
+          "Source text max count per locale sent to MT (this param is used to avoid "
+              + "sending too many strings to MT)")
+  int sourceTextMaxCount = 100;
+
   @Autowired CommandHelper commandHelper;
 
   @Autowired RepositoryMachineTranslationClient repositoryMachineTranslationClient;
@@ -74,6 +82,7 @@ public class RepositoryMachineTranslationCommand extends Command {
         new RepositoryMachineTranslationBody();
     repositoryMachineTranslationBody.setRepositoryName(repositoryParam);
     repositoryMachineTranslationBody.setTargetBcp47tags(locales);
+    repositoryMachineTranslationBody.setSourceTextMaxCountPerLocale(sourceTextMaxCount);
 
     repositoryMachineTranslationBody =
         repositoryMachineTranslationClient.translateRepository(repositoryMachineTranslationBody);

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/RepositoryMachineTranslationBody.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/RepositoryMachineTranslationBody.java
@@ -9,6 +9,8 @@ public class RepositoryMachineTranslationBody {
   String repositoryName;
   List<String> targetBcp47tags;
 
+  int sourceTextMaxCountPerLocale;
+
   PollableTask pollableTask;
 
   public String getRepositoryName() {
@@ -25,6 +27,14 @@ public class RepositoryMachineTranslationBody {
 
   public void setTargetBcp47tags(List<String> targetBcp47tags) {
     this.targetBcp47tags = targetBcp47tags;
+  }
+
+  public int getSourceTextMaxCountPerLocale() {
+    return sourceTextMaxCountPerLocale;
+  }
+
+  public void setSourceTextMaxCountPerLocale(int sourceTextMaxCountPerLocale) {
+    this.sourceTextMaxCountPerLocale = sourceTextMaxCountPerLocale;
   }
 
   @JsonProperty

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/MachineTranslationWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/MachineTranslationWS.java
@@ -82,7 +82,8 @@ public class MachineTranslationWS {
     PollableFuture<Void> pollableFuture =
         repositoryMachineTranslationService.translateRepository(
             repositoryMachineTranslationBody.getRepositoryName(),
-            repositoryMachineTranslationBody.getTargetBcp47tags());
+            repositoryMachineTranslationBody.getTargetBcp47tags(),
+            repositoryMachineTranslationBody.getSourceTextMaxCountPerLocale());
     repositoryMachineTranslationBody.setPollableTask(pollableFuture.getPollableTask());
     return repositoryMachineTranslationBody;
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/RepositoryMachineTranslationBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/machinetranslation/RepositoryMachineTranslationBody.java
@@ -10,6 +10,8 @@ public class RepositoryMachineTranslationBody {
   String repositoryName;
   List<String> targetBcp47tags;
 
+  int sourceTextMaxCountPerLocale;
+
   PollableTask pollableTask;
 
   public String getRepositoryName() {
@@ -26,6 +28,14 @@ public class RepositoryMachineTranslationBody {
 
   public void setTargetBcp47tags(List<String> targetBcp47tags) {
     this.targetBcp47tags = targetBcp47tags;
+  }
+
+  public int getSourceTextMaxCountPerLocale() {
+    return sourceTextMaxCountPerLocale;
+  }
+
+  public void setSourceTextMaxCountPerLocale(int sourceTextMaxCountPerLocale) {
+    this.sourceTextMaxCountPerLocale = sourceTextMaxCountPerLocale;
   }
 
   @JsonProperty


### PR DESCRIPTION
- Make configurable the limit in the CLI, keep the default limit low to avoid wrong usage. it is a max count per locale
- Add batching to support repositories with more than 1000 strings

Note this does not compute the character count and could also failed if the max is reached. We need to create batches based on char count instead. see if we need later