### PR TITLE
GetWordsInString method updates related to wished attributes inside html tags

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -29,14 +29,10 @@ public class CheckerUtils {
    * tags which contains one of the attributes from the WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK list.
    */
   static {
-    StringBuilder pattern = new StringBuilder("<[^>]+(?:");
-    for (String att : WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK) {
-      pattern.append(att).append("|");
-    }
-    pattern.deleteCharAt(pattern.length() - 1);
-    pattern.append(")\"(.*?)\".*?>");
+    String pattern =
+        "<[^>]+(?:" + String.join("|", WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK) + ")\"(.*?)\".*?>";
 
-    WISHED_HTML_ATTRIBUTES_VALUE_PATTERN = Pattern.compile(pattern.toString());
+    WISHED_HTML_ATTRIBUTES_VALUE_PATTERN = Pattern.compile(pattern);
   }
 
   public static List<String> getWordsInString(String str) {
@@ -45,7 +41,7 @@ public class CheckerUtils {
     }
     List<String> words = new ArrayList<>();
     BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
-    str = removeHtmlTagsFromStringButKeepingWishedHtmlAttValues(str);
+    str = removeHtmlTagsAndKeepWishedAttribute(str);
     wordBreakIterator.setText(str);
     int start = wordBreakIterator.first();
     for (int end = wordBreakIterator.next();
@@ -68,7 +64,7 @@ public class CheckerUtils {
    *     the value of the attribute (at the end) if matches any of the attributes from the
    *     WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK list.
    */
-  protected static String removeHtmlTagsFromStringButKeepingWishedHtmlAttValues(String str) {
+  protected static String removeHtmlTagsAndKeepWishedAttribute(String str) {
     if (StringUtils.isEmpty(str)) {
       return str;
     }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -2,8 +2,10 @@ package com.box.l10n.mojito.cli.command.checks;
 
 import com.ibm.icu.text.BreakIterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
@@ -17,13 +19,33 @@ public class CheckerUtils {
    */
   private static final Pattern HTML_TAGS_PATTERN = Pattern.compile("<[^>]+>");
 
+  private static final Pattern WISHED_HTML_ATTRIBUTES_VALUE_PATTERN;
+
+  private static final List<String> WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK =
+      Arrays.asList("title=", "alt=", "value=", "placeholder=");
+
+  /**
+   * Initializes regex pattern for the wished_html_attributes_value_pattern. The regex matches html
+   * tags which contains one of the attributes from the WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK list.
+   */
+  static {
+    StringBuilder pattern = new StringBuilder("<[^>]+(?:");
+    for (String att : WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK) {
+      pattern.append(att).append("|");
+    }
+    pattern.deleteCharAt(pattern.length() - 1);
+    pattern.append(")\"(.*?)\".*?>");
+
+    WISHED_HTML_ATTRIBUTES_VALUE_PATTERN = Pattern.compile(pattern.toString());
+  }
+
   public static List<String> getWordsInString(String str) {
     if (StringUtils.isEmpty(str)) {
       return new ArrayList<>();
     }
     List<String> words = new ArrayList<>();
     BreakIterator wordBreakIterator = BreakIterator.getWordInstance(Locale.ENGLISH);
-    str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
+    str = removeHtmlTagsFromStringButKeepingWishedHtmlAttValues(str);
     wordBreakIterator.setText(str);
     int start = wordBreakIterator.first();
     for (int end = wordBreakIterator.next();
@@ -34,5 +56,30 @@ public class CheckerUtils {
       }
     }
     return words;
+  }
+
+  /**
+   * Removes all the html tags present in a string, but keeping a wished attribute value (attached
+   * at the end of the string) when applicable.
+   *
+   * @param str A string which may or may not contain html tags.
+   * @return 1 - The same input string if there are no html tags present; or 2 - The input string
+   *     without any html tag content; or 3 - The input string removing the html tags, but attaching
+   *     the value of the attribute (at the end) if matches any of the attributes from the
+   *     WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK list.
+   */
+  protected static String removeHtmlTagsFromStringButKeepingWishedHtmlAttValues(String str) {
+    if (StringUtils.isEmpty(str)) {
+      return str;
+    }
+
+    Matcher matcher = WISHED_HTML_ATTRIBUTES_VALUE_PATTERN.matcher(str);
+    String wishedHtmlAttValue = null;
+    if (matcher.find()) {
+      wishedHtmlAttValue = matcher.group(1);
+    }
+    str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
+
+    return wishedHtmlAttValue != null ? str + " " + wishedHtmlAttValue : str;
   }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -51,6 +51,85 @@ class CheckerUtilsTest {
   }
 
   @Test
+  void weShouldBeAbleTo_getWordsInString_andNotIgnoreTitleAttValue() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored  <comp src=\"some.jpg\" alt=\"TitleAtt Content\">, but title");
+    assertThat(result)
+        .containsExactly(
+            "Text",
+            "inside",
+            "html",
+            "tags",
+            "should",
+            "be",
+            "ignored",
+            "but",
+            "title",
+            "TitleAtt",
+            "Content");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_andNotIgnoreAltAttValue() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored  <comp src=\"some.jpg\" alt=\"AltAtt Content\">, but alt");
+    assertThat(result)
+        .containsExactly(
+            "Text", "inside", "html", "tags", "should", "be", "ignored", "but", "alt", "AltAtt",
+            "Content");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_andNotIgnoreValueAttValue() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored  <comp src=\"some.jpg\" value=\"ValueAtt Content\">, but value");
+    assertThat(result)
+        .containsExactly(
+            "Text",
+            "inside",
+            "html",
+            "tags",
+            "should",
+            "be",
+            "ignored",
+            "but",
+            "value",
+            "ValueAtt",
+            "Content");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_andNotIgnorePlaceholderAttValue() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored  <comp src=\"some.jpg\" placeholder=\"PlaceholderAtt Content\">, but placeholder");
+    assertThat(result)
+        .containsExactly(
+            "Text",
+            "inside",
+            "html",
+            "tags",
+            "should",
+            "be",
+            "ignored",
+            "but",
+            "placeholder",
+            "PlaceholderAtt",
+            "Content");
+  }
+
+  @Test
+  void weShouldBeAbleTo_getWordsInString_andIgnoreUnwantedHtmlAttributes() {
+    List<String> result =
+        CheckerUtils.getWordsInString(
+            "Text inside html tags should be ignored <comp src=\"some.jpg\" att=\"AnyAtt Content\" another=\"Another Content\">");
+    assertThat(result).containsExactly("Text", "inside", "html", "tags", "should", "be", "ignored");
+  }
+
+  @Test
   void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
     List<String> result = CheckerUtils.getWordsInString("");
     assertThat(result).isEmpty();


### PR DESCRIPTION
- Creates removeHtmlTagsFromStringButKeepingWishedHtmlAttValues method which is used by the GetWordsInString method. The reason is that we still would like to have spell checks for certain html attributes, but most of the content inside the html tags can be ignored by spell check.
- Added unit tests covering the changes
- We now have a list (WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK) where html attributes can be added, so if you think there are more attributes we should insert in that list, please let me know.
- At this time the WISHED_HTML_ATTRIBUTES_FOR_SPELL_CHECK list contains 4 attributes: title, alt, value, and placeholder