### PR TITLE
Make the dynamic jobs "recoverable" so they are automatically restarted

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/quartz/QuartzPollableTaskScheduler.java
@@ -104,7 +104,11 @@ public class QuartzPollableTaskScheduler {
       if (jobDetail == null) {
         logger.debug("Job doesn't exist, create for key: {}", keyName);
         jobDetail =
-            JobBuilder.newJob().ofType(quartzJobInfo.getClazz()).withIdentity(jobKey).build();
+            JobBuilder.newJob()
+                .ofType(quartzJobInfo.getClazz())
+                .withIdentity(jobKey)
+                .requestRecovery()
+                .build();
       }
 
       logger.debug("Schedule a job for key: {}", keyName);


### PR DESCRIPTION
Currently none of the dynamic jobs are marked as “recoverable” hence in case of a Quartz scheduler failure/restart, they won’t be automatically retried. In the case of a server crash or hard shutdown (some deployment) since the job are not restarted, the related PollableTaks will eventually be detected as a zombie when their TTL is reached and will then be marked as failed.

This PR is exploratory, it might be better to set it at the job level and let only well idem potent job use it.