### PR TITLE
Get Words in String Method Fix

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CheckerUtils.java
@@ -74,7 +74,7 @@ public class CheckerUtils {
     if (matcher.find()) {
       wishedHtmlAttValue = matcher.group(1);
     }
-    str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), "");
+    str = str.replaceAll(HTML_TAGS_PATTERN.pattern(), " ");
 
     return wishedHtmlAttValue != null ? str + " " + wishedHtmlAttValue : str;
   }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/CheckerUtilsTest.java
@@ -130,6 +130,12 @@ class CheckerUtilsTest {
   }
 
   @Test
+  void weShouldBeAbleTo_getWordsInString_whenThereAreNoSpacesAmongHtmlTags() {
+    List<String> result = CheckerUtils.getWordsInString("<b>These are different</b><br>Words");
+    assertThat(result).containsExactly("These", "are", "different", "Words");
+  }
+
+  @Test
   void weShouldNotThrowExceptionWhen_getWordsInString_providingEmptyStringAsInput() {
     List<String> result = CheckerUtils.getWordsInString("");
     assertThat(result).isEmpty();


### PR DESCRIPTION
When html inputs such as:
```
<ul>
<li>word1<\li><li>word2<\li>
<\ul>
```

is provided, work1word2 is being recognized as a single word. 
With this fix, html tags will be replaced to empty spaces, avoiding this issue.

Before the fix, the test case including such inputs was failing, but after replacing html tags to an empty space, all tests passed.

![image](https://github.com/box/mojito/assets/44348924/a89bb2d5-04bd-4f29-9301-60bf68cbed49)


