### PR TITLE
PR should be unblocked when I18N skip checks is applied

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ExtractionCheckCommand.java
@@ -59,8 +59,7 @@ public class ExtractionCheckCommand extends Command {
 
   @Autowired ExtractionDiffService extractionDiffService;
 
-  @Autowired(required = false)
-  GithubClients githubClients;
+  @Autowired GithubClients githubClients;
 
   @Autowired ConsoleWriter consoleWriter;
 
@@ -282,9 +281,7 @@ public class ExtractionCheckCommand extends Command {
           .newLine()
           .a("Checks disabled as --skip-checks is set to true.")
           .println();
-      if (!Strings.isNullOrEmpty(checksSkippedMessage)) {
-        sendChecksSkippedNotifications();
-      }
+      sendChecksSkippedNotifications();
     } else {
       ExtractionPaths baseExtractionPaths =
           new ExtractionPaths(inputDirectoryParam, baseExtractionName);

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithub.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithub.java
@@ -114,6 +114,17 @@ public class ExtractionCheckNotificationSenderGithub extends ExtractionCheckNoti
 
   @Override
   public void sendChecksSkippedNotification() {
+    if (isSetCommitStatus) {
+      githubClients
+          .getClient(githubOwner)
+          .addStatusToCommit(
+              githubRepo,
+              commitSha,
+              GHCommitState.SUCCESS,
+              "Checks disabled as SKIP_I18N_CHECKS was applied in comments.",
+              "I18N String Checks",
+              commitStatusTargetUrl);
+    }
     if (!Strings.isNullOrEmpty(checksSkippedMessage)) {
       githubClients
           .getClient(githubOwner)

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithubTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/extractioncheck/ExtractionCheckNotificationSenderGithubTest.java
@@ -192,6 +192,14 @@ public class ExtractionCheckNotificationSenderGithubTest {
     Assert.assertTrue(prNumberCaptor.getValue().equals(100));
     Assert.assertTrue(
         messageCaptor.getValue().equals(GithubIcon.WARNING + " This is a checks skipped message"));
+    verify(githubClientMock, times(1))
+        .addStatusToCommit(
+            "testRepo",
+            "123456789",
+            GHCommitState.SUCCESS,
+            "Checks disabled as SKIP_I18N_CHECKS was applied in comments.",
+            "I18N String Checks",
+            "https://somewebaddress.com/");
   }
 
   @Test


### PR DESCRIPTION
Changing Github commit status to success when I18N checks are skipped