### PR TITLE
Support Adobe Magento CSV language packages 

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/CSVAdobeMagentoFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/CSVAdobeMagentoFileType.java
@@ -1,0 +1,37 @@
+package com.box.l10n.mojito.cli.filefinder.file;
+
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.DOT;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PATH_SEPERATOR;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.SUB_PATH;
+
+import com.box.l10n.mojito.cli.filefinder.locale.CVSAdobeMagentoLocaleType;
+import com.box.l10n.mojito.okapi.FilterConfigIdOverride;
+
+/** @author jaurambault */
+public class CSVAdobeMagentoFileType extends LocaleAsFileNameType {
+
+  public CSVAdobeMagentoFileType() {
+    this.sourceFileExtension = "csv";
+    this.subPath = "i18n";
+    this.sourceFilePatternTemplate =
+        "{"
+            + PARENT_PATH
+            + "}{"
+            + SUB_PATH
+            + "}"
+            + PATH_SEPERATOR
+            + "{"
+            + LOCALE
+            + "}"
+            + DOT
+            + "{"
+            + FILE_EXTENSION
+            + "}";
+    this.targetFilePatternTemplate = this.sourceFilePatternTemplate;
+    this.filterConfigIdOverride = FilterConfigIdOverride.CSV_ADOBE_MAGENTO;
+    this.localeType = new CVSAdobeMagentoLocaleType();
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileTypes.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileTypes.java
@@ -19,6 +19,7 @@ public enum FileTypes {
   PO(POFileType.class),
   XTB(XtbFileType.class),
   CSV(CSVFileType.class),
+  CSV_ADOBE_MAGENTO(CSVAdobeMagentoFileType.class),
   JS(JSFileType.class),
   JSON(JSONFileType.class),
   JSON_NOBASENAME(JSONNoBasenameFileType.class),

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/locale/CVSAdobeMagentoLocaleType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/locale/CVSAdobeMagentoLocaleType.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.cli.filefinder.locale;
+
+/**
+ * {@link LocaleType} implementation for Chrome extension. Use "_" in locale names.
+ *
+ * @author jaurambault
+ */
+public class CVSAdobeMagentoLocaleType extends AnyLocaleTargetNotSourceType {
+  public String getTargetLocaleRepresentation(String targetLocale) {
+    return targetLocale.replace("-", "_");
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
@@ -845,6 +845,56 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
   }
 
   @Test
+  public void importCsvAdobeMagento() throws Exception {
+
+    System.setProperty("overrideExpectedTestFiles", "true");
+
+    Repository repository = createTestRepoUsingRepoService();
+
+    getL10nJCommander()
+        .run(
+            "push",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-ft",
+            "CSV_ADOBE_MAGENTO",
+            "-sl",
+            "en_US");
+
+    getL10nJCommander()
+        .run(
+            "import",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-t",
+            getInputResourcesTestDir("translations").getAbsolutePath(),
+            "-ft",
+            "CSV_ADOBE_MAGENTO",
+            "-sl",
+            "en_US");
+
+    getL10nJCommander()
+        .run(
+            "pull",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-t",
+            getTargetTestDir().getAbsolutePath(),
+            "-ft",
+            "CSV_ADOBE_MAGENTO",
+            "-sl",
+            "en_US");
+
+    checkExpectedGeneratedResources();
+  }
+
+  @Test
   public void importUnused() throws Exception {
     Repository repository = createTestRepoUsingRepoService();
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
@@ -1148,6 +1148,58 @@ public class PullCommandTest extends CLITestBase {
   }
 
   @Test
+  public void pullCsvAdobeMagento() throws Exception {
+    Repository repository = createTestRepoUsingRepoService();
+
+    getL10nJCommander()
+        .run(
+            "push",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-ft",
+            "CSV_ADOBE_MAGENTO",
+            "-sl",
+            "en_US");
+
+    Asset asset = assetClient.getAssetByPathAndRepositoryId("i18n/en_US.csv", repository.getId());
+
+    importTranslations(asset.getId(), "source-xliff_", "fr-FR");
+    importTranslations(asset.getId(), "source-xliff_", "ja-JP");
+
+    getL10nJCommander()
+        .run(
+            "pull",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-t",
+            getTargetTestDir("target").getAbsolutePath(),
+            "-ft",
+            "CSV_ADOBE_MAGENTO",
+            "-sl",
+            "en_US");
+
+    getL10nJCommander()
+        .run(
+            "pull",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source_modified").getAbsolutePath(),
+            "-t",
+            getTargetTestDir("target_modified").getAbsolutePath(),
+            "-ft",
+            "CSV_ADOBE_MAGENTO",
+            "-sl",
+            "en_US");
+
+    checkExpectedGeneratedResources();
+  }
+
+  @Test
   public void pullJS() throws Exception {
     Repository repository = createTestRepoUsingRepoService();
 

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/expected/i18n/fr_CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/expected/i18n/fr_CA.csv
@@ -1,0 +1,5 @@
+100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+1 month,1 mois

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/expected/i18n/fr_FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/expected/i18n/fr_FR.csv
@@ -1,0 +1,5 @@
+100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+1 month,1 mois

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/expected/i18n/ja_JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/expected/i18n/ja_JP.csv
@@ -1,0 +1,5 @@
+100 character description:,100文字の説明:
+15 min,15分
+1 day,1日
+1 hour,1時間
+1 month,1か月

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/source/i18n/en_US.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/source/i18n/en_US.csv
@@ -1,0 +1,5 @@
+100 character description:,100 character description:
+15 min,15 min
+1 day,1 day
+1 hour,1 hour
+1 month,1 month

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/translations/i18n/fr_CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/translations/i18n/fr_CA.csv
@@ -1,0 +1,5 @@
+﻿100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+1 month,1 mois

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/translations/i18n/fr_FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/translations/i18n/fr_FR.csv
@@ -1,0 +1,5 @@
+﻿100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+1 month,1 mois

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/translations/i18n/ja_JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importCsvAdobeMagento/input/translations/i18n/ja_JP.csv
@@ -1,0 +1,5 @@
+﻿100 character description:,100文字の説明:
+15 min,15分
+1 day,1日
+1 hour,1時間
+1 month,1か月

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target/i18n/fr_CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target/i18n/fr_CA.csv
@@ -1,0 +1,5 @@
+100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+1 month,1 mois

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target/i18n/fr_FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target/i18n/fr_FR.csv
@@ -1,0 +1,5 @@
+100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+1 month,1 mois

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target/i18n/ja_JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target/i18n/ja_JP.csv
@@ -1,0 +1,5 @@
+100 character description:,100文字の説明:
+15 min,15分
+1 day,1日
+1 hour,1時間
+1 month,1か月

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target_modified/i18n/fr_CA.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target_modified/i18n/fr_CA.csv
@@ -1,0 +1,5 @@
+100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+Something new,Something new

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target_modified/i18n/fr_FR.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target_modified/i18n/fr_FR.csv
@@ -1,0 +1,5 @@
+100 character description:,Description de 100 caractères :
+15 min,15 min
+1 day,1 jour
+1 hour,1 heure
+Something new,Something new

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target_modified/i18n/ja_JP.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/expected/target_modified/i18n/ja_JP.csv
@@ -1,0 +1,5 @@
+100 character description:,100文字の説明:
+15 min,15分
+1 day,1日
+1 hour,1時間
+Something new,Something new

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/source/en_US.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/source/en_US.csv
@@ -1,0 +1,5 @@
+100 character description:,100 character description:
+15 min,15 min
+1 day,1 day
+1 hour,1 hour
+1 month,1 month

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/source/i18n/en_US.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/source/i18n/en_US.csv
@@ -1,0 +1,5 @@
+100 character description:,100 character description:
+15 min,15 min
+1 day,1 day
+1 hour,1 hour
+1 month,1 month

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/source_modified/i18n/en_US.csv
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/source_modified/i18n/en_US.csv
@@ -1,0 +1,5 @@
+100 character description:,100 character description:
+15 min,15 min
+1 day,1 day
+1 hour,1 hour
+Something new,Something new

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/translations/source-xliff_fr-FR.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/translations/source-xliff_fr-FR.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:okp="okapi-framework:xliff-extensions" version="1.2">
+    <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100 character description:" datatype="php">
+                <source>100 character description:</source>
+                <target>Description de 100 caractères :</target>
+            </trans-unit>
+            <trans-unit id="" resname="15 min" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15 min</target>
+            </trans-unit>
+            <trans-unit id="" resname="1 day" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1 jour</target>
+            </trans-unit>
+            <trans-unit id="" resname="1 hour" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1 heure</target>
+            </trans-unit>
+            <trans-unit id="" resname="1 month" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1 mois</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullCsvAdobeMagento/input/translations/source-xliff_ja-JP.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:okp="okapi-framework:xliff-extensions" version="1.2">
+    <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100 character description:" datatype="php">
+                <source>100 character description:</source>
+                <target>100文字の説明:</target>
+            </trans-unit>
+            <trans-unit id="" resname="15 min" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15分</target>
+            </trans-unit>
+            <trans-unit id="" resname="1 day" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1日</target>
+            </trans-unit>
+            <trans-unit id="" resname="1 hour" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1時間</target>
+            </trans-unit>
+            <trans-unit id="" resname="1 month" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1か月</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/common/src/main/java/com/box/l10n/mojito/okapi/FilterConfigIdOverride.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/FilterConfigIdOverride.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.okapi;
 
+import com.box.l10n.mojito.okapi.filters.CSVFilter;
 import com.box.l10n.mojito.okapi.filters.MacStringsdictFilterKey;
 import com.box.l10n.mojito.okapi.filters.XcodeXliffFilter;
 
@@ -10,7 +11,8 @@ import com.box.l10n.mojito.okapi.filters.XcodeXliffFilter;
 public enum FilterConfigIdOverride {
   PROPERTIES_JAVA("okf_properties"),
   MACSTRINGSDICT_FILTER_KEY(MacStringsdictFilterKey.FILTER_CONFIG_ID),
-  XCODE_XLIFF(XcodeXliffFilter.FILTER_CONFIG_ID);
+  XCODE_XLIFF(XcodeXliffFilter.FILTER_CONFIG_ID),
+  CSV_ADOBE_MAGENTO(CSVFilter.FILTER_CONFIG_ID_ADOBE_MAGENTO);
 
   String okapiFilterId;
 

--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/CSVFilter.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/CSVFilter.java
@@ -10,6 +10,9 @@ public class CSVFilter extends CommaSeparatedValuesFilter {
 
   public static final String FILTER_NAME = "okf_table_csv@mojito";
   public static final String FILTER_CONFIG_ID = "okf_table_csv@mojito";
+  public static final String FILTER_CONFIG_ID_ADOBE_MAGENTO = "okf_table_csv@mojito_adobe_magento";
+
+  net.sf.okapi.filters.table.csv.Parameters parameters;
 
   public CSVFilter() {
     super();
@@ -21,6 +24,13 @@ public class CSVFilter extends CommaSeparatedValuesFilter {
         "Table (Comma-Separated Values)",
         "Comma-separated values, optional header with field names.",
         "okf_table_csv_mojito.fprm");
+
+    addConfiguration(
+        false,
+        FILTER_CONFIG_ID_ADOBE_MAGENTO,
+        "Adobe magento CSV",
+        "Comma-separated values, 2 columns: source, target",
+        "okf_table_csv_mojito_adobe_magento.fprm");
   }
 
   /**

--- a/common/src/main/resources/com/box/l10n/mojito/okapi/filters/okf_table_csv_mojito_adobe_magento.fprm
+++ b/common/src/main/resources/com/box/l10n/mojito/okapi/filters/okf_table_csv_mojito_adobe_magento.fprm
@@ -1,0 +1,9 @@
+#v1
+fieldDelimiter=,
+textQualifier="
+sourceIdColumns=1
+sourceColumns=1
+targetColumns=2
+sourceIdSourceRefs=1
+targetSourceRefs=1
+parametersClass=net.sf.okapi.filters.table.csv.Parameters


### PR DESCRIPTION
The CSV has 2 columns: source, target. The filename is made of the locale only with "_" and is inside the "i18n" directory

See reference documentation: https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-languagepack