### PR TITLE
Add parameter to allow skipping of plurals in comment checker

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerOptions.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerOptions.java
@@ -1,5 +1,6 @@
 package com.box.l10n.mojito.cli.command.checks;
 
+import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.CONTEXT_COMMENT_PLURAL_SKIP;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.CONTEXT_COMMENT_REJECT_PATTERN_KEY;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.DICTIONARY_ADDITIONS_PATH_KEY;
 import static com.box.l10n.mojito.cli.command.checks.CliCheckerParameters.DICTIONARY_AFFIX_FILE_PATH_KEY;
@@ -56,6 +57,10 @@ public class CliCheckerOptions {
 
   public String getRecommendStringIdLabelIgnorePattern() {
     return optionsMap.get(RECOMMEND_STRING_ID_LABEL_IGNORE_PATTERN_KEY.getKey());
+  }
+
+  public Boolean getPluralsSkipped() {
+    return Boolean.valueOf(optionsMap.get(CONTEXT_COMMENT_PLURAL_SKIP.getKey()));
   }
 
   public ImmutableMap<String, String> getOptionsMap() {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerParameters.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/CliCheckerParameters.java
@@ -6,7 +6,8 @@ public enum CliCheckerParameters {
   DICTIONARY_FILE_PATH_KEY("dictionaryFilePath"),
   DICTIONARY_AFFIX_FILE_PATH_KEY("dictionaryAffixFilePath"),
   CONTEXT_COMMENT_REJECT_PATTERN_KEY("contextCommentRejectPattern"),
-  RECOMMEND_STRING_ID_LABEL_IGNORE_PATTERN_KEY("recommendStringIdLabelIgnorePattern");
+  RECOMMEND_STRING_ID_LABEL_IGNORE_PATTERN_KEY("recommendStringIdLabelIgnorePattern"),
+  CONTEXT_COMMENT_PLURAL_SKIP("contextCommentSkipPlurals");
 
   private String key;
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliChecker.java
@@ -4,6 +4,7 @@ import static com.box.l10n.mojito.cli.command.extractioncheck.ExtractionCheckNot
 
 import com.box.l10n.mojito.cli.command.extraction.AssetExtractionDiff;
 import com.box.l10n.mojito.okapi.extractor.AssetExtractorTextUnit;
+import com.google.common.base.Strings;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -106,6 +107,9 @@ public class ContextAndCommentCliChecker extends AbstractCliChecker {
     String failureText = null;
     String[] splitNameArray = assetExtractorTextUnit.getName().split("---");
     String context = null;
+    if (isPlural(assetExtractorTextUnit) && cliCheckerOptions.getPluralsSkipped()) {
+      return failureText;
+    }
     if (splitNameArray.length > 1) {
       context = splitNameArray[1];
     }
@@ -124,6 +128,10 @@ public class ContextAndCommentCliChecker extends AbstractCliChecker {
     }
 
     return failureText;
+  }
+
+  private boolean isPlural(AssetExtractorTextUnit assetExtractorTextUnit) {
+    return !Strings.isNullOrEmpty(assetExtractorTextUnit.getPluralForm());
   }
 
   private boolean isBlank(String string) {

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliCheckerTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/checks/ContextAndCommentCliCheckerTest.java
@@ -213,4 +213,25 @@ public class ContextAndCommentCliCheckerTest {
             + System.lineSeparator(),
         result.getNotificationText());
   }
+
+  @Test
+  public void testPluralStringsSkippedIfOptionEnabled() {
+    List<AssetExtractorTextUnit> addedTUs = new ArrayList<>();
+    AssetExtractorTextUnit assetExtractorTextUnit = new AssetExtractorTextUnit();
+    assetExtractorTextUnit.setName("Some string id --- ");
+    assetExtractorTextUnit.setSource("A source string with no errors.");
+    assetExtractorTextUnit.setComments(null);
+    assetExtractorTextUnit.setPluralForm("one");
+    addedTUs.add(assetExtractorTextUnit);
+    List<AssetExtractionDiff> assetExtractionDiffs = new ArrayList<>();
+    AssetExtractionDiff assetExtractionDiff = new AssetExtractionDiff();
+    assetExtractionDiff.setAddedTextunits(addedTUs);
+    assetExtractionDiffs.add(assetExtractionDiff);
+    ImmutableMap<String, String> optionsMap =
+        ImmutableMap.of(CliCheckerParameters.CONTEXT_COMMENT_PLURAL_SKIP.getKey(), "true");
+    contextAndCommentCliChecker.setCliCheckerOptions(
+        new CliCheckerOptions(Sets.newHashSet(SINGLE_BRACE_REGEX), Sets.newHashSet(), optionsMap));
+    CliCheckResult result = contextAndCommentCliChecker.run(assetExtractionDiffs);
+    Assert.assertTrue(result.isSuccessful());
+  }
 }


### PR DESCRIPTION
Allows skipping of plurals in the context and comment checker if an option is passed to the extraction cli checks command