### PR TITLE
CLI checks should not fail when strings are removed from code base (gettext edge case)

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
@@ -1,8 +1,17 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
 import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
 import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -31,12 +40,127 @@ public abstract class AbstractCliChecker {
     this.cliCheckerOptions = options;
   }
 
-  protected List<AssetExtractorTextUnit> getAddedTextUnits(
+  /**
+   * Gets added text units from the diff but applies extra filter to handle PO file and extractor
+   * edge cases.
+   *
+   * <p>In the case of gettext extractor and PO files there is an edge case that can lead to check
+   * existing strings eventhough they are not changed directly. If the string does not pass the
+   * check it will raise a failure which becomes pretty confusing. No error should be raised when
+   * removing old strings, or moving them around(include changing files, etc).
+   *
+   * <p>Code base contains following gettext calls:
+   *
+   * <pre>
+   * # comment1
+   * _(source1, context1)
+   *
+   * # comment2
+   * _(source1, context1)
+   *
+   * # comment3
+   * _(source1, context1)
+   * </pre>
+   *
+   * <p>This will get extracted as a single text unit in a PO file like this
+   *
+   * <pre>
+   * #. comment1
+   * #. comment2
+   * #. comment3
+   * #: usage1
+   * #: usage2
+   * #: usage3
+   * msgctxt "context1"
+   * msgid "source1"
+   * msgstr ""
+   * </pre>
+   *
+   * <p>And after filtering in Mojito, the comments get joined with returned lines {source1,
+   * context1, "comment1\ncomment2\ncomment3"}
+   *
+   * <p>Following code is removed from the code base:
+   *
+   * <pre>
+   * # comment2
+   * _(source1, context1)
+   * </pre>
+   *
+   * <p>The PO extractor will now produce:
+   *
+   * <pre>
+   * #. comment1
+   * #. comment3
+   * #: usage1
+   * #: usage3
+   * msgctxt "context1"
+   * msgid "source1"
+   * msgstr ""
+   * </pre>
+   *
+   * <p>And after filtering in Mojito, the comments get joined with returned lines {source1,
+   * comment1, "comment1\ncomment3"}
+   *
+   * <p>The asset extraction diff will contain: added={source1, context1, "comment1\ncomment3"}
+   * removed={source1, context1, "comment1\ncomment2\ncomment3"}
+   *
+   * <p>In that case we don't want to run checks on the added text unit because if the text unit is
+   * not compliant it will fail and look odd as the developer is just removing old code (also covers
+   * reodering of the comment by the extractor for xyz reasons). On the other hand we don't want to
+   * miss running the check when string were reused somewhere else with yet another comment.
+   *
+   * <p>This checks for any added text unit if there is a matching text unit in "removed" based on
+   * the source and content only. Then check that the "added" comments are a subset of the "removed"
+   * comments. The set is built on the assemption that we can split by '\n'
+   *
+   * @param assetExtractionDiffs
+   * @return
+   */
+  protected List<AssetExtractorTextUnit> getAddedTextUnitsExcludingInconsistentComments(
       List<AssetExtractionDiff> assetExtractionDiffs) {
     return assetExtractionDiffs.stream()
-        .map(AssetExtractionDiff::getAddedTextunits)
+        .map(
+            assetExtractionDiff -> {
+              Map<String, AssetExtractorTextUnit> mapNameAndContentToRemovedTextUnit =
+                  assetExtractionDiff.getRemovedTextunits().stream()
+                      .collect(
+                          toMap(
+                              assetExtractorTextUnit ->
+                                  assetExtractorTextUnit.getName()
+                                      + assetExtractorTextUnit.getSource(),
+                              identity()));
+
+              return assetExtractionDiff.getAddedTextunits().stream()
+                  .filter(
+                      addedTextUnit -> {
+                        boolean shouldIncludeTextUnit = true;
+
+                        AssetExtractorTextUnit removed =
+                            mapNameAndContentToRemovedTextUnit.get(
+                                addedTextUnit.getName() + addedTextUnit.getSource());
+                        if (removed != null) {
+                          Set<String> commentsInRemoved = getCommentsAsSet(removed);
+                          Set<String> commentsInAdded = getCommentsAsSet(addedTextUnit);
+                          SetView<String> inAddedButNotInRemoved =
+                              Sets.difference(commentsInAdded, commentsInRemoved);
+                          if (inAddedButNotInRemoved.isEmpty()) {
+                            // there is no new comments introduced (ie. one or many have been
+                            // removed, or order may have changed). We don't need to review the text
+                            // unit
+                            shouldIncludeTextUnit = false;
+                          }
+                        }
+
+                        return shouldIncludeTextUnit;
+                      })
+                  .collect(toList());
+            })
         .flatMap(List::stream)
-        .collect(Collectors.toList());
+        .collect(toList());
+  }
+
+  Set<String> getCommentsAsSet(AssetExtractorTextUnit removedTextUnit) {
+    return Arrays.stream(removedTextUnit.getComments().split("\n")).collect(Collectors.toSet());
   }
 
   protected CliCheckResult createCliCheckerResult() {
@@ -48,14 +172,14 @@ public abstract class AbstractCliChecker {
   }
 
   protected List<String> getSourceStringsFromDiff(List<AssetExtractionDiff> assetExtractionDiffs) {
-    return getAddedTextUnits(assetExtractionDiffs).stream()
+    return getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
         .map(AssetExtractorTextUnit::getSource)
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   protected List<Pattern> getRegexPatterns() {
     return cliCheckerOptions.getParameterRegexSet().stream()
         .map(regex -> Pattern.compile(regex.getRegex()))
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
@@ -76,7 +76,7 @@ public class ContextAndCommentCliChecker extends AbstractCliChecker {
 
   private List<ContextAndCommentCliCheckerResult> runChecks(
       List<AssetExtractionDiff> assetExtractionDiffs) {
-    return getAddedTextUnits(assetExtractionDiffs).stream()
+    return getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
         .map(
             assetExtractorTextUnit ->
                 getContextAndCommentCliCheckerResult(

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextCommentRejectPatternChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextCommentRejectPatternChecker.java
@@ -52,7 +52,7 @@ public class ContextCommentRejectPatternChecker extends AbstractCliChecker {
   }
 
   private String getFailureText(List<AssetExtractionDiff> assetExtractionDiffs, Pattern pattern) {
-    return getAddedTextUnits(assetExtractionDiffs).stream()
+    return getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
         .filter(textUnit -> isInvalidContextOrComment(pattern, textUnit))
         .map(textUnit -> buildFailureText(textUnit))
         .collect(Collectors.joining(System.lineSeparator()));

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderChecker.java
@@ -44,7 +44,7 @@ public class EmptyPlaceholderChecker extends AbstractCliChecker {
         .filter(regex -> isEmptyPlaceholderRegex(regex))
         .flatMap(
             placeholderRegularExpressions ->
-                getAddedTextUnits(assetExtractionDiffs).stream()
+                getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
                     .map(assetExtractorTextUnit -> assetExtractorTextUnit.getSource())
                     .filter(
                         source ->

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseChecker.java
@@ -40,7 +40,7 @@ public class GlossaryCaseChecker extends AbstractCliChecker {
       GlossaryTermCaseCheckerTrie glossaryTermCaseCheckerTrie,
       List<AssetExtractionDiff> assetExtractionDiffs) {
     List<GlossaryCaseCheckerSearchResult> failures =
-        getAddedTextUnits(assetExtractionDiffs).stream()
+        getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
             .map(
                 assetExtractorTextUnit ->
                     glossaryTermCaseCheckerTrie.runGlossaryCaseCheck(

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
@@ -43,7 +43,7 @@ public class PlaceholderCommentChecker extends AbstractCliChecker {
     List<AbstractPlaceholderDescriptionCheck> placeholderDescriptionChecks =
         getPlaceholderCommentChecks();
 
-    return getAddedTextUnits(assetExtractionDiffs).stream()
+    return getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
         .map(
             assetExtractorTextUnit ->
                 getPlaceholderCommentCheckResult(

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
@@ -49,7 +49,7 @@ public class RecommendStringIdChecker extends AbstractCliChecker {
 
   private List<String> getRecommendedIdPrefixUpdates(
       List<AssetExtractionDiff> assetExtractionDiffs) {
-    return getAddedTextUnits(assetExtractionDiffs).stream()
+    return getAddedTextUnitsExcludingInconsistentComments(assetExtractionDiffs).stream()
         .map(textUnit -> getRecommendStringIdCheckResult(textUnit))
         .filter(recommendation -> recommendation.isRecommendedUpdate())
         .map(

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
@@ -11,6 +11,7 @@ import com.box.l10n.mojito.cli.command.checks.CliCheckResult;
 import com.box.l10n.mojito.cli.console.ConsoleWriter;
 import com.box.l10n.mojito.rest.resttemplate.AuthenticatedRestTemplate;
 import com.google.common.collect.Lists;
+import java.util.List;
 import org.fusesource.jansi.Ansi;
 import org.junit.Assert;
 import org.junit.Test;
@@ -301,6 +302,201 @@ public class ExtractionCheckCommandTest extends CLITestBase {
         outputCapture.toString().contains("Unknown check name in hard fail list 'INVALID_NAME'"));
   }
 
+  /**
+   * this is a functional test for the {@link
+   * com.box.l10n.mojito.cli.command.checks.AbstractCliChecker#getAddedTextUnitsExcludingInconsistentComments(List)}
+   *
+   * <p>If combination source+context is added again with a different comment we run the check and
+   * eventually reject it if it is not valid
+   */
+  @Test
+  public void runCheckWithInconsistentCommentsInGettextAdd() throws Exception {
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source1").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source1");
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source2").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source2");
+
+    getL10nJCommander()
+        .run(
+            "extract-diff",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1");
+
+    getL10nJCommander()
+        .run(
+            "extraction-check",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1",
+            "-cl",
+            "CONTEXT_COMMENT_CHECKER",
+            "-hf",
+            "CONTEXT_COMMENT_CHECKER");
+
+    Assert.assertTrue(
+        outputCapture
+            .toString()
+            .contains("Source string `source1` failed check with error: Context string is empty."));
+  }
+
+  /**
+   * this is a functional test for the {@link
+   * com.box.l10n.mojito.cli.command.checks.AbstractCliChecker#getAddedTextUnitsExcludingInconsistentComments(List)}
+   *
+   * <p>Before adding the logic to exclude inconsistent comment, we'd have run the check on the text
+   * unit, and if it was invalid we would have got an error. This was missleading because only the
+   * order of the comments had changed - due to maybe order of the extraction, line, or file moving
+   * around.
+   */
+  @Test
+  public void runCheckWithInconsistentCommentsInGettextChange() throws Exception {
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source1").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source1");
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source2").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source2");
+
+    getL10nJCommander()
+        .run(
+            "extract-diff",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1");
+
+    getL10nJCommander()
+        .run(
+            "extraction-check",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1",
+            "-cl",
+            "CONTEXT_COMMENT_CHECKER",
+            "-hf",
+            "CONTEXT_COMMENT_CHECKER");
+
+    Assert.assertTrue(outputCapture.toString().contains("Running checks against new strings"));
+    Assert.assertTrue(outputCapture.toString().contains("Checks completed"));
+    Assert.assertFalse(
+        outputCapture.toString().contains("failed") || outputCapture.toString().contains("Failed"));
+  }
+
+  /**
+   * this is a functional test for the {@link
+   * com.box.l10n.mojito.cli.command.checks.AbstractCliChecker#getAddedTextUnitsExcludingInconsistentComments(List)}
+   *
+   * <p>Before adding the logic to exclude inconsistent comment, we'd have run the check on the text
+   * unit, and if it was invalid we would have got an error. This was missleading because the old
+   * usage was just removed
+   */
+  @Test
+  public void runCheckWithInconsistentCommentsInGettextRemove() throws Exception {
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source1").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source1");
+
+    getL10nJCommander()
+        .run(
+            "extract",
+            "-s",
+            getInputResourcesTestDir("source2").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-n",
+            "source2");
+
+    getL10nJCommander()
+        .run(
+            "extract-diff",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1");
+
+    getL10nJCommander()
+        .run(
+            "extraction-check",
+            "-i",
+            getTargetTestDir("extractions").getAbsolutePath(),
+            "-o",
+            getTargetTestDir("extraction-diffs").getAbsolutePath(),
+            "-c",
+            "source2",
+            "-b",
+            "source1",
+            "-cl",
+            "CONTEXT_COMMENT_CHECKER",
+            "-hf",
+            "CONTEXT_COMMENT_CHECKER");
+
+    Assert.assertTrue(outputCapture.toString().contains("Running checks against new strings"));
+    Assert.assertTrue(outputCapture.toString().contains("Checks completed"));
+    Assert.assertFalse(
+        outputCapture.toString().contains("failed") || outputCapture.toString().contains("Failed"));
+  }
+
   @Test
   public void testChecksSkippedIfSkipChecksEnabled() {
     ConsoleWriter consoleWriter = Mockito.mock(ConsoleWriter.class);
@@ -378,5 +574,10 @@ public class ExtractionCheckCommandTest extends CLITestBase {
     extractionCheckCommand.reportStatistics(Lists.newArrayList(success, failure));
     verify(consoleWriter, times(1))
         .a("Error reporting statistics to http endpoint: test exception");
+  }
+
+  public void testPOMultiCommentForSameSourceAndTarget() {
+    // we test that removing usage of a string does not re-trigger checking
+
   }
 }

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextAdd/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextAdd/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. comment1
+#. comment2
+#. comment3
+#: usage1
+#: usage2
+#: usage3
+msgid "source1"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextAdd/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextAdd/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#. comment1
+#. comment2
+#. comment4
+#. comment3
+#: usage1
+#: usage2
+#: usage4
+#: usage3
+msgid "source1"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextChange/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextChange/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. comment1
+#. comment2
+#. comment3
+#: usage1
+#: usage2
+#: usage3
+msgid "source1"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextChange/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextChange/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#. comment1
+#. comment3
+#. comment2
+#: usage1
+#: usage3
+#: usage2
+msgid "source1"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextRemove/input/source1/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextRemove/input/source1/LC_MESSAGES/messages.pot
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. comment1
+#. comment2
+#. comment3
+#: usage1
+#: usage2
+#: usage3
+msgid "source1"
+msgstr ""

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextRemove/input/source2/LC_MESSAGES/messages.pot
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest_IO/runCheckWithInconsistentCommentsInGettextRemove/input/source2/LC_MESSAGES/messages.pot
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-24 11:50-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+ 
+
+#. comment1
+#. comment3
+#: usage1
+#: usage2
+msgid "source1"
+msgstr ""


### PR DESCRIPTION
In the case of gettext extractor and PO files there is an edge case that can lead to check existing strings even though they are not changed directly. If the string does not pass the check it will raise a failure which becomes pretty confusing. No error should be raised when removing old strings, or moving them around (include changing files, etc).

See the specific example in the code documentation