### PR TITLE
Change how the extract diff notifier sets the translation-required label

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithub.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithub.java
@@ -1,13 +1,19 @@
 package com.box.l10n.mojito.cli.command.extractiondiffnotifier;
 
+import static com.box.l10n.mojito.github.PRLabel.TRANSLATIONS_READY;
 import static com.box.l10n.mojito.github.PRLabel.TRANSLATIONS_REQUIRED;
 import static com.box.l10n.mojito.github.PRLabel.updatePRLabel;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.cli.command.extraction.ExtractionDiffStatistics;
 import com.box.l10n.mojito.github.GithubClient;
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
 
 public class ExtractionDiffNotifierGithub implements ExtractionDiffNotifier {
+
+  /** logger */
+  static Logger logger = getLogger(ExtractionDiffNotifierGithub.class);
 
   ExtractionDiffNotifierMessageBuilder extractionDiffNotifierMessageBuilder;
 
@@ -36,8 +42,24 @@ public class ExtractionDiffNotifierGithub implements ExtractionDiffNotifier {
 
     String message = extractionDiffNotifierMessageBuilder.getMessage(extractionDiffStatistics);
     githubClient.addCommentToPR(repository, prNumber, message);
+
     if (extractionDiffStatistics.getAdded() > 0) {
-      updatePRLabel(githubClient, repository, prNumber, TRANSLATIONS_REQUIRED);
+      // For the initial string addition, the CLI will put the label, but for updates that creates
+      // new strings and if the initial string set has been translated, the server will have to
+      // change the label since this command won't have enough information to know the current
+      // state.
+      //
+      // The "translation-required" label would eventually be set by the server, but we set it here
+      // earlier here to be more reactive and not have to wait for the server to process the branch
+      // (which can lag a bit)
+      if (githubClient.isLabelAppliedToPR(repository, prNumber, TRANSLATIONS_READY.toString())) {
+        logger.debug(
+            "'translation-ready' is present, skip setting the 'translation-required' to avoid"
+                + " being in an invalid state where the translations are actually ready");
+      } else {
+        logger.debug("Set 'translation-required' early to avoid lag in the server setting it");
+        updatePRLabel(githubClient, repository, prNumber, TRANSLATIONS_REQUIRED);
+      }
     }
     return message;
   }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithubTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractiondiffnotifier/ExtractionDiffNotifierGithubTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.extractiondiffnotifier;
 
+import static com.box.l10n.mojito.github.PRLabel.TRANSLATIONS_READY;
 import static com.box.l10n.mojito.github.PRLabel.TRANSLATIONS_REQUIRED;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -60,6 +61,30 @@ public class ExtractionDiffNotifierGithubTest {
             ExtractionDiffStatistics.builder().added(1).build());
 
     verify(mockGithubClient, times(1))
+        .addLabelToPR(repository, prNumber, TRANSLATIONS_REQUIRED.toString());
+  }
+
+  @Test
+  public void testLabelNotAppliedWhenTranslationReadyLabelPresent() {
+    GithubClient mockGithubClient = mock(GithubClient.class);
+
+    String repository = "repository";
+    int prNumber = 1;
+    when(mockGithubClient.isLabelAppliedToPR(repository, 1, TRANSLATIONS_READY.toString()))
+        .thenReturn(true);
+
+    ExtractionDiffNotifierGithub extractionDiffNotifierGithub =
+        new ExtractionDiffNotifierGithub(
+            new ExtractionDiffNotifierMessageBuilder("{baseMessage}"),
+            mockGithubClient,
+            repository,
+            prNumber);
+
+    final String msg =
+        extractionDiffNotifierGithub.sendDiffStatistics(
+            ExtractionDiffStatistics.builder().added(1).build());
+
+    verify(mockGithubClient, times(0))
         .addLabelToPR(repository, prNumber, TRANSLATIONS_REQUIRED.toString());
   }
 


### PR DESCRIPTION
For the initial string addition, the CLI will put the label, but for updates that creates new strings and if the initial string set has been translated, the server will have to change the label since this command won't have enough information to know the current state. The "translation-required" label would eventually be set by the server, but we set it here earlier here to be more reactive and not have to wait for the server to process the branch (which can lag a bit)