### PR TITLE
Updating Translations Ready Message

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenders.java
@@ -149,7 +149,8 @@ public class BranchNotificationMessageSenders {
                           messages.getUpdatedStrings(),
                           messages.getTranslationsReady(),
                           messages.getScreenshotsMissing(),
-                          messages.getNoMoreStrings());
+                          messages.getNoMoreStrings(),
+                          slackConfigurationProperties.isGithubPR());
 
                   BranchNotificationMessageSenderSlack branchNotificationMessageSenderSlack =
                       new BranchNotificationMessageSenderSlack(
@@ -158,7 +159,8 @@ public class BranchNotificationMessageSenders {
                           slackChannels,
                           branchNotificationMessageBuilderSlack,
                           slackConfigurationProperties.getUserEmailPattern(),
-                          slackConfigurationProperties.isUseDirectMessage());
+                          slackConfigurationProperties.isUseDirectMessage(),
+                          slackConfigurationProperties.isGithubPR());
 
                   return new SimpleEntry<String, BranchNotificationMessageSenderSlack>(
                       id, branchNotificationMessageSenderSlack);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationProperties.java
@@ -71,6 +71,8 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
     boolean useDirectMessage = false;
 
+    boolean githubPR = false;
+
     public String getSlackClientId() {
       return slackClientId;
     }
@@ -101,6 +103,14 @@ public class BranchNotificationMessageSendersConfigurationProperties {
 
     public void setUseDirectMessage(boolean useDirectMessage) {
       this.useDirectMessage = useDirectMessage;
+    }
+
+    public boolean isGithubPR() {
+      return githubPR;
+    }
+
+    public void setGithubPR(boolean githubPR) {
+      this.githubPR = githubPR;
     }
 
     public static class MessageBuilderConfigurationProperties {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageBuilderGithub.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageBuilderGithub.java
@@ -84,8 +84,14 @@ public class BranchNotificationMessageBuilderGithub {
     return noMoreStringsMsg;
   }
 
-  public String getTranslatedMessage() {
-    return translationsReadyMsg;
+  public String getTranslatedMessage(String branchName, GithubBranchDetails branchDetails) {
+    MessageFormat messageFormat = new MessageFormat(translationsReadyMsg);
+    ImmutableMap<String, Object> messageParamMap =
+        ImmutableMap.<String, Object>builder()
+            .put("branchName", branchName)
+            .put("githubRepository", branchDetails.getRepository())
+            .build();
+    return messageFormat.format(messageParamMap);
   }
 
   public String getScreenshotMissingMessage() {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/BranchNotificationMessageSenderGithub.java
@@ -86,7 +86,7 @@ public class BranchNotificationMessageSenderGithub implements BranchNotification
       githubClient.addCommentToPR(
           branchDetails.getRepository(),
           branchDetails.getPrNumber(),
-          branchNotificationMessageBuilderGithub.getTranslatedMessage());
+          branchNotificationMessageBuilderGithub.getTranslatedMessage(branchName, branchDetails));
       updatePRLabel(
           githubClient,
           branchDetails.getRepository(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/GithubBranchDetails.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/github/GithubBranchDetails.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.service.branch.notification.github;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.github.GithubException;
+import java.util.Objects;
 import org.slf4j.Logger;
 
 public class GithubBranchDetails {
@@ -38,5 +39,20 @@ public class GithubBranchDetails {
 
   public Integer getPrNumber() {
     return prNumber;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GithubBranchDetails that = (GithubBranchDetails) o;
+    return Objects.equals(owner, that.owner)
+        && Objects.equals(repository, that.repository)
+        && Objects.equals(prNumber, that.prNumber);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(owner, repository, prNumber);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/branch/notification/slack/BranchNotificationMessageSenderSlack.java
@@ -27,6 +27,7 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
 
   String userEmailPattern;
   boolean useDirectMessage;
+  boolean githubPR;
 
   public BranchNotificationMessageSenderSlack(
       String id,
@@ -34,7 +35,8 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
       SlackChannels slackChannels,
       BranchNotificationMessageBuilderSlack branchNotificationMessageBuilderSlack,
       String userEmailPattern,
-      boolean useDirectMessage) {
+      boolean useDirectMessage,
+      boolean isGithubPR) {
     this.id = id;
     this.slackClient = Preconditions.checkNotNull(slackClient);
     this.slackChannels = Preconditions.checkNotNull(slackChannels);
@@ -42,6 +44,7 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
         Preconditions.checkNotNull(branchNotificationMessageBuilderSlack);
     this.userEmailPattern = Preconditions.checkNotNull(userEmailPattern);
     this.useDirectMessage = useDirectMessage;
+    this.githubPR = isGithubPR;
   }
 
   @Override
@@ -96,7 +99,8 @@ public class BranchNotificationMessageSenderSlack implements BranchNotificationM
           branchNotificationMessageBuilderSlack.getTranslatedMessage(
               slackChannels.getSlackChannelForDirectOrBotMessage(
                   useDirectMessage, username, userEmailPattern),
-              messageId);
+              messageId,
+              branchName);
 
       ChatPostMessageResponse chatPostMessageResponse = slackClient.sendInstantMessage(message);
     } catch (SlackClientException sce) {

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenderGithubTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSenderGithubTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.box.l10n.mojito.github.GithubClient;
 import com.box.l10n.mojito.service.branch.notification.github.BranchNotificationMessageBuilderGithub;
 import com.box.l10n.mojito.service.branch.notification.github.BranchNotificationMessageSenderGithub;
+import com.box.l10n.mojito.service.branch.notification.github.GithubBranchDetails;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -27,6 +28,8 @@ public class BranchNotificationMessageSenderGithubTest {
 
   String branchName = "testOwner/testRepo/pulls/1";
 
+  GithubBranchDetails githubBranchDetails = new GithubBranchDetails(branchName);
+
   @Before
   public void setup() {
     sourceStrings = new ArrayList<>();
@@ -35,7 +38,8 @@ public class BranchNotificationMessageSenderGithubTest {
         .thenReturn("Test new message");
     when(branchNotificationMessageBuilderGithubMock.getUpdatedMessage(branchName, sourceStrings))
         .thenReturn("Test updated message");
-    when(branchNotificationMessageBuilderGithubMock.getTranslatedMessage())
+    when(branchNotificationMessageBuilderGithubMock.getTranslatedMessage(
+            branchName, githubBranchDetails))
         .thenReturn("Test translated message");
     when(branchNotificationMessageBuilderGithubMock.getScreenshotMissingMessage())
         .thenReturn("Test screenshot missing message");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationPropertiesTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/branch/notification/BranchNotificationMessageSendersConfigurationPropertiesTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.context.junit4.SpringRunner;
       "l10n.branchNotification.notifiers.phabricator.phabricator-1.reviewer=reviewer1",
       "l10n.branchNotification.notifiers.phabricator.phabricator-1.messages.newStrings=Override newStrings Phabricator",
       "l10n.branchNotification.notifiers.github.github-1.owner=owner1",
+      "l10n.branchNotification.notifiers.slack.slack-1.githubPR=true",
     })
 @EnableConfigurationProperties
 public class BranchNotificationMessageSendersConfigurationPropertiesTest {
@@ -53,6 +54,7 @@ public class BranchNotificationMessageSendersConfigurationPropertiesTest {
     assertThat(slack1)
         .extracting("slackClientId", "userEmailPattern", "messages.newStrings")
         .containsExactly("slackClientId1", "{0}@test.com", "Override newStrings");
+    assertThat(slack1).extracting("githubPR").isEqualTo(true);
   }
 
   @Test


### PR DESCRIPTION
Replaces `branchName` and `githubRepository` placeholders accordingly, when they are present in the `Translations ready` message.