### PR TITLE
Mojito invalid Android comment extraction for attribute translatable=…

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/AndroidFilter.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/AndroidFilter.java
@@ -42,6 +42,9 @@ public class AndroidFilter extends XMLFilter {
   private static final Pattern PATTERN_UPDATE_FORM =
       Pattern.compile("(\\s*<.*?item.+?quantity.+?\".+?\">)");
 
+  public static final Pattern FIND_LAST_TRANSLATABLE_FALSE =
+      Pattern.compile("(?s).*translatable.*=.*\"false\"");
+
   private static final String XML_COMMENT_GROUP_NAME = "comment";
 
   @Autowired TextUnitUtils textUnitUtils;
@@ -212,6 +215,11 @@ public class AndroidFilter extends XMLFilter {
   protected String getNoteFromXMLCommentsInSkeleton(String skeleton) {
 
     String note = null;
+
+    final Matcher matcherForLastTranslatableFalse = FIND_LAST_TRANSLATABLE_FALSE.matcher(skeleton);
+    if (matcherForLastTranslatableFalse.find()) {
+      skeleton = skeleton.substring(matcherForLastTranslatableFalse.group(0).length());
+    }
 
     StringBuilder commentBuilder = new StringBuilder();
 

--- a/common/src/test/java/com/box/l10n/mojito/okapi/filters/AndroidFilterTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/okapi/filters/AndroidFilterTest.java
@@ -34,9 +34,22 @@ public class AndroidFilterTest {
 
   @Test
   public void testGetNoteFromXMLCommentsInSkeletonMultiline() {
-    String skeleton = "blalbala <!-- line 1 --> <!-- line 2 -->  <!-- line 3 --> blalba";
+    String skeleton = "blalbala <!-- line 1 -->\n<!-- line 2 -->\n<!-- line 3 --> blalba";
     AndroidFilter instance = new AndroidFilter();
     String expResult = "line 1 line 2 line 3";
+    String result = instance.getNoteFromXMLCommentsInSkeleton(skeleton);
+    assertEquals(expResult, result);
+  }
+
+  @Test
+  public void testGetNoteFromXMLCommentsInSkeletonWithSkipTranslatable() {
+    String skeleton =
+        "<!-- comment for untranslatable -->\n"
+            + "<string name=\"to_skip\" translatable=\"false\">To skip</string>\n"
+            + "<!-- comment to extract -->\n"
+            + "<string name=\"to_extract\">To extract</string>\n";
+    AndroidFilter instance = new AndroidFilter();
+    String expResult = "comment to extract";
     String result = instance.getNoteFromXMLCommentsInSkeleton(skeleton);
     assertEquals(expResult, result);
   }


### PR DESCRIPTION
…"false"

When a string has the attribute translatable="false" and it has a comment, then its comment is prepended to the comment of the next string. Instead the comment should be skipped.