### PR TITLE
Batch import logic to not copy over the source comment into target comment

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractImportTranslationsStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/AbstractImportTranslationsStep.java
@@ -445,7 +445,7 @@ public abstract class AbstractImportTranslationsStep extends AbstractMd5Computat
               tmTextUnitId,
               targetLocaleId,
               targetString,
-              null,
+              targetComment,
               status,
               includedInLocalizedFile,
               createdDate,

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterService.java
@@ -234,7 +234,7 @@ public class TextUnitBatchImporterService {
             currentTextUnit.getStatus(),
             DigestUtils.md5Hex(currentTextUnit.getTarget()),
             currentTextUnit.isIncludedInLocalizedFile(),
-            currentTextUnit.getComment(),
+            currentTextUnit.getTargetComment(),
             textUnitForBatchImport.getStatus(),
             DigestUtils.md5Hex(textUnitForBatchImport.getContent()),
             textUnitForBatchImport.isIncludedInLocalizedFile(),
@@ -359,7 +359,7 @@ public class TextUnitBatchImporterService {
 
               textUnitForBatchImport.setLocale(localeService.findByBcp47Tag(t.getTargetLocale()));
               textUnitForBatchImport.setContent(NormalizationUtils.normalize(t.getTarget()));
-              textUnitForBatchImport.setComment(t.getComment());
+              textUnitForBatchImport.setComment(t.getTargetComment());
               textUnitForBatchImport.setIncludedInLocalizedFile(t.isIncludedInLocalizedFile());
               textUnitForBatchImport.setStatus(t.getStatus() == null ? APPROVED : t.getStatus());
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterServiceTest.java
@@ -80,6 +80,7 @@ public class TextUnitBatchImporterServiceTest extends ServiceTestBase {
     textUnitDTO.setAssetPath(tmTestData.asset.getPath());
     textUnitDTO.setName("TEST2");
     textUnitDTO.setTarget("TEST2 translation for fr");
+    textUnitDTO.setComment("Comment2");
 
     TextUnitDTO textUnitDTO2 = new TextUnitDTO();
     textUnitDTO2.setRepositoryName(tmTestData.repository.getName());
@@ -87,6 +88,7 @@ public class TextUnitBatchImporterServiceTest extends ServiceTestBase {
     textUnitDTO2.setAssetPath(tmTestData.asset.getPath());
     textUnitDTO2.setName("TEST3");
     textUnitDTO2.setTarget("TEST3 translation for fr");
+    textUnitDTO2.setTargetComment("TEST3 target comment");
 
     TextUnitDTO textUnitDTO3 = new TextUnitDTO();
     textUnitDTO3.setRepositoryName(tmTestData.repository.getName());
@@ -121,9 +123,12 @@ public class TextUnitBatchImporterServiceTest extends ServiceTestBase {
     i++;
     assertEquals("TEST2", textUnitDTOsFromSearch.get(i).getName());
     assertEquals("TEST2 translation for fr", textUnitDTOsFromSearch.get(i).getTarget());
+    assertNull(textUnitDTOsFromSearch.get(i).getTarget());
+    assertNull(textUnitDTOsFromSearch.get(i).getTargetComment());
     i++;
     assertEquals("TEST3", textUnitDTOsFromSearch.get(i).getName());
     assertEquals("TEST3 translation for fr", textUnitDTOsFromSearch.get(i).getTarget());
+    assertEquals("TEST3 target comment", textUnitDTOsFromSearch.get(i).getTargetComment());
     i++;
   }
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/tm/importer/TextUnitBatchImporterServiceTest.java
@@ -123,7 +123,6 @@ public class TextUnitBatchImporterServiceTest extends ServiceTestBase {
     i++;
     assertEquals("TEST2", textUnitDTOsFromSearch.get(i).getName());
     assertEquals("TEST2 translation for fr", textUnitDTOsFromSearch.get(i).getTarget());
-    assertNull(textUnitDTOsFromSearch.get(i).getTarget());
     assertNull(textUnitDTOsFromSearch.get(i).getTargetComment());
     i++;
     assertEquals("TEST3", textUnitDTOsFromSearch.get(i).getName());


### PR DESCRIPTION
If an actual target comment is provided, it will be now saved properly.

Noticed that the source comment gets systematically copied into the target text unit variant when performing a ThirdPartySync but it applies to all import. This seems to be the behavior since day 1 of the TextUnitBatchImporterService yet it is a bug.