### PR TITLE
Set up building legacy Mojito code

### DIFF
--- a/.github/act.md
+++ b/.github/act.md
@@ -1,0 +1,9 @@
+To debug build issue specific to Github actions, use [act](https://github.com/nektos/act).
+
+At the moment of writting `act -v ` doesn't work with Maven. Installing Maven is an option but in the end the issue
+showing on Github action was not happening.
+
+To run with the same image as Github action use, `act -v -P ubuntu-latest=nektos/act-environments-ubuntu:18.04`. 
+The image is huge though 18G but that might be needed to be able to reproduce issues. Also had to set the locale
+manually in the container.
+

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -1,0 +1,17 @@
+name: Run tests - Ubuntu + Java 8
+
+on:
+  [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Maven install, test skipped
+        run: mvn install -DskipTests
+      - name: Maven test
+        run: mvn test

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 8.0.292
+          java-version: 8
       - name: Maven install, test skipped
         run: mvn install -DskipTests
       - name: Maven test

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 8.0.292

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -10,7 +10,8 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8.0.292
       - name: Maven install, test skipped
         run: mvn install -DskipTests
       - name: Maven test

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Mojito 
 ====
 
-[![Join the chat at https://gitter.im/box/mojito](https://badges.gitter.im/box/mojito.svg)](https://gitter.im/box/mojito?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Project Status](http://opensource.box.com/badges/active.svg)](http://opensource.box.com/badges)
-[![Build Status](https://travis-ci.org/box/mojito.svg?branch=master)](https://travis-ci.org/box/mojito/branches)
+> :warning: **This branch contains legacy Mojito code.**
+
+[![Project Status](http://opensource.box.com/badges/deprecated.svg)](http://opensource.box.com/badges)
 
 Mojito is a continuous localization platform. Rely on continuous integration to collect all of your software strings in one place. Check what products need localization in real time. Create and import translation packages with a single click. Search and edit translations across all products and languages! And if you have a small dedicated translation team, they can work directly in mojito.
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-cli</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <name>Mojito - CLI</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.110</version>
+        <version>0.110-legacy-1-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -26,26 +26,26 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-webapp</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-restclient</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -161,6 +161,7 @@
                 <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <useNativeGit>true</useNativeGit>
                 </configuration>
             </plugin>
         </plugins>

--- a/cli/src/main/java/com/box/l10n/mojito/cli/App.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/App.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.cli;
 
 import com.box.l10n.mojito.cli.command.L10nJCommander;
 import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,8 @@ public class App implements CommandLineRunner {
      * @param args
      */
     public static void main(String[] args) {
+        XmlParsingConfiguration.disableXPathLimits();
+
         SpringApplication app = new SpringApplication(App.class);
         app.setBannerMode(Banner.Mode.OFF);
         app.setWebEnvironment(false);

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
@@ -161,13 +161,13 @@ public class DropExportCommand extends Command {
         return bcp47tags;
     }
     
-    private boolean shouldCreateDrop(Repository repository) {
+    protected boolean shouldCreateDrop(Repository repository) {
         boolean createDrop = false;
-        Set<String> Bcp47TagsForTranslation = Sets.newHashSet(getBcp47TagsForExportFromRepository(repository));
+        Set<String> bcp47TagsForTranslation = Sets.newHashSet(getBcp47TagsForExportFromRepository(repository));
         RepositoryStatistic repoStat = repository.getRepositoryStatistic();
         if (repoStat != null) {
             for (RepositoryLocaleStatistic repoLocaleStat : repoStat.getRepositoryLocaleStatistics()) {
-                if (Bcp47TagsForTranslation.contains(repoLocaleStat.getLocale().getBcp47Tag()) && repoLocaleStat.getForTranslationCount() > 0L) {
+                if (bcp47TagsForTranslation.contains(repoLocaleStat.getLocale().getBcp47Tag()) && repoLocaleStat.getForTranslationCount() > 0L) {
                     createDrop = true;
                     break;
                 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PushCommand.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -83,23 +84,25 @@ public class PushCommand extends Command {
 
         ArrayList<FileMatch> sourceFileMatches = commandHelper.getSourceFileMatches(commandDirectories, fileType, sourceLocale, sourcePathFilterRegex);
 
-        Stream<SourceAsset> sourceAssetStream = sourceFileMatches.stream().map(sourceFileMatch -> {
-            String sourcePath = sourceFileMatch.getSourcePath();
+        Stream<SourceAsset> sourceAssetStream = sourceFileMatches.stream()
+                .sorted(Comparator.comparing(FileMatch::getSourcePath))
+                .map(sourceFileMatch -> {
+                    String sourcePath = sourceFileMatch.getSourcePath();
 
-            String assetContent = commandHelper.getFileContentWithXcodePatch(sourceFileMatch);
+                    String assetContent = commandHelper.getFileContentWithXcodePatch(sourceFileMatch);
 
-            SourceAsset sourceAsset = new SourceAsset();
-            sourceAsset.setBranch(branchName);
-            sourceAsset.setBranchCreatedByUsername(branchCreatedBy);
-            sourceAsset.setPath(sourcePath);
-            sourceAsset.setContent(assetContent);
-            sourceAsset.setExtractedContent(false);
-            sourceAsset.setRepositoryId(repository.getId());
-            sourceAsset.setFilterConfigIdOverride(sourceFileMatch.getFileType().getFilterConfigIdOverride());
-            sourceAsset.setFilterOptions(commandHelper.getFilterOptionsOrDefaults(sourceFileMatch.getFileType(), filterOptionsParam));
+                    SourceAsset sourceAsset = new SourceAsset();
+                    sourceAsset.setBranch(branchName);
+                    sourceAsset.setBranchCreatedByUsername(branchCreatedBy);
+                    sourceAsset.setPath(sourcePath);
+                    sourceAsset.setContent(assetContent);
+                    sourceAsset.setExtractedContent(false);
+                    sourceAsset.setRepositoryId(repository.getId());
+                    sourceAsset.setFilterConfigIdOverride(sourceFileMatch.getFileType().getFilterConfigIdOverride());
+                    sourceAsset.setFilterOptions(commandHelper.getFilterOptionsOrDefaults(sourceFileMatch.getFileType(), filterOptionsParam));
 
-            return sourceAsset;
-        });
+                    return sourceAsset;
+                });
 
         pushService.push(repository, sourceAssetStream, branchName, PushService.PushType.NORMAL);
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.cli;
 
 import com.box.l10n.mojito.cli.command.L10nJCommander;
+import com.box.l10n.mojito.cli.command.RepositoryStatusChecker;
 import com.box.l10n.mojito.entity.Locale;
 import com.box.l10n.mojito.entity.Repository;
 import com.box.l10n.mojito.entity.TMTextUnitVariant;
@@ -87,7 +88,9 @@ public class CLITestBase extends IOTestBase {
     ResttemplateConfig resttemplateConfig;
 
     @Autowired
-    RepositoryClient repositoryClient;
+    protected RepositoryClient repositoryClient;
+
+    RepositoryStatusChecker repositoryStatusChecker = new RepositoryStatusChecker();
 
     @Autowired
     AssetRepository assetRepository;
@@ -210,15 +213,7 @@ public class CLITestBase extends IOTestBase {
     protected void waitForRepositoryToHaveStringsForTranslations(Long repositoryId) throws InterruptedException {
         waitForCondition("wait for repository stats to show forTranslationCount > 0 before exporting a drop", () -> {
             com.box.l10n.mojito.rest.entity.Repository repository = repositoryClient.getRepositoryById(repositoryId);
-            RepositoryStatistic repositoryStat = repository.getRepositoryStatistic();
-            boolean forTranslation = false;
-            for (RepositoryLocaleStatistic repositoryLocaleStat : repositoryStat.getRepositoryLocaleStatistics()) {
-                if (repositoryLocaleStat.getForTranslationCount() > 0L) {
-                    forTranslation = true;
-                }
-                break;
-            }
-            return forTranslation;
+            return repositoryStatusChecker.hasStringsForTranslationsForExportableLocales(repository);
         });
     }
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/CLITestBase.java
@@ -18,6 +18,7 @@ import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
 import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import com.box.l10n.mojito.test.IOTestBase;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import com.google.common.io.Files;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -107,6 +108,8 @@ public class CLITestBase extends IOTestBase {
                 int serverPort = event.getEmbeddedServletContainer().getPort();
                 logger.debug("Saving port number = {}", serverPort);
                 resttemplateConfig.setPort(serverPort);
+
+                XmlParsingConfiguration.disableXPathLimits();
             }
         };
     }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/GitBlameCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/GitBlameCommandTest.java
@@ -13,6 +13,7 @@ import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
 import org.eclipse.jgit.blame.BlameResult;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +49,18 @@ public class GitBlameCommandTest extends CLITestBase {
      */
     boolean shallowClone = true;
 
+    /**
+     * GitActions has an even differnt type of checkout than Travis, just skip for now
+     */
+    boolean isGitActions() {
+        Boolean githubActions = Boolean.valueOf(System.getenv("GITHUB_ACTIONS"));
+        logger.info("Github actions: {}", githubActions);
+        return githubActions;
+    }
+
     @Test
     public void android() throws Exception {
+        Assume.assumeFalse(isGitActions());
 
         Repository repository = createTestRepoUsingRepoService();
         File sourceDirectory = getInputResourcesTestDir("source");
@@ -79,6 +90,8 @@ public class GitBlameCommandTest extends CLITestBase {
 
     @Test
     public void poFile() throws Exception {
+
+        Assume.assumeFalse(isGitActions());
 
         Repository repository = createTestRepoUsingRepoService();
         File sourceDirectory = getInputResourcesTestDir("source");
@@ -115,7 +128,7 @@ public class GitBlameCommandTest extends CLITestBase {
     public void textUnitNameToTextUnitNameInSourceDefault() {
         GitBlameCommand gitBlameCommand = new GitBlameCommand();
 
-        FileType fileType = new POFileType() ;
+        FileType fileType = new POFileType();
 
         assertEquals("test", gitBlameCommand.textUnitNameToTextUnitNameInSource("test", fileType, false));
         assertEquals("test", gitBlameCommand.textUnitNameToTextUnitNameInSource("test _zero", fileType, true));
@@ -155,8 +168,8 @@ public class GitBlameCommandTest extends CLITestBase {
 
         assertEquals("hello", gitBlameCommand.textUnitNameToTextUnitNameInSource("hello/message", fileType, false));
         assertEquals("hello/message_zero", gitBlameCommand.textUnitNameToTextUnitNameInSource("hello/message_zero", fileType, true));
-         try {
-             gitBlameCommand.textUnitNameToTextUnitNameInSource("hello_zero", fileType, false);
+        try {
+            gitBlameCommand.textUnitNameToTextUnitNameInSource("hello_zero", fileType, false);
             fail("should throw an exception if the regex doesn't match");
         } catch (IllegalArgumentException iae) {
             assertEquals("The pattern to extract the 'text unit name in source' must match. For text unit name: hello_zero", iae.getMessage());
@@ -221,10 +234,7 @@ public class GitBlameCommandTest extends CLITestBase {
     @Test
     public void getBlameResultForLines() throws Exception {
 
-        if (shallowClone) {
-            // that won't work on a shallow clone / on travis. Keep it for local testing
-            return;
-        }
+        Assume.assumeFalse(shallowClone);
 
         File sourceDirectory = getInputResourcesTestDir("source");
         String filepath = sourceDirectory.getAbsolutePath();
@@ -290,6 +300,7 @@ public class GitBlameCommandTest extends CLITestBase {
 
     @Test(expected = LineMissingException.class)
     public void updateGitBlameOutOfBousnd() throws CommandException, NoSuchFileException, LineMissingException {
+        Assume.assumeFalse(isGitActions());
         GitBlameCommand gitBlameCommand = new GitBlameCommand();
         gitBlameCommand.commandDirectories = new CommandDirectories(getBaseDir().getAbsolutePath());
         gitBlameCommand.initGitRepository();
@@ -312,6 +323,8 @@ public class GitBlameCommandTest extends CLITestBase {
 
     @Test(expected = ArrayIndexOutOfBoundsException.class)
     public void getSourceCommitsAccessOutOfBound() throws CommandException, NoSuchFileException {
+        Assume.assumeFalse(isGitActions());
+
         GitBlameCommand gitBlameCommand = new GitBlameCommand();
         gitBlameCommand.commandDirectories = new CommandDirectories(getBaseDir().getAbsolutePath());
         gitBlameCommand.initGitRepository();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepositoryStatusChecker.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepositoryStatusChecker.java
@@ -1,0 +1,14 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.rest.entity.Repository;
+
+/**
+ *
+ * @author garion
+ */
+public class RepositoryStatusChecker {
+    public boolean hasStringsForTranslationsForExportableLocales(Repository repository) {
+        DropExportCommand dropExportCommand = new DropExportCommand();
+        return dropExportCommand.shouldCreateDrop(repository);
+    }
+}

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-common</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <name>Mojito - Common</name>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.110</version>
+        <version>0.110-legacy-1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/common/src/main/java/com/box/l10n/mojito/xml/XmlParsingConfiguration.java
+++ b/common/src/main/java/com/box/l10n/mojito/xml/XmlParsingConfiguration.java
@@ -1,0 +1,19 @@
+package com.box.l10n.mojito.xml;
+
+/**
+ * Utility class to configure settings for XML and XPath operations.
+ *
+ * @author garion
+ */
+public class XmlParsingConfiguration {
+
+    /**
+     * Disables XML parsing limits introduced by JDK 8u331 in order to maintain backwards compatibility with
+     * Okapi dependencies. See: https://www.oracle.com/java/technologies/javase/8u331-relnotes.html
+     */
+    public static void disableXPathLimits() {
+        System.setProperty("jdk.xml.xpathExprGrpLimit", "0");
+        System.setProperty("jdk.xml.xpathTotalOpLimit", "0");
+        System.setProperty("jdk.xml.xpathExprOpLimit", "0");
+    }
+}

--- a/mavenplugin/pom.xml
+++ b/mavenplugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-maven-plugin</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <name>Mojito - Maven Plugin</name>
     <packaging>maven-plugin</packaging>
     
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.110</version>
+        <version>0.110-legacy-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.box.l10n.mojito</groupId>
     <artifactId>mojito-parent</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Mojito</name>
 

--- a/restclient/pom.xml
+++ b/restclient/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-restclient</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <name>Mojito - RestClient</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.110</version>
+        <version>0.110-legacy-1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
@@ -224,7 +224,7 @@ public class RepositoryClient extends BaseClient {
         }
 
         if (createdBefore != null) {
-            filterParams.put("createdBefore", createdBefore.toString());
+            filterParams.put("createdBefore", String.valueOf(createdBefore.getMillis()));
         }
 
         List<Branch> branches = authenticatedRestTemplate.getForObjectAsListWithQueryStringParams(

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-test-common</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <name>Mojito - Test common</name>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.110</version>
+        <version>0.110-legacy-1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/test-common/src/main/java/com/box/l10n/mojito/test/IOTestBase.java
+++ b/test-common/src/main/java/com/box/l10n/mojito/test/IOTestBase.java
@@ -249,7 +249,12 @@ public class IOTestBase {
                 // If that's a file, check that the both files have the same content
                 if (file2.isFile() && !Files.equal(file1, file2)) {
                     throw new DifferentDirectoryContentException("File: " + file1.toString() +
-                            " and file: " + file2.toString() + " have different content");
+                            " and file: " + file2.toString() + " have different content." +
+                            "\n\nfile1 content:\n\n" +
+                            FileUtils.readFileToString(file1, StandardCharsets.UTF_8) +
+                            "\n\nfile2 content:\n\n" +
+                            FileUtils.readFileToString(file2, StandardCharsets.UTF_8)
+                    );
                 }
             }
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -70,7 +70,7 @@
     "mojito-drop-export": "java -jar ../cli/target/mojito-cli-*.jar drop-export -r Mojito",
     "mojito-drop-import": "java -jar ../cli/target/mojito-cli-*.jar drop-import -r Mojito",
     "create-demo-data": "java -jar ../cli/target/mojito-cli-*.jar demo-create -n Demo",
-    "preinstall": "if type npx >/dev/null 2>&1; then npx npm-force-resolutions; fi"
+    "preinstall": "node/node_modules/npm/bin/npx-cli.js npm-force-resolutions"
   },
   "resolutions": {
     "kind-of": "^6.0.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -70,7 +70,7 @@
     "mojito-drop-export": "java -jar ../cli/target/mojito-cli-*.jar drop-export -r Mojito",
     "mojito-drop-import": "java -jar ../cli/target/mojito-cli-*.jar drop-import -r Mojito",
     "create-demo-data": "java -jar ../cli/target/mojito-cli-*.jar demo-create -n Demo",
-    "preinstall": "npx npm-force-resolutions"
+    "preinstall": "if type npx >/dev/null 2>&1; then npx npm-force-resolutions; fi"
   },
   "resolutions": {
     "kind-of": "^6.0.3",

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <start-class>com.box.l10n.mojito.Application</start-class>
-        <frontend.maven.plugin.version>1.10.0</frontend.maven.plugin.version>
+        <frontend.maven.plugin.version>1.14.0</frontend.maven.plugin.version>
         <node.version>v8.8.1</node.version>
         <npm.version>6.11.3</npm.version>
     </properties>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <start-class>com.box.l10n.mojito.Application</start-class>
-        <frontend.maven.plugin.version>1.8.0</frontend.maven.plugin.version>
+        <frontend.maven.plugin.version>1.10.0</frontend.maven.plugin.version>
         <node.version>v8.8.1</node.version>
         <npm.version>6.11.3</npm.version>
     </properties>
@@ -464,6 +464,18 @@
                                 <configuration>
                                     <nodeVersion>${node.version}</nodeVersion>
                                     <npmVersion>${npm.version}</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npx force resolutions</id>
+                                <goals>
+                                    <goal>npx</goal>
+                                </goals>
+
+                                <phase>generate-resources</phase>
+
+                                <configuration>
+                                    <arguments>npm-force-resolutions</arguments>
                                 </configuration>
                             </execution>
                             <execution>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -418,6 +418,7 @@
                 <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <useNativeGit>true</useNativeGit>
                 </configuration>
             </plugin>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-webapp</artifactId>
-    <version>0.110</version>
+    <version>0.110-legacy-1-SNAPSHOT</version>
     <name>Mojito - Webapp</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.110</version>
+        <version>0.110-legacy-1-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -210,20 +210,20 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-restclient</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.110</version>
+            <version>0.110-legacy-1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -467,18 +467,6 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>npx force resolutions</id>
-                                <goals>
-                                    <goal>npx</goal>
-                                </goals>
-
-                                <phase>generate-resources</phase>
-
-                                <configuration>
-                                    <arguments>npm-force-resolutions</arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>npm install</id>
                                 <goals>
                                     <goal>npm</goal>

--- a/webapp/src/main/java/com/box/l10n/mojito/Application.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/Application.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito;
 
 import com.box.l10n.mojito.entity.BaseEntity;
 import com.box.l10n.mojito.json.ObjectMapper;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -44,6 +45,8 @@ public class Application {
     boolean shouldIndentJacksonOutput;
 
     public static void main(String[] args) throws IOException {
+
+        XmlParsingConfiguration.disableXPathLimits();
 
         SpringApplication springApplication = new SpringApplication(Application.class);
         springApplication.addListeners(new ApplicationPidFileWriter("application.pid"));

--- a/webapp/src/test/java/com/box/l10n/mojito/rest/WSTestBase.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/rest/WSTestBase.java
@@ -8,6 +8,7 @@ import com.box.l10n.mojito.rest.client.exception.LocaleNotFoundException;
 import com.box.l10n.mojito.rest.entity.RepositoryLocale;
 import com.box.l10n.mojito.rest.resttemplate.AuthenticatedRestTemplate;
 import com.box.l10n.mojito.rest.resttemplate.ResttemplateConfig;
+import com.box.l10n.mojito.xml.XmlParsingConfiguration;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -80,6 +81,8 @@ public class WSTestBase {
                 int serverPort = event.getEmbeddedServletContainer().getPort();
                 logger.debug("Saving port number = {}", serverPort);
                 resttemplateConfig.setPort(serverPort);
+
+                XmlParsingConfiguration.disableXPathLimits();
             }
         };
     }


### PR DESCRIPTION
Prepare a branch for development off of legacy Mojito base (v0.110).

* added a legacy warning to readme
* updated version to `0.110-legacy-1-SNAPSHOT` (c6575b0), now it matches post-release commit from `maven-release-plugin` (like f639691) but also has an additional `-legacy` qualifier
* cherry-picked stuff to have a working CI through GitHub Actions with passing tests
	* GitHub actions config (4bb2308, 607fddb, 63257e2, ec05195)
	* fixes for npm issues (6c36e4f, 2f6c977) & bumped `frontend-maven-plugin` to latest (fbbf7c4) so that now it works when building on ARM Macs
	* fix for FEATURE_SECURE_PROCESSING Xpath limits (30d3793) & undid related GitHub Actions workaround (5fbd960)
	* fix for flaky tests caused by unstable asset order after CLI push (233d777, 089ac57)
	* fix for failing test caused by incorrect timezone serialization (26c2ef9)
	* modified fix for flaky test(s?) caused by `waitForRepositoryToHaveStringsForTranslations` checking for any locale instead of exportable locales (49b2c50, based on 514d5c2)