### PR TITLE
Fixing Notification Messages Format

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/AbstractCliChecker.java
@@ -19,6 +19,8 @@ public abstract class AbstractCliChecker {
 
   protected CliCheckerOptions cliCheckerOptions;
 
+  public static final String BULLET_POINT = "\t• ";
+
   public static AbstractCliChecker createInstanceForClassName(String className)
       throws CliCheckerInstantiationException {
     try {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
@@ -62,7 +62,8 @@ public class ContextAndCommentCliChecker extends AbstractCliChecker {
                   .filter(ContextAndCommentCliCheckerResult::isFailed)
                   .map(
                       result ->
-                          "* Source string "
+                          BULLET_POINT
+                              + "Source string "
                               + QUOTE_MARKER
                               + result.getSourceString()
                               + QUOTE_MARKER

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextCommentRejectPatternChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextCommentRejectPatternChecker.java
@@ -74,9 +74,9 @@ public class ContextCommentRejectPatternChecker extends AbstractCliChecker {
 
   private String buildFailureText(AssetExtractorTextUnit textUnit) {
     StringBuilder sb = new StringBuilder();
-    sb.append("* Source string " + QUOTE_MARKER);
+    sb.append(BULLET_POINT).append("Source string ").append(QUOTE_MARKER);
     sb.append(textUnit.getSource());
-    sb.append(QUOTE_MARKER + " has an invalid context or comment string.");
+    sb.append(QUOTE_MARKER).append(" has an invalid context or comment string.");
     return sb.toString();
   }
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ControlCharacterChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ControlCharacterChecker.java
@@ -47,13 +47,14 @@ public class ControlCharacterChecker extends AbstractCliChecker {
 
     if (!result.isSuccessful) {
       StringBuilder sb = new StringBuilder();
-      sb.append(
-          "* Control character found in source string "
-              + QUOTE_MARKER
-              + source
-              + QUOTE_MARKER
-              + " at index "
-              + indexMatches.stream()
+      sb.append(BULLET_POINT)
+          .append("Control character found in source string ")
+          .append(QUOTE_MARKER)
+          .append(source)
+          .append(QUOTE_MARKER)
+          .append(" at index ")
+          .append(
+              indexMatches.stream()
                   .map(index -> Integer.toString(index))
                   .collect(Collectors.joining(", ")));
       sb.append(".");

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderChecker.java
@@ -79,7 +79,7 @@ public class EmptyPlaceholderChecker extends AbstractCliChecker {
     notificationText.append(System.lineSeparator());
     notificationText.append(
         failures.stream()
-            .map(source -> "* " + QUOTE_MARKER + source + QUOTE_MARKER)
+            .map(source -> BULLET_POINT + QUOTE_MARKER + source + QUOTE_MARKER)
             .collect(Collectors.joining(System.lineSeparator())));
     notificationText.append(System.lineSeparator());
     return notificationText;

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseChecker.java
@@ -75,7 +75,7 @@ public class GlossaryCaseChecker extends AbstractCliChecker {
     StringBuilder sb = new StringBuilder();
     sb.append(System.lineSeparator());
     for (String failureText : failure.getFailures()) {
-      builder.append(String.format("* %s", failureText));
+      builder.append(BULLET_POINT).append(failureText);
       builder.append(System.lineSeparator());
     }
     return sb.toString();

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentChecker.java
@@ -117,7 +117,7 @@ public class PlaceholderCommentChecker extends AbstractCliChecker {
                   sb.append(System.lineSeparator());
                   return sb.append(
                           failureMap.get(source).stream()
-                              .map(failure -> "* " + failure)
+                              .map(failure -> BULLET_POINT + failure)
                               .collect(Collectors.joining(System.lineSeparator())))
                       .toString();
                 })

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdChecker.java
@@ -41,7 +41,7 @@ public class RecommendStringIdChecker extends AbstractCliChecker {
     sb.append(System.lineSeparator());
     sb.append(
         recommendations.stream()
-            .map(recommendation -> "* " + recommendation)
+            .map(recommendation -> BULLET_POINT + recommendation)
             .collect(Collectors.joining(System.lineSeparator())));
     sb.append(System.lineSeparator());
     return sb.toString();

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/SpellCliChecker.java
@@ -273,9 +273,13 @@ public class SpellCliChecker extends AbstractCliChecker {
         .forEach(
             misspelling -> {
               List<String> suggestions = failureMap.get(sourceString).get(misspelling);
-              builder.append("  ● '").append(misspelling).append("' ");
+              builder
+                  .append(BULLET_POINT)
+                  .append(QUOTE_MARKER)
+                  .append(misspelling)
+                  .append(QUOTE_MARKER);
               if (!suggestions.isEmpty()) {
-                builder.append("- Did you mean ");
+                builder.append(" - Did you mean ");
                 builder.append(
                     suggestions.stream()
                         .collect(

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSender.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSender.java
@@ -40,6 +40,7 @@ public abstract class ExtractionCheckNotificationSender {
 
   protected String getFormattedNotificationMessage(
       String messageTemplate, String messageKey, String message) {
+    message += getDoubleNewLines();
     MessageFormat messageFormatForTemplate = new MessageFormat(messageTemplate);
     return messageFormatForTemplate.format(ImmutableMap.of(messageKey, message));
   }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommandTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -138,7 +139,8 @@ public class ExtractionCheckCommandTest extends CLITestBase {
         outputCapture
             .toString()
             .contains(
-                "* Source string `This is a new source string missing a context` failed check with error: Context string is empty."));
+                BULLET_POINT
+                    + "Source string `This is a new source string missing a context` failed check with error: Context string is empty."));
   }
 
   @Test

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliCheckerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
 
@@ -64,7 +65,8 @@ public class ContextAndCommentCliCheckerTest {
     Assert.assertEquals(
         "Context and comment check found failures:"
             + System.lineSeparator()
-            + "* Source string "
+            + BULLET_POINT
+            + "Source string "
             + QUOTE_MARKER
             + "A source string with no errors."
             + QUOTE_MARKER
@@ -92,7 +94,8 @@ public class ContextAndCommentCliCheckerTest {
     Assert.assertEquals(
         "Context and comment check found failures:"
             + System.lineSeparator()
-            + "* Source string "
+            + BULLET_POINT
+            + "Source string "
             + QUOTE_MARKER
             + "A source string with no errors."
             + QUOTE_MARKER
@@ -120,7 +123,8 @@ public class ContextAndCommentCliCheckerTest {
     Assert.assertEquals(
         "Context and comment check found failures:"
             + System.lineSeparator()
-            + "* Source string "
+            + BULLET_POINT
+            + "Source string "
             + QUOTE_MARKER
             + "A source string with no errors."
             + QUOTE_MARKER
@@ -148,7 +152,8 @@ public class ContextAndCommentCliCheckerTest {
     Assert.assertEquals(
         "Context and comment check found failures:"
             + System.lineSeparator()
-            + "* Source string "
+            + BULLET_POINT
+            + "Source string "
             + QUOTE_MARKER
             + "A source string with no errors."
             + QUOTE_MARKER
@@ -199,7 +204,8 @@ public class ContextAndCommentCliCheckerTest {
     Assert.assertEquals(
         "Context and comment check found failures:"
             + System.lineSeparator()
-            + "* Source string "
+            + BULLET_POINT
+            + "Source string "
             + QUOTE_MARKER
             + "A source string with no errors."
             + QUOTE_MARKER

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextCommentRejectPatternCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextCommentRejectPatternCheckerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.CONTEXT_COMMENT_REJECT_PATTERN_KEY;
 import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX;
@@ -73,7 +74,8 @@ public class ContextCommentRejectPatternCheckerTest {
         result
             .getNotificationText()
             .contains(
-                "* Source string "
+                BULLET_POINT
+                    + "Source string "
                     + QUOTE_MARKER
                     + "A source string with no errors."
                     + QUOTE_MARKER

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/EmptyPlaceholderCheckerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
 
@@ -65,7 +66,7 @@ public class EmptyPlaceholderCheckerTest {
     Assert.assertEquals(
         "Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:"
             + System.lineSeparator()
-            + "* "
+            + BULLET_POINT
             + QUOTE_MARKER
             + "A source string with a empty placeholder {}."
             + QUOTE_MARKER
@@ -92,7 +93,7 @@ public class EmptyPlaceholderCheckerTest {
     Assert.assertEquals(
         "Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:"
             + System.lineSeparator()
-            + "* "
+            + BULLET_POINT
             + QUOTE_MARKER
             + "A source string with two {} empty placeholders {}."
             + QUOTE_MARKER
@@ -125,7 +126,7 @@ public class EmptyPlaceholderCheckerTest {
     Assert.assertEquals(
         "Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:"
             + System.lineSeparator()
-            + "* "
+            + BULLET_POINT
             + QUOTE_MARKER
             + "A source string with two {} empty placeholders {}."
             + QUOTE_MARKER
@@ -152,7 +153,7 @@ public class EmptyPlaceholderCheckerTest {
     Assert.assertEquals(
         "Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:"
             + System.lineSeparator()
-            + "* "
+            + BULLET_POINT
             + QUOTE_MARKER
             + "A source string with two {} placeholders {name}."
             + QUOTE_MARKER
@@ -184,12 +185,12 @@ public class EmptyPlaceholderCheckerTest {
     Assert.assertEquals(
         "Found empty placeholders in the following source strings, please remove or update placeholders to contain a descriptive name:"
             + System.lineSeparator()
-            + "* "
+            + BULLET_POINT
             + QUOTE_MARKER
             + "A source string with two {} empty placeholders {}."
             + QUOTE_MARKER
             + System.lineSeparator()
-            + "* "
+            + BULLET_POINT
             + QUOTE_MARKER
             + "Another source string with two {} empty placeholders {}."
             + QUOTE_MARKER

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/GlossaryCaseCheckerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.GLOSSARY_FILE_PATH_KEY;
 import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 
@@ -94,13 +95,15 @@ public class GlossaryCaseCheckerTest {
     Assert.assertEquals(
         "Glossary check failures:"
             + System.lineSeparator()
-            + "* MAJOR: String "
+            + BULLET_POINT
+            + "MAJOR: String "
             + QUOTE_MARKER
             + "A source string with company and ads Manager in it."
             + QUOTE_MARKER
             + " contains glossary term 'Company' which must match exactly."
             + System.lineSeparator()
-            + "* WARN: String "
+            + BULLET_POINT
+            + "WARN: String "
             + QUOTE_MARKER
             + "A source string with company and ads Manager in it."
             + QUOTE_MARKER
@@ -125,7 +128,8 @@ public class GlossaryCaseCheckerTest {
     Assert.assertEquals(
         "Glossary check failures:"
             + System.lineSeparator()
-            + "* WARN: String "
+            + BULLET_POINT
+            + "WARN: String "
             + QUOTE_MARKER
             + "A source string with ads                Manager in it."
             + QUOTE_MARKER
@@ -166,7 +170,8 @@ public class GlossaryCaseCheckerTest {
     Assert.assertEquals(
         "Glossary check failures:"
             + System.lineSeparator()
-            + "* WARN: String "
+            + BULLET_POINT
+            + "WARN: String "
             + QUOTE_MARKER
             + "A source string with ads Manager in it."
             + QUOTE_MARKER
@@ -192,7 +197,8 @@ public class GlossaryCaseCheckerTest {
     Assert.assertEquals(
         "Glossary check failures:"
             + System.lineSeparator()
-            + "* WARN: String "
+            + BULLET_POINT
+            + "WARN: String "
             + QUOTE_MARKER
             + "A source string with Ads-Manager in it."
             + QUOTE_MARKER
@@ -232,7 +238,8 @@ public class GlossaryCaseCheckerTest {
     Assert.assertEquals(
         "Glossary check failures:"
             + System.lineSeparator()
-            + "* WARN: String "
+            + BULLET_POINT
+            + "WARN: String "
             + QUOTE_MARKER
             + "A source string with event Manager in it."
             + QUOTE_MARKER

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/PlaceholderCommentCheckerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.DOUBLE_BRACE_REGEX;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX;
@@ -140,7 +141,8 @@ public class PlaceholderCommentCheckerTest {
             + QUOTE_MARKER
             + " failed check:"
             + System.lineSeparator()
-            + "* Missing description for placeholder with name "
+            + BULLET_POINT
+            + "Missing description for placeholder with name "
             + QUOTE_MARKER
             + "another"
             + QUOTE_MARKER
@@ -202,7 +204,8 @@ public class PlaceholderCommentCheckerTest {
         result
             .getNotificationText()
             .contains(
-                "* Missing description for placeholder with name "
+                BULLET_POINT
+                    + "Missing description for placeholder with name "
                     + QUOTE_MARKER
                     + "placeholder2"
                     + QUOTE_MARKER
@@ -211,7 +214,8 @@ public class PlaceholderCommentCheckerTest {
         result
             .getNotificationText()
             .contains(
-                "* Missing description for placeholder with name "
+                BULLET_POINT
+                    + "Missing description for placeholder with name "
                     + QUOTE_MARKER
                     + "%d"
                     + QUOTE_MARKER

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/RecommendStringIdCheckerTest.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.RECOMMEND_STRING_ID_LABEL_IGNORE_PATTERN_KEY;
 import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
@@ -62,7 +63,8 @@ public class RecommendStringIdCheckerTest {
     Assert.assertEquals(
         "Recommended id updates for the following strings:"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "incorrect.prefix.someStringId"
             + QUOTE_MARKER
@@ -204,7 +206,8 @@ public class RecommendStringIdCheckerTest {
     Assert.assertEquals(
         "Recommended id updates for the following strings:"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "someStringId"
             + QUOTE_MARKER
@@ -235,7 +238,8 @@ public class RecommendStringIdCheckerTest {
     Assert.assertEquals(
         "Recommended id updates for the following strings:"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "someStringId"
             + QUOTE_MARKER
@@ -291,7 +295,8 @@ public class RecommendStringIdCheckerTest {
     Assert.assertEquals(
         "Recommended id updates for the following strings:"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "someStringId"
             + QUOTE_MARKER
@@ -301,7 +306,8 @@ public class RecommendStringIdCheckerTest {
             + QUOTE_MARKER
             + " to be prefixed with 'root.'"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "someOtherStringId"
             + QUOTE_MARKER
@@ -348,7 +354,8 @@ public class RecommendStringIdCheckerTest {
     Assert.assertEquals(
         "Recommended id updates for the following strings:"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "someStringId"
             + QUOTE_MARKER
@@ -358,7 +365,8 @@ public class RecommendStringIdCheckerTest {
             + QUOTE_MARKER
             + " to be prefixed with 'root.'"
             + System.lineSeparator()
-            + "* Please update id "
+            + BULLET_POINT
+            + "Please update id "
             + QUOTE_MARKER
             + "someOtherStringId"
             + QUOTE_MARKER

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/SpellCliCheckerTest.java
@@ -1,8 +1,10 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.AbstractCliChecker.BULLET_POINT;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.DICTIONARY_ADDITIONS_PATH_KEY;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.DICTIONARY_AFFIX_FILE_PATH_KEY;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.DICTIONARY_FILE_PATH_KEY;
+import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNotificationSender.QUOTE_MARKER;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PLACEHOLDER_NO_SPECIFIER_REGEX;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.PRINTF_LIKE_VARIABLE_TYPE_REGEX;
 import static com.box.l10n.mojito.regex.PlaceholderRegularExpressions.SINGLE_BRACE_REGEX;
@@ -75,7 +77,7 @@ public class SpellCliCheckerTest {
   }
 
   @Test
-  public void testHardFailureIsSet() throws Exception {
+  public void testHardFailureIsSet() {
     Set<CliCheckerType> hardFailureSet = new HashSet<>();
     hardFailureSet.add(CliCheckerType.SPELL_CHECKER);
     spellCliChecker.setCliCheckerOptions(
@@ -94,7 +96,7 @@ public class SpellCliCheckerTest {
   }
 
   @Test
-  public void testStringWithNoErrors() throws Exception {
+  public void testStringWithNoErrors() {
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertTrue(result.isSuccessful());
     assertTrue(result.getNotificationText().isEmpty());
@@ -102,7 +104,7 @@ public class SpellCliCheckerTest {
   }
 
   @Test
-  public void testStringWithErrors() throws Exception {
+  public void testStringWithErrors() {
     List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
     AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
     assetExtractorTextUnit.setSource("A source strng with some erors.");
@@ -116,7 +118,16 @@ public class SpellCliCheckerTest {
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
     String expectedResult =
-        "The string `A source strng with some erors.` contains misspelled words:\n  ● 'strng' \n  ● 'erors' \n\n";
+        String.format(
+            "The string %sA source strng with some erors.%s contains misspelled words:\n%s%sstrng%s\n%s%serors%s\n\n",
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER);
     assertEquals(expectedResult, result.getNotificationText());
     assertFalse(result.isHardFail());
   }
@@ -157,7 +168,7 @@ public class SpellCliCheckerTest {
   }
 
   @Test
-  public void testParametersAreNotSpellChecked() throws Exception {
+  public void testParametersAreNotSpellChecked() {
     List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
     AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
     assetExtractorTextUnit.setSource("A source string with {image_name} errors.");
@@ -235,13 +246,24 @@ public class SpellCliCheckerTest {
                 .build()));
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     String expectedResult =
-        "The string `A source strng with some erors.` contains misspelled words:\n  ● 'strng' \n  ● 'erors' \n\nIf a word is correctly spelt please add your spelling to target/tests/resources/dictAddition.txt to avoid future false negatives.";
+        String.format(
+            "The string %sA source strng with some erors.%s contains misspelled words:\n%s%sstrng%s\n%s%serors%s\n\nIf a "
+                + "word is correctly spelt please add your spelling to target/tests/resources/dictAddition.txt to "
+                + "avoid future false negatives.",
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER);
     assertFalse(result.isSuccessful());
     assertEquals(expectedResult, result.getNotificationText());
   }
 
   @Test
-  public void testMultipleStringsWithMisspellings() throws Exception {
+  public void testMultipleStringsWithMisspellings() {
     List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
     AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
     assetExtractorTextUnit.setSource("A source strng with some erors.");
@@ -257,13 +279,27 @@ public class SpellCliCheckerTest {
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
     String expectedResult =
-        "The string `Another string with falures` contains misspelled words:\n  ● 'falures' \n\nThe string "
-            + "`A source strng with some erors.` contains misspelled words:\n  ● 'strng' \n  ● 'erors' \n\n";
+        String.format(
+            "The string %sAnother string with falures%s contains misspelled words:\n%s%sfalures%s\n\nThe string "
+                + "%sA source strng with some erors.%s contains misspelled words:\n%s%sstrng%s\n%s%serors%s\n\n",
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER);
     assertEquals(expectedResult, result.getNotificationText());
   }
 
   @Test
-  public void testNestedICUPlaceholderIsExcludedFromSpellcheck() throws Exception {
+  public void testNestedICUPlaceholderIsExcludedFromSpellcheck() {
     List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
     AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
     assetExtractorTextUnit.setSource(
@@ -328,7 +364,9 @@ public class SpellCliCheckerTest {
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
     String expectedResult =
-        "The string `A source string with identicl identicl identicl errors.` contains misspelled words:\n  ● 'identicl' \n\n";
+        String.format(
+            "The string %sA source string with identicl identicl identicl errors.%s contains misspelled words:\n%s%sidenticl%s\n\n",
+            QUOTE_MARKER, QUOTE_MARKER, BULLET_POINT, QUOTE_MARKER, QUOTE_MARKER);
     assertEquals(expectedResult, result.getNotificationText());
   }
 
@@ -350,7 +388,9 @@ public class SpellCliCheckerTest {
     CliCheckResult result = spellCliChecker.run(assetExtractionDiffs);
     assertFalse(result.isSuccessful());
     String expectedResult =
-        "The string `A source string with identicl identicl identicl errors.` contains misspelled words:\n  ● 'identicl' \n\n";
+        String.format(
+            "The string %sA source string with identicl identicl identicl errors.%s contains misspelled words:\n%s%sidenticl%s\n\n",
+            QUOTE_MARKER, QUOTE_MARKER, BULLET_POINT, QUOTE_MARKER, QUOTE_MARKER);
     assertEquals(expectedResult, result.getNotificationText());
   }
 
@@ -489,8 +529,20 @@ public class SpellCliCheckerTest {
     assertFalse(result.isSuccessful());
     assertFalse(result.getNotificationText().isEmpty());
     String expectedResult =
-        "The string `A sorce strng with some erors.` contains misspelled words:\n  ● 'sorce' - Did you mean source, "
-            + "sorcerer or sorcery?\n  ● 'strng' - Did you mean string or strong?\n  ● 'erors' - Did you mean errors?\n\n";
+        String.format(
+            "The string %sA sorce strng with some erors.%s contains misspelled words:\n%s%ssorce%s - Did you mean source, "
+                + "sorcerer or sorcery?\n%s%sstrng%s - Did you mean string or strong?\n%s%serors%s - Did you mean errors?\n\n",
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER,
+            BULLET_POINT,
+            QUOTE_MARKER,
+            QUOTE_MARKER);
     assertEquals(expectedResult, result.getNotificationText());
     assertFalse(result.isHardFail());
   }


### PR DESCRIPTION
Follow-up work of [PR948](https://github.com/box/mojito/pull/948)

This PR contains the following changes:

- Changed all the notification message `*` symbols to bullet point symbol to be compatible with other platforms such as slack
- Updated the code to use a same bullet point constant (if changes are needed we can now change it in a single place).
- Added an empty line after the baseMessage. This is helpful when there are more some custom text to show after the base message, so this text will be append after an empty line.
- Unit tests updated accordingly