### PR TITLE
Fixing Spell Check Notification Format

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
@@ -241,7 +241,7 @@ public class SpellCliChecker extends AbstractCliChecker {
         failureMap.keySet().stream()
             .map(sourceString -> buildFailureText(failureMap, sourceString))
             .collect(Collectors.joining(System.lineSeparator())));
-    notificationText.append(System.lineSeparator() + System.lineSeparator());
+    notificationText.append(System.lineSeparator());
     addDictionaryUpdateInformation(notificationText);
 
     return notificationText.toString();
@@ -259,19 +259,21 @@ public class SpellCliChecker extends AbstractCliChecker {
 
   private String buildFailureText(
       Map<String, Map<String, List<String>>> failureMap, String sourceString) {
-    return failureMap.get(sourceString).keySet().stream()
-        .map(
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append("The string ")
+        .append(QUOTE_MARKER)
+        .append(sourceString)
+        .append(QUOTE_MARKER)
+        .append(" contains misspelled words:")
+        .append(System.lineSeparator());
+    failureMap
+        .get(sourceString)
+        .keySet()
+        .forEach(
             misspelling -> {
-              StringBuilder builder = new StringBuilder();
-              builder.append(
-                  "The string "
-                      + QUOTE_MARKER
-                      + sourceString
-                      + QUOTE_MARKER
-                      + " contains misspelled words:"
-                      + System.lineSeparator());
               List<String> suggestions = failureMap.get(sourceString).get(misspelling);
-              builder.append(" * '" + misspelling + "' ");
+              builder.append("  ● '").append(misspelling).append("' ");
               if (!suggestions.isEmpty()) {
                 builder.append("- Did you mean ");
                 builder.append(
@@ -281,9 +283,9 @@ public class SpellCliChecker extends AbstractCliChecker {
                                 Collectors.toList(), joinCommaSeparated(", ", " or "))));
                 builder.append("?");
               }
-              return builder.toString();
-            })
-        .collect(Collectors.joining(System.lineSeparator()));
+              builder.append(System.lineSeparator());
+            });
+    return builder.toString();
   }
 
   private static Function<List<String>, String> joinCommaSeparated(

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
@@ -115,9 +115,9 @@ public class SpellCliCheckerTest {
     when(hunspellMock.spell("erors")).thenReturn(false);
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
-    assertFalse(result.getNotificationText().isEmpty());
-    assertTrue(result.getNotificationText().contains("* 'erors'"));
-    assertTrue(result.getNotificationText().contains("* 'strng'"));
+    String expectedResult =
+        "The string `A source strng with some erors.` contains misspelled words:\n  ● 'strng' \n  ● 'erors' \n\n";
+    assertEquals(expectedResult, result.getNotificationText());
     assertFalse(result.isHardFail());
   }
 
@@ -234,16 +234,10 @@ public class SpellCliCheckerTest {
                     "target/tests/resources/dictAddition.txt")
                 .build()));
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
+    String expectedResult =
+        "The string `A source strng with some erors.` contains misspelled words:\n  ● 'strng' \n  ● 'erors' \n\nIf a word is correctly spelt please add your spelling to target/tests/resources/dictAddition.txt to avoid future false negatives.";
     assertFalse(result.isSuccessful());
-    assertFalse(result.getNotificationText().isEmpty());
-    assertTrue(result.getNotificationText().contains("* 'erors'"));
-    assertTrue(result.getNotificationText().contains("* 'strng'"));
-    assertTrue(
-        result
-            .getNotificationText()
-            .contains(
-                "If a word is correctly spelt please add your spelling to target/tests/resources/dictAddition.txt to avoid future false negatives."));
-    assertFalse(result.isHardFail());
+    assertEquals(expectedResult, result.getNotificationText());
   }
 
   @Test
@@ -262,10 +256,10 @@ public class SpellCliCheckerTest {
 
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
-    assertFalse(result.getNotificationText().isEmpty());
-    assertTrue(result.getNotificationText().contains("* 'erors'"));
-    assertTrue(result.getNotificationText().contains("* 'strng'"));
-    assertTrue(result.getNotificationText().contains("* 'falures'"));
+    String expectedResult =
+        "The string `Another string with falures` contains misspelled words:\n  ● 'falures' \n\nThe string "
+            + "`A source strng with some erors.` contains misspelled words:\n  ● 'strng' \n  ● 'erors' \n\n";
+    assertEquals(expectedResult, result.getNotificationText());
   }
 
   @Test
@@ -333,12 +327,13 @@ public class SpellCliCheckerTest {
 
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
-    assertTrue(result.getNotificationText().contains("* 'identicl'"));
-    assertEquals(1, result.getNotificationText().chars().filter(c -> c == '*').count());
+    String expectedResult =
+        "The string `A source string with identicl identicl identicl errors.` contains misspelled words:\n  ● 'identicl' \n\n";
+    assertEquals(expectedResult, result.getNotificationText());
   }
 
   @Test
-  public void testMultipleIdenticalErrorsInMultipleIdenticalStrings() throws Exception {
+  public void testMultipleIdenticalErrorsInMultipleIdenticalStrings() {
     List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
     AssetExtractorTextUnit assetExtractorTextUnit1 = new AssetExtractorTextUnit();
     assetExtractorTextUnit1.setSource("A source string with identicl identicl identicl errors.");
@@ -354,8 +349,9 @@ public class SpellCliCheckerTest {
 
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
-    assertTrue(result.getNotificationText().contains("* 'identicl'"));
-    assertEquals(1, result.getNotificationText().chars().filter(c -> c == '*').count());
+    String expectedResult =
+        "The string `A source string with identicl identicl identicl errors.` contains misspelled words:\n  ● 'identicl' \n\n";
+    assertEquals(expectedResult, result.getNotificationText());
   }
 
   @Test
@@ -492,12 +488,10 @@ public class SpellCliCheckerTest {
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
     assertFalse(result.getNotificationText().isEmpty());
-    assertTrue(result.getNotificationText().contains("* 'erors'"));
-    assertTrue(result.getNotificationText().contains("* 'strng'"));
-    assertTrue(result.getNotificationText().contains("* 'sorce'"));
-    assertTrue(result.getNotificationText().contains("Did you mean errors?"));
-    assertTrue(result.getNotificationText().contains("Did you mean string or strong?"));
-    assertTrue(result.getNotificationText().contains("Did you mean source, sorcerer or sorcery?"));
+    String expectedResult =
+        "The string `A sorce strng with some erors.` contains misspelled words:\n  ● 'sorce' - Did you mean source, "
+            + "sorcerer or sorcery?\n  ● 'strng' - Did you mean string or strong?\n  ● 'erors' - Did you mean errors?\n\n";
+    assertEquals(expectedResult, result.getNotificationText());
     assertFalse(result.isHardFail());
   }
 


### PR DESCRIPTION
Spell check notifications were being displayed such as:
![image](https://github.com/box/mojito/assets/44348924/d517aa5c-dca1-4638-a4a9-d1409b08e2fe)

- Changed to display the `The string ... contains misspelled words` just once instead of repeating the phrase when more than one misspelled word was found. Please note that unit tests have good output sample to look at.

- Changed * to ● because the spell check slack notification was not being rendered as bullet point.

- Updated unit tests accordingly