### PR TITLE
GetWordsInString Method Updates

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -11,30 +11,30 @@ import org.apache.commons.lang3.StringUtils;
 
 public class CheckerUtils {
 
-    /**
-     * Pattern matching for html tags.
-     *
-     * <p>"<" matches an opening angle bracket, "[^>]+" matches one or more characters that are not a
-     * closing angle bracket and ">" matches a closing angle bracket
-     */
-    private static final Pattern HTML_TAGS_PATTERN = Pattern.compile("<[^>]+>");
+  /**
+   * Pattern matching for html tags.
+   *
+   * <p>"<" matches an opening angle bracket, "[^>]+" matches one or more characters that are not a
+   * closing angle bracket and ">" matches a closing angle bracket
+   */
+  private static final Pattern HTML_TAGS_PATTERN = Pattern.compile("<[^>]+>");
 
-    public static List<String> getWordsInString(String str) {
-        if (StringUtils.isEmpty(str)) {
-            return new ArrayList<>();
-        }
-        List<String> words = new ArrayList<>();
-        BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
-        str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
-        wordBreakIterator.setText(str);
-        int start = wordBreakIterator.first();
-        for (int end = wordBreakIterator.next();
-             end != BreakIterator.DONE;
-             start = end, end = wordBreakIterator.next()) {
-            if (wordBreakIterator.getRuleStatus() != BreakIterator.WORD_NONE) {
-                words.add(str.substring(start, end));
-            }
-        }
-        return words;
+  public static List<String> getWordsInString(String str) {
+    if (StringUtils.isEmpty(str)) {
+      return new ArrayList<>();
     }
+    List<String> words = new ArrayList<>();
+    BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
+    str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
+    wordBreakIterator.setText(str);
+    int start = wordBreakIterator.first();
+    for (int end = wordBreakIterator.next();
+        end != BreakIterator.DONE;
+        start = end, end = wordBreakIterator.next()) {
+      if (wordBreakIterator.getRuleStatus() != BreakIterator.WORD_NONE) {
+        words.add(str.substring(start, end));
+      }
+    }
+    return words;
+  }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -1,24 +1,40 @@
 package com.box.l10n.mojito.cli.command.checks;
 
 import com.ibm.icu.text.BreakIterator;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class CheckerUtils {
 
-  public static List<String> getWordsInString(String str) {
-    List<String> words = new ArrayList<>();
-    BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
-    wordBreakIterator.setText(str);
-    int start = wordBreakIterator.first();
-    for (int end = wordBreakIterator.next();
-        end != BreakIterator.DONE;
-        start = end, end = wordBreakIterator.next()) {
-      if (wordBreakIterator.getRuleStatus() != BreakIterator.WORD_NONE) {
-        words.add(str.substring(start, end));
-      }
+    /**
+     * Pattern matching for html tags.
+     *
+     * <p>"<" matches an opening angle bracket, "[^>]+" matches one or more characters that are not a
+     * closing angle bracket and ">" matches a closing angle bracket
+     */
+    private static final Pattern HTML_TAGS_PATTERN = Pattern.compile("<[^>]+>");
+
+    public static List<String> getWordsInString(String str) {
+        if (StringUtils.isEmpty(str)) {
+            return new ArrayList<>();
+        }
+        List<String> words = new ArrayList<>();
+        BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
+        str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
+        wordBreakIterator.setText(str);
+        int start = wordBreakIterator.first();
+        for (int end = wordBreakIterator.next();
+             end != BreakIterator.DONE;
+             start = end, end = wordBreakIterator.next()) {
+            if (wordBreakIterator.getRuleStatus() != BreakIterator.WORD_NONE) {
+                words.add(str.substring(start, end));
+            }
+        }
+        return words;
     }
-    return words;
-  }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -1,12 +1,10 @@
 package com.box.l10n.mojito.cli.command.checks;
 
 import com.ibm.icu.text.BreakIterator;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
-
 import org.apache.commons.lang3.StringUtils;
 
 public class CheckerUtils {

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -1,0 +1,96 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CheckerUtilsTest {
+
+    @Test
+    void weShouldBeAbleTo_getWordsInString_providingASingleWordAsInput() {
+        List<String> result = CheckerUtils.getWordsInString("Hello");
+        assertEquals(1, result.size());
+        assertTrue(result.contains("Hello"));
+    }
+
+    @Test
+    void weShouldBeAbleTo_getWordsInString_providingMultipleStringsAsInput() {
+        List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
+        assertEquals(7, result.size());
+        assertTrue(result.contains("Hello"));
+        assertTrue(result.contains("how"));
+        assertTrue(result.contains("can"));
+        assertTrue(result.contains("I"));
+        assertTrue(result.contains("help"));
+        assertTrue(result.contains("you"));
+        assertTrue(result.contains("today"));
+    }
+
+    @Test
+    void weShouldBeAbleTo_getWordsInString_ignoringHtmlTag() {
+        List<String> result =
+                CheckerUtils.getWordsInString("This is a string containing html tag <br>");
+        assertEquals(7, result.size());
+        assertFalse(result.contains("<br>"));
+        assertFalse(result.contains("br"));
+    }
+
+    @Test
+    void weShouldBeAbleTo_getWordsInString_withoutIgnoringTextBetweenHtmlTags() {
+        List<String> result =
+                CheckerUtils.getWordsInString("This string has a bold html tag <b>Text</b>");
+        assertEquals(8, result.size());
+        assertFalse(result.contains("<b>"));
+        assertFalse(result.contains("</b>"));
+        assertFalse(result.contains("b"));
+        assertTrue(result.contains("Text"));
+    }
+
+    @Test
+    void weShouldBeAbleTo_getWordsInString_ignoringMultipleHtmlTags() {
+        List<String> result =
+                CheckerUtils.getWordsInString(
+                        "<br>This text </br> have <html> elements <p> for testing </p> purposes<b>.");
+
+        assertEquals(7, result.size());
+
+        assertTrue(result.contains("This"));
+        assertTrue(result.contains("text"));
+        assertTrue(result.contains("have"));
+        assertTrue(result.contains("elements"));
+        assertTrue(result.contains("for"));
+        assertTrue(result.contains("testing"));
+        assertTrue(result.contains("purposes"));
+    }
+
+    @Test
+    void weShouldBeAbleTo_getWordsInString_ignoringTextInsideHtmlTags() {
+        List<String> result =
+                CheckerUtils.getWordsInString(
+                        "Text inside html tags should be ignored <img src=\"example.jpg\">.");
+
+        assertEquals(7, result.size());
+
+        assertTrue(result.contains("Text"));
+        assertTrue(result.contains("inside"));
+        assertTrue(result.contains("html"));
+        assertTrue(result.contains("tags"));
+        assertTrue(result.contains("should"));
+        assertTrue(result.contains("be"));
+        assertTrue(result.contains("ignored"));
+    }
+
+    @Test
+    void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
+        List<String> result = CheckerUtils.getWordsInString("");
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void weShouldNotThrowExceptionWhen_getWordsInString_providingNullAsInput() {
+        List<String> result = CheckerUtils.getWordsInString(null);
+        assertEquals(0, result.size());
+    }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -1,51 +1,44 @@
 package com.box.l10n.mojito.cli.command.checks;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 class CheckerUtilsTest {
 
   @Test
   void weShouldBeAbleTo_getWordsInString_providingASingleWordAsInput() {
     List<String> result = CheckerUtils.getWordsInString("Hello");
-    assertEquals(1, result.size());
-    assertTrue(result.contains("Hello"));
+    List<String> expectedResult = Collections.singletonList("Hello");
+    assertEquals(expectedResult, result);
   }
 
   @Test
   void weShouldBeAbleTo_getWordsInString_providingMultipleWordsAsInput() {
     List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
-    assertEquals(7, result.size());
-    assertTrue(result.contains("Hello"));
-    assertTrue(result.contains("how"));
-    assertTrue(result.contains("can"));
-    assertTrue(result.contains("I"));
-    assertTrue(result.contains("help"));
-    assertTrue(result.contains("you"));
-    assertTrue(result.contains("today"));
+    List<String> expectedResult = Arrays.asList("Hello", "how", "can", "I", "help", "you", "today");
+    assertEquals(expectedResult, result);
   }
 
   @Test
   void weShouldBeAbleTo_getWordsInString_ignoringHtmlTag() {
     List<String> result =
         CheckerUtils.getWordsInString("This is a string containing html tag <br>");
-    assertEquals(7, result.size());
-    assertFalse(result.contains("<br>"));
-    assertFalse(result.contains("br"));
+    List<String> expectedResult =
+        Arrays.asList("This", "is", "a", "string", "containing", "html", "tag");
+    assertEquals(expectedResult, result);
   }
 
   @Test
   void weShouldBeAbleTo_getWordsInString_withoutIgnoringTextBetweenHtmlTags() {
     List<String> result =
         CheckerUtils.getWordsInString("This string has a bold html tag <b>Text</b>");
-    assertEquals(8, result.size());
-    assertFalse(result.contains("<b>"));
-    assertFalse(result.contains("</b>"));
-    assertFalse(result.contains("b"));
-    assertTrue(result.contains("Text"));
+    List<String> expectedResult =
+        Arrays.asList("This", "string", "has", "a", "bold", "html", "tag", "Text");
+    assertEquals(expectedResult, result);
   }
 
   @Test
@@ -54,15 +47,9 @@ class CheckerUtilsTest {
         CheckerUtils.getWordsInString(
             "<br>This text </br> have <html> elements <p> for testing </p> purposes<b>.");
 
-    assertEquals(7, result.size());
-
-    assertTrue(result.contains("This"));
-    assertTrue(result.contains("text"));
-    assertTrue(result.contains("have"));
-    assertTrue(result.contains("elements"));
-    assertTrue(result.contains("for"));
-    assertTrue(result.contains("testing"));
-    assertTrue(result.contains("purposes"));
+    List<String> expectedResult =
+        Arrays.asList("This", "text", "have", "elements", "for", "testing", "purposes");
+    assertEquals(expectedResult, result);
   }
 
   @Test
@@ -70,16 +57,9 @@ class CheckerUtilsTest {
     List<String> result =
         CheckerUtils.getWordsInString(
             "Text inside html tags should be ignored <img src=\"example.jpg\">.");
-
-    assertEquals(7, result.size());
-
-    assertTrue(result.contains("Text"));
-    assertTrue(result.contains("inside"));
-    assertTrue(result.contains("html"));
-    assertTrue(result.contains("tags"));
-    assertTrue(result.contains("should"));
-    assertTrue(result.contains("be"));
-    assertTrue(result.contains("ignored"));
+    List<String> expectedResult =
+        Arrays.asList("Text", "inside", "html", "tags", "should", "be", "ignored");
+    assertEquals(expectedResult, result);
   }
 
   @Test

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -8,89 +8,89 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CheckerUtilsTest {
 
-    @Test
-    void weShouldBeAbleTo_getWordsInString_providingASingleWordAsInput() {
-        List<String> result = CheckerUtils.getWordsInString("Hello");
-        assertEquals(1, result.size());
-        assertTrue(result.contains("Hello"));
-    }
+  @Test
+  void weShouldBeAbleTo_getWordsInString_providingASingleWordAsInput() {
+    List<String> result = CheckerUtils.getWordsInString("Hello");
+    assertEquals(1, result.size());
+    assertTrue(result.contains("Hello"));
+  }
 
-    @Test
-    void weShouldBeAbleTo_getWordsInString_providingMultipleStringsAsInput() {
-        List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
-        assertEquals(7, result.size());
-        assertTrue(result.contains("Hello"));
-        assertTrue(result.contains("how"));
-        assertTrue(result.contains("can"));
-        assertTrue(result.contains("I"));
-        assertTrue(result.contains("help"));
-        assertTrue(result.contains("you"));
-        assertTrue(result.contains("today"));
-    }
+  @Test
+  void weShouldBeAbleTo_getWordsInString_providingMultipleStringsAsInput() {
+    List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
+    assertEquals(7, result.size());
+    assertTrue(result.contains("Hello"));
+    assertTrue(result.contains("how"));
+    assertTrue(result.contains("can"));
+    assertTrue(result.contains("I"));
+    assertTrue(result.contains("help"));
+    assertTrue(result.contains("you"));
+    assertTrue(result.contains("today"));
+  }
 
-    @Test
-    void weShouldBeAbleTo_getWordsInString_ignoringHtmlTag() {
-        List<String> result =
-                CheckerUtils.getWordsInString("This is a string containing html tag <br>");
-        assertEquals(7, result.size());
-        assertFalse(result.contains("<br>"));
-        assertFalse(result.contains("br"));
-    }
+  @Test
+  void weShouldBeAbleTo_getWordsInString_ignoringHtmlTag() {
+    List<String> result =
+        CheckerUtils.getWordsInString("This is a string containing html tag <br>");
+    assertEquals(7, result.size());
+    assertFalse(result.contains("<br>"));
+    assertFalse(result.contains("br"));
+  }
 
-    @Test
-    void weShouldBeAbleTo_getWordsInString_withoutIgnoringTextBetweenHtmlTags() {
-        List<String> result =
-                CheckerUtils.getWordsInString("This string has a bold html tag <b>Text</b>");
-        assertEquals(8, result.size());
-        assertFalse(result.contains("<b>"));
-        assertFalse(result.contains("</b>"));
-        assertFalse(result.contains("b"));
-        assertTrue(result.contains("Text"));
-    }
+  @Test
+  void weShouldBeAbleTo_getWordsInString_withoutIgnoringTextBetweenHtmlTags() {
+    List<String> result =
+        CheckerUtils.getWordsInString("This string has a bold html tag <b>Text</b>");
+    assertEquals(8, result.size());
+    assertFalse(result.contains("<b>"));
+    assertFalse(result.contains("</b>"));
+    assertFalse(result.contains("b"));
+    assertTrue(result.contains("Text"));
+  }
 
-    @Test
-    void weShouldBeAbleTo_getWordsInString_ignoringMultipleHtmlTags() {
-        List<String> result =
-                CheckerUtils.getWordsInString(
-                        "<br>This text </br> have <html> elements <p> for testing </p> purposes<b>.");
+  @Test
+  void weShouldBeAbleTo_getWordsInString_ignoringMultipleHtmlTags() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "<br>This text </br> have <html> elements <p> for testing </p> purposes<b>.");
 
-        assertEquals(7, result.size());
+    assertEquals(7, result.size());
 
-        assertTrue(result.contains("This"));
-        assertTrue(result.contains("text"));
-        assertTrue(result.contains("have"));
-        assertTrue(result.contains("elements"));
-        assertTrue(result.contains("for"));
-        assertTrue(result.contains("testing"));
-        assertTrue(result.contains("purposes"));
-    }
+    assertTrue(result.contains("This"));
+    assertTrue(result.contains("text"));
+    assertTrue(result.contains("have"));
+    assertTrue(result.contains("elements"));
+    assertTrue(result.contains("for"));
+    assertTrue(result.contains("testing"));
+    assertTrue(result.contains("purposes"));
+  }
 
-    @Test
-    void weShouldBeAbleTo_getWordsInString_ignoringTextInsideHtmlTags() {
-        List<String> result =
-                CheckerUtils.getWordsInString(
-                        "Text inside html tags should be ignored <img src=\"example.jpg\">.");
+  @Test
+  void weShouldBeAbleTo_getWordsInString_ignoringTextInsideHtmlTags() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored <img src=\"example.jpg\">.");
 
-        assertEquals(7, result.size());
+    assertEquals(7, result.size());
 
-        assertTrue(result.contains("Text"));
-        assertTrue(result.contains("inside"));
-        assertTrue(result.contains("html"));
-        assertTrue(result.contains("tags"));
-        assertTrue(result.contains("should"));
-        assertTrue(result.contains("be"));
-        assertTrue(result.contains("ignored"));
-    }
+    assertTrue(result.contains("Text"));
+    assertTrue(result.contains("inside"));
+    assertTrue(result.contains("html"));
+    assertTrue(result.contains("tags"));
+    assertTrue(result.contains("should"));
+    assertTrue(result.contains("be"));
+    assertTrue(result.contains("ignored"));
+  }
 
-    @Test
-    void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
-        List<String> result = CheckerUtils.getWordsInString("");
-        assertEquals(0, result.size());
-    }
+  @Test
+  void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
+    List<String> result = CheckerUtils.getWordsInString("");
+    assertEquals(0, result.size());
+  }
 
-    @Test
-    void weShouldNotThrowExceptionWhen_getWordsInString_providingNullAsInput() {
-        List<String> result = CheckerUtils.getWordsInString(null);
-        assertEquals(0, result.size());
-    }
+  @Test
+  void weShouldNotThrowExceptionWhen_getWordsInString_providingNullAsInput() {
+    List<String> result = CheckerUtils.getWordsInString(null);
+    assertEquals(0, result.size());
+  }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -16,7 +16,7 @@ class CheckerUtilsTest {
   }
 
   @Test
-  void weShouldBeAbleTo_getWordsInString_providingMultipleStringsAsInput() {
+  void weShouldBeAbleTo_getWordsInString_providingMultipleWordsAsInput() {
     List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
     assertEquals(7, result.size());
     assertTrue(result.contains("Hello"));

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -1,9 +1,7 @@
 package com.box.l10n.mojito.cli.command.checks;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -12,33 +10,27 @@ class CheckerUtilsTest {
   @Test
   void weShouldBeAbleTo_getWordsInString_providingASingleWordAsInput() {
     List<String> result = CheckerUtils.getWordsInString("Hello");
-    List<String> expectedResult = Collections.singletonList("Hello");
-    assertEquals(expectedResult, result);
+    assertThat(result).containsExactly("Hello");
   }
 
   @Test
   void weShouldBeAbleTo_getWordsInString_providingMultipleWordsAsInput() {
     List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
-    List<String> expectedResult = Arrays.asList("Hello", "how", "can", "I", "help", "you", "today");
-    assertEquals(expectedResult, result);
+    assertThat(result).containsExactly("Hello", "how", "can", "I", "help", "you", "today");
   }
 
   @Test
   void weShouldBeAbleTo_getWordsInString_ignoringHtmlTag() {
     List<String> result =
         CheckerUtils.getWordsInString("This is a string containing html tag <br>");
-    List<String> expectedResult =
-        Arrays.asList("This", "is", "a", "string", "containing", "html", "tag");
-    assertEquals(expectedResult, result);
+    assertThat(result).containsExactly("This", "is", "a", "string", "containing", "html", "tag");
   }
 
   @Test
   void weShouldBeAbleTo_getWordsInString_withoutIgnoringTextBetweenHtmlTags() {
     List<String> result =
         CheckerUtils.getWordsInString("This string has a bold html tag <b>Text</b>");
-    List<String> expectedResult =
-        Arrays.asList("This", "string", "has", "a", "bold", "html", "tag", "Text");
-    assertEquals(expectedResult, result);
+    assertThat(result).containsExactly("This", "string", "has", "a", "bold", "html", "tag", "Text");
   }
 
   @Test
@@ -46,10 +38,8 @@ class CheckerUtilsTest {
     List<String> result =
         CheckerUtils.getWordsInString(
             "<br>This text </br> have <html> elements <p> for testing </p> purposes<b>.");
-
-    List<String> expectedResult =
-        Arrays.asList("This", "text", "have", "elements", "for", "testing", "purposes");
-    assertEquals(expectedResult, result);
+    assertThat(result)
+        .containsExactly("This", "text", "have", "elements", "for", "testing", "purposes");
   }
 
   @Test
@@ -57,20 +47,18 @@ class CheckerUtilsTest {
     List<String> result =
         CheckerUtils.getWordsInString(
             "Text inside html tags should be ignored <img src=\"example.jpg\">.");
-    List<String> expectedResult =
-        Arrays.asList("Text", "inside", "html", "tags", "should", "be", "ignored");
-    assertEquals(expectedResult, result);
+    assertThat(result).containsExactly("Text", "inside", "html", "tags", "should", "be", "ignored");
   }
 
   @Test
   void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
     List<String> result = CheckerUtils.getWordsInString("");
-    assertEquals(0, result.size());
+    assertThat(result).isEmpty();
   }
 
   @Test
   void weShouldNotThrowExceptionWhen_getWordsInString_providingNullAsInput() {
     List<String> result = CheckerUtils.getWordsInString(null);
-    assertEquals(0, result.size());
+    assertThat(result).isEmpty();
   }
 }


### PR DESCRIPTION
Fixes issues when text containing HTML tags are provided, causing failures under the spell check.

- Html tags should now be removed from the list of words (result of the method getWordsInString), as they shouldn't be considered as words for spell checks.
- The method getWordsInString returns an empty array if a null or empty string is provided as input. 
- Added unit tests for the getWordsInString method