### PR TITLE
GetWordsInString Method Changes

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -4,12 +4,26 @@ import com.ibm.icu.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 
 public class CheckerUtils {
 
+  /**
+   * Pattern matching for html tags.
+   *
+   * <p>"<" matches an opening angle bracket, "[^>]+" matches one or more characters that are not a
+   * closing angle bracket and ">" matches a closing angle bracket
+   */
+  private static final Pattern HTML_TAGS_PATTERN = Pattern.compile("<[^>]+>");
+
   public static List<String> getWordsInString(String str) {
+    if (StringUtils.isEmpty(str)) {
+      return new ArrayList<>();
+    }
     List<String> words = new ArrayList<>();
     BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
+    str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
     wordBreakIterator.setText(str);
     int start = wordBreakIterator.first();
     for (int end = wordBreakIterator.next();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -1,0 +1,64 @@
+package com.box.l10n.mojito.cli.command.checks;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CheckerUtilsTest {
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_providingASingleWordAsInput() {
+    List<String> result = CheckerUtils.getWordsInString("Hello");
+    assertThat(result).containsExactly("Hello");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_providingMultipleWordsAsInput() {
+    List<String> result = CheckerUtils.getWordsInString("Hello, how can I help you today?");
+    assertThat(result).containsExactly("Hello", "how", "can", "I", "help", "you", "today");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_ignoringHtmlTag() {
+    List<String> result =
+        CheckerUtils.getWordsInString("This is a string containing html tag <br>");
+    assertThat(result).containsExactly("This", "is", "a", "string", "containing", "html", "tag");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_withoutIgnoringTextBetweenHtmlTags() {
+    List<String> result =
+        CheckerUtils.getWordsInString("This string has a bold html tag <b>Text</b>");
+    assertThat(result).containsExactly("This", "string", "has", "a", "bold", "html", "tag", "Text");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_ignoringMultipleHtmlTags() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "<br>This text </br> have <html> elements <p> for testing </p> purposes<b>.");
+    assertThat(result)
+        .containsExactly("This", "text", "have", "elements", "for", "testing", "purposes");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_ignoringTextInsideHtmlTags() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored <img src=\"example.jpg\">.");
+    assertThat(result).containsExactly("Text", "inside", "html", "tags", "should", "be", "ignored");
+  }
+
+  @Test
+  void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
+    List<String> result = CheckerUtils.getWordsInString("");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void weShouldNotThrowExceptionWhen_getWordsInString_providingNullAsInput() {
+    List<String> result = CheckerUtils.getWordsInString(null);
+    assertThat(result).isEmpty();
+  }
+}


### PR DESCRIPTION
Fixes issues when text containing HTML tags are provided, causing failures under the spell check.

- Html tags should now be removed from the list of words (result of the method getWordsInString), as they shouldn't be considered as words for spell checks.
- The method getWordsInString returns an empty array if a null or empty string is provided as input.
- Added unit tests for the getWordsInString method