### PR TITLE
Add proxy support for Box client

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
@@ -1,10 +1,6 @@
 package com.box.l10n.mojito.boxsdk;
 
-import com.box.sdk.BoxAPIConnection;
-import com.box.sdk.BoxDeveloperEditionAPIConnection;
-import com.box.sdk.IAccessTokenCache;
-import com.box.sdk.InMemoryLRUAccessTokenCache;
-import com.box.sdk.JWTEncryptionPreferences;
+import com.box.sdk.*;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -63,11 +59,14 @@ public class BoxAPIConnectionProvider {
         BoxSDKServiceConfig boxSDKServiceConfig = boxSDKServiceConfigProvider.getConfig();
         JWTEncryptionPreferences encryptionPref = boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
 
-        BoxAPIConnection connection = BoxDeveloperEditionAPIConnection.getUserConnection(
-                boxSDKServiceConfig.getAppUserId(),
-                boxSDKServiceConfig.getClientId(),
-                boxSDKServiceConfig.getClientSecret(),
-                encryptionPref, getAccessTokenCache());
+        BoxDeveloperEditionAPIConnection connection = new BoxDeveloperEditionAPIConnection(
+            boxSDKServiceConfig.getAppUserId(),
+            DeveloperEditionEntityType.USER,
+            boxSDKServiceConfig.getClientId(),
+            boxSDKServiceConfig.getClientSecret(),
+            encryptionPref,
+            getAccessTokenCache()
+        );
 
         if (boxSDKServiceConfig.getProxyHost() != null && boxSDKServiceConfig.getProxyPort() != null) {
             logger.debug("Setting proxy for Box API connection");
@@ -78,6 +77,8 @@ public class BoxAPIConnectionProvider {
                 connection.setProxyBasicAuthentication(boxSDKServiceConfig.getProxyUser(), boxSDKServiceConfig.getProxyPassword());
             }
         }
+
+        connection.authenticate();
 
         return connection;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
@@ -55,25 +55,15 @@ public class BoxAPIConnectionProvider {
      */
     protected BoxAPIConnection createBoxAPIConnection() throws BoxSDKServiceException {
         logger.debug("Getting a new App User Connection using the current config");
-
-        BoxSDKServiceConfig boxSDKServiceConfig = boxSDKServiceConfigProvider.getConfig();
-        JWTEncryptionPreferences encryptionPref = boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
-
-        BoxDeveloperEditionAPIConnection connection = new BoxDeveloperEditionAPIConnection(
-            boxSDKServiceConfig.getAppUserId(),
-            DeveloperEditionEntityType.USER,
-            boxSDKServiceConfig.getClientId(),
-            boxSDKServiceConfig.getClientSecret(),
-            encryptionPref,
-            getAccessTokenCache()
-        );
+        BoxDeveloperEditionAPIConnection connection = createUserConnection();
 
         if (boxSDKServiceConfig.getProxyHost() != null && boxSDKServiceConfig.getProxyPort() != null) {
             logger.debug("Setting proxy for Box API connection");
             Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(boxSDKServiceConfig.getProxyHost(), boxSDKServiceConfig.getProxyPort()));
             connection.setProxy(proxy);
 
-            if (boxSDKServiceConfig.getProxyUser() != null) {
+            if (boxSDKServiceConfig.getProxyUser() != null && boxSDKServiceConfig.getProxyPassword() != null) {
+                logger.debug("Setting proxy basic auth for Box API connection");
                 connection.setProxyBasicAuthentication(boxSDKServiceConfig.getProxyUser(), boxSDKServiceConfig.getProxyPassword());
             }
         }
@@ -81,6 +71,19 @@ public class BoxAPIConnectionProvider {
         connection.authenticate();
 
         return connection;
+    }
+
+    protected BoxDeveloperEditionAPIConnection createUserConnection() throws BoxSDKServiceException {
+        JWTEncryptionPreferences encryptionPref = boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
+
+        return new BoxDeveloperEditionAPIConnection(
+            boxSDKServiceConfig.getAppUserId(),
+            DeveloperEditionEntityType.USER,
+            boxSDKServiceConfig.getClientId(),
+            boxSDKServiceConfig.getClientSecret(),
+            encryptionPref,
+            getAccessTokenCache()
+        );
     }
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfig.java
@@ -56,4 +56,24 @@ public interface BoxSDKServiceConfig {
      */
     String getDropsFolderId();
 
+    /**
+     * @return Host of an HTTP proxy to use when connecting to API
+     */
+    String getProxyHost();
+
+    /**
+     * @return Port of an HTTP proxy to use when connecting to API
+     */
+    Integer getProxyPort();
+
+    /**
+     * @return Username to use for an HTTP proxy that requires basic auth
+     */
+    String getProxyUser();
+
+    /**
+     * @return Password to use for an HTTP proxy that requires basic auth
+     */
+    String getProxyPassword();
+
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfigFromProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfigFromProperties.java
@@ -25,6 +25,10 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
     String privateKeyPassword;
     String enterpriseId;
     String appUserId;
+    String proxyHost;
+    Integer proxyPort;
+    String proxyUser;
+    String proxyPassword;
 
     /**
      * The folder ID of the Box root folder, for the active profile. It is
@@ -82,6 +86,22 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
         return dropsFolderId;
     }
 
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
     public void setClientId(String clientId) {
         this.clientId = clientId;
     }
@@ -118,6 +138,22 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
         this.dropsFolderId = dropsFolderId;
     }
 
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public void setProxyUser(String proxyUser) {
+        this.proxyUser = proxyUser;
+    }
+
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
+    }
+
     @Override
     public int hashCode() {
         int hash = 5;
@@ -131,6 +167,10 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
         hash = 41 * hash + Objects.hashCode(this.appUserId);
         hash = 41 * hash + Objects.hashCode(this.rootFolderId);
         hash = 41 * hash + Objects.hashCode(this.dropsFolderId);
+        hash = 41 * hash + Objects.hashCode(this.proxyHost);
+        hash = 41 * hash + Objects.hashCode(this.proxyPort);
+        hash = 41 * hash + Objects.hashCode(this.proxyUser);
+        hash = 41 * hash + Objects.hashCode(this.proxyPassword);
         return hash;
     }
 
@@ -174,6 +214,18 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
             return false;
         }
         if (!Objects.equals(this.dropsFolderId, other.dropsFolderId)) {
+            return false;
+        }
+        if (!Objects.equals(this.proxyHost, other.proxyHost)) {
+            return false;
+        }
+        if (!Objects.equals(this.proxyPort, other.proxyPort)) {
+            return false;
+        }
+        if (!Objects.equals(this.proxyUser, other.proxyUser)) {
+            return false;
+        }
+        if (!Objects.equals(this.proxyPassword, other.proxyPassword)) {
             return false;
         }
         return true;

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/BoxSDKServiceConfigEntity.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/BoxSDKServiceConfigEntity.java
@@ -135,6 +135,26 @@ public class BoxSDKServiceConfigEntity extends AuditableEntity implements BoxSDK
         return dropsFolderId;
     }
 
+    public String getProxyHost() {
+        /* TODO add proxy support */
+        return null;
+    }
+
+    public Integer getProxyPort() {
+        /* TODO add proxy support */
+        return null;
+    }
+
+    public String getProxyUser() {
+        /* TODO add proxy support */
+        return null;
+    }
+
+    public String getProxyPassword() {
+        /* TODO add proxy support */
+        return null;
+    }
+
     public void setDropsFolderId(String dropsFolderId) {
         this.dropsFolderId = dropsFolderId;
     }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
@@ -2,12 +2,7 @@ package com.box.l10n.mojito.service.boxsdk;
 
 import com.box.l10n.mojito.boxsdk.BoxSDKJWTProvider;
 import com.box.l10n.mojito.boxsdk.BoxSDKServiceException;
-import com.box.sdk.BoxAPIException;
-import com.box.sdk.BoxDeveloperEditionAPIConnection;
-import com.box.sdk.BoxUser;
-import com.box.sdk.CreateUserParams;
-import com.box.sdk.InMemoryLRUAccessTokenCache;
-import com.box.sdk.JWTEncryptionPreferences;
+import com.box.sdk.*;
 import com.ibm.icu.text.MessageFormat;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,12 +43,8 @@ public class BoxSDKAppUserService {
         try {
             logger.debug("Creating Box App User: {}", MOJITO_APP_USER_NAME);
             JWTEncryptionPreferences jwtEncryptionPreferences = boxSDKJWTProvider.getJWTEncryptionPreferences(publicKeyId, privateKey, privateKeyPassword);
-            BoxDeveloperEditionAPIConnection appEnterpriseConnection = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(
-                    enterpriseId,
-                    clientId,
-                    clientSecret,
-                    jwtEncryptionPreferences,
-                    new InMemoryLRUAccessTokenCache(5));
+            BoxDeveloperEditionAPIConnection appEnterpriseConnection = new BoxDeveloperEditionAPIConnection(enterpriseId,
+                    DeveloperEditionEntityType.ENTERPRISE, clientId, clientSecret, jwtEncryptionPreferences, new InMemoryLRUAccessTokenCache(5));
 
             if (proxyHost != null && proxyPort != null) {
                 logger.debug("Setting proxy for Box API connection");
@@ -64,6 +55,8 @@ public class BoxSDKAppUserService {
                     appEnterpriseConnection.setProxyBasicAuthentication(proxyUser, proxyPassword);
                 }
             }
+
+            appEnterpriseConnection.authenticate();
 
             CreateUserParams createUserParams = new CreateUserParams();
             createUserParams.setSpaceAmount(UNLIMITED_SPACE);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
@@ -12,6 +12,10 @@ import com.ibm.icu.text.MessageFormat;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -38,7 +42,8 @@ public class BoxSDKAppUserService {
      * @throws BoxSDKServiceException
      */
     public BoxUser.Info createAppUser(String clientId, String clientSecret, String publicKeyId,
-                String privateKey, String privateKeyPassword, String enterpriseId) throws BoxSDKServiceException {
+                String privateKey, String privateKeyPassword, String enterpriseId,
+              String proxyHost, Integer proxyPort, String proxyUser, String proxyPassword) throws BoxSDKServiceException {
 
         try {
             logger.debug("Creating Box App User: {}", MOJITO_APP_USER_NAME);
@@ -49,6 +54,16 @@ public class BoxSDKAppUserService {
                     clientSecret,
                     jwtEncryptionPreferences,
                     new InMemoryLRUAccessTokenCache(5));
+
+            if (proxyHost != null && proxyPort != null) {
+                logger.debug("Setting proxy for Box API connection");
+                Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+                appEnterpriseConnection.setProxy(proxy);
+
+                if (proxyUser != null) {
+                    appEnterpriseConnection.setProxyBasicAuthentication(proxyUser, proxyPassword);
+                }
+            }
 
             CreateUserParams createUserParams = new CreateUserParams();
             createUserParams.setSpaceAmount(UNLIMITED_SPACE);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKServiceConfigEntityService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKServiceConfigEntityService.java
@@ -93,7 +93,11 @@ public class BoxSDKServiceConfigEntityService {
                 boxSDKServiceConfig.getPublicKeyId(),
                 boxSDKServiceConfig.getPrivateKey(),
                 boxSDKServiceConfig.getPrivateKeyPassword(),
-                boxSDKServiceConfig.getEnterpriseId()
+                boxSDKServiceConfig.getEnterpriseId(),
+                boxSDKServiceConfig.getProxyHost(),
+                boxSDKServiceConfig.getProxyPort(),
+                boxSDKServiceConfig.getProxyUser(),
+                boxSDKServiceConfig.getProxyPassword()
         );
 
         boxSDKServiceConfig.setAppUserId(appUser.getID());

--- a/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.boxsdk;
 
 import com.box.sdk.BoxAPIConnection;
+import com.box.sdk.BoxDeveloperEditionAPIConnection;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,7 +70,43 @@ public class BoxAPIConnectionProviderTest {
         return config;
     }
 
+    public BoxSDKServiceConfig getTestConfigWithProxy() {
+        BoxSDKServiceConfig config = Mockito.spy(BoxSDKServiceConfigFromProperties.class);
+        Mockito.when(config.getClientId()).thenReturn("a");
+        Mockito.when(config.getClientSecret()).thenReturn("b");
+        Mockito.when(config.getPublicKeyId()).thenReturn("c");
+        Mockito.when(config.getPrivateKey()).thenReturn("d");
+        Mockito.when(config.getPrivateKeyPassword()).thenReturn("e");
+        Mockito.when(config.getEnterpriseId()).thenReturn("f");
+        Mockito.when(config.getAppUserId()).thenReturn("g");
+        Mockito.when(config.getRootFolderId()).thenReturn("h");
+        Mockito.when(config.getDropsFolderId()).thenReturn("i");
+        Mockito.when(config.getProxyHost()).thenReturn("j");
+        Mockito.when(config.getProxyPort()).thenReturn(11);
+        Mockito.when(config.getProxyUser()).thenReturn(null);
+        Mockito.when(config.getProxyPassword()).thenReturn(null);
 
+        return config;
+    }
+
+    public BoxSDKServiceConfig getTestConfigWithProxyBasicAuth() {
+        BoxSDKServiceConfig config = Mockito.spy(BoxSDKServiceConfigFromProperties.class);
+        Mockito.when(config.getClientId()).thenReturn("a");
+        Mockito.when(config.getClientSecret()).thenReturn("b");
+        Mockito.when(config.getPublicKeyId()).thenReturn("c");
+        Mockito.when(config.getPrivateKey()).thenReturn("d");
+        Mockito.when(config.getPrivateKeyPassword()).thenReturn("e");
+        Mockito.when(config.getEnterpriseId()).thenReturn("f");
+        Mockito.when(config.getAppUserId()).thenReturn("g");
+        Mockito.when(config.getRootFolderId()).thenReturn("h");
+        Mockito.when(config.getDropsFolderId()).thenReturn("i");
+        Mockito.when(config.getProxyHost()).thenReturn("j");
+        Mockito.when(config.getProxyPort()).thenReturn(11);
+        Mockito.when(config.getProxyUser()).thenReturn("l");
+        Mockito.when(config.getProxyPassword()).thenReturn("m");
+
+        return config;
+    }
 
     public BoxAPIConnectionProvider getBoxAPIConnectionProviderMock() throws BoxSDKServiceException {
         BoxAPIConnection boxAPIConnection = Mockito.mock(BoxAPIConnection.class);
@@ -144,6 +181,34 @@ public class BoxAPIConnectionProviderTest {
 
     }
 
-    // TODO testGetConnectionWillCreateProxiedConnection()
-    // TODO testGetConnectionWillCreateAuthenticatedProxiedConnection()
+    @Test
+    public void testGetConnectionWillCreateProxiedConnection() throws Exception {
+        BoxSDKServiceConfig config = getTestConfigWithProxy();
+        Mockito.when(boxSDKServiceConfigProvider.getConfig()).thenReturn(config);
+
+        BoxAPIConnection boxAPIConnectionMock = Mockito.mock(BoxDeveloperEditionAPIConnection.class);
+
+        BoxAPIConnectionProvider providerSpy = Mockito.spy(boxAPIConnectionProvider);
+        Mockito.doReturn(boxAPIConnectionMock).when(providerSpy).createUserConnection();
+
+        providerSpy.getConnection();
+
+        Mockito.verify(boxAPIConnectionMock, Mockito.times(1)).setProxy(Mockito.any());
+    }
+
+    @Test
+    public void testGetConnectionWillCreateAuthenticatedProxiedConnection() throws Exception {
+        BoxSDKServiceConfig config = getTestConfigWithProxyBasicAuth();
+        Mockito.when(boxSDKServiceConfigProvider.getConfig()).thenReturn(config);
+
+        BoxAPIConnection boxAPIConnectionMock = Mockito.mock(BoxDeveloperEditionAPIConnection.class);
+
+        BoxAPIConnectionProvider providerSpy = Mockito.spy(boxAPIConnectionProvider);
+        Mockito.doReturn(boxAPIConnectionMock).when(providerSpy).createUserConnection();
+
+        providerSpy.getConnection();
+
+        Mockito.verify(boxAPIConnectionMock, Mockito.times(1)).setProxy(Mockito.any());
+        Mockito.verify(boxAPIConnectionMock, Mockito.times(1)).setProxyBasicAuthentication(Mockito.anyString(), Mockito.anyString());
+    }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
@@ -42,6 +42,10 @@ public class BoxAPIConnectionProviderTest {
         Mockito.when(config.getAppUserId()).thenReturn("6");
         Mockito.when(config.getRootFolderId()).thenReturn("7");
         Mockito.when(config.getDropsFolderId()).thenReturn("8");
+        Mockito.when(config.getProxyHost()).thenReturn(null);
+        Mockito.when(config.getProxyPort()).thenReturn(null);
+        Mockito.when(config.getProxyUser()).thenReturn(null);
+        Mockito.when(config.getProxyPassword()).thenReturn(null);
 
         return config;
     }
@@ -57,6 +61,10 @@ public class BoxAPIConnectionProviderTest {
         Mockito.when(config.getAppUserId()).thenReturn("g");
         Mockito.when(config.getRootFolderId()).thenReturn("h");
         Mockito.when(config.getDropsFolderId()).thenReturn("i");
+        Mockito.when(config.getProxyHost()).thenReturn(null);
+        Mockito.when(config.getProxyPort()).thenReturn(null);
+        Mockito.when(config.getProxyUser()).thenReturn(null);
+        Mockito.when(config.getProxyPassword()).thenReturn(null);
 
         return config;
     }
@@ -135,4 +143,7 @@ public class BoxAPIConnectionProviderTest {
         Mockito.verify(providerSpy, Mockito.times(2)).createBoxAPIConnection();
 
     }
+
+    // TODO testGetConnectionWillCreateProxiedConnection()
+    // TODO testGetConnectionWillCreateAuthenticatedProxiedConnection()
 }


### PR DESCRIPTION
Added support for HTTP Proxy with Basic Authentication to Box Client.

It can only be used when configuring Box Client through properties like so:
```
l10n.dropExporter.type=BOX
l10n.boxclient.useConfigsFromProperties=true

l10n.boxclient.clientId=
l10n.boxclient.clientSecret=
l10n.boxclient.publicKeyId=
l10n.boxclient.privateKey=
l10n.boxclient.privateKeyPassword=
l10n.boxclient.enterpriseId=
l10n.boxclient.appUserId=

l10n.boxclient.rootFolderId=
l10n.boxclient.dropsFolderId=

l10n.boxclient.proxyHost=
l10n.boxclient.proxyPort=
l10n.boxclient.proxyUser=
l10n.boxclient.proxyPassword=
```

I didn't add support for configuring through browser UI because to fully implement that, it would be necessary to add new columns in `webapp/src/main/java/com/box/l10n/mojito/entity/BoxSDKServiceConfigEntity.java` - and we want to avoid modifying database schema in legacy.

## Test

Simiilar to #980

1. In [`webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceBoxTest.java:32`](https://github.com/box/mojito/tree/box-proxy/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceBoxTest.java#L32) comment out annotation `@Ignore`. Build with `./mvnw clean install -DskipTests=true`.

2. Create file `$HOME/.l10n/config/webapp/application-test.properties` and fill the following properties
```
l10n.boxclient.clientId=
l10n.boxclient.clientSecret=
l10n.boxclient.publicKeyId=
l10n.boxclient.privateKey=
l10n.boxclient.privateKeyPassword=
l10n.boxclient.enterpriseId=
l10n.boxclient.appUserId=

l10n.boxclient.rootFolderId=
l10n.boxclient.dropsFolderId=

l10n.boxclient.proxyHost=
l10n.boxclient.proxyPort=
l10n.boxclient.proxyUser=
l10n.boxclient.proxyPassword=
```
according to this doc https://www.mojito.global//docs/guides/integrating-with-box/.

3. Create drop folder structure on Box (`mojito` > `Project Requests` as per https://www.mojito.global//docs/guides/integrating-with-box/) and fill properties `rootFolderId` and `dropsFolderId` accordingly.

4. Set up a proxy for verification
```
brew install mitmproxy
mitmproxy --proxyauth='mojito:mojito' --allow-hosts='api.box.com|dl.boxcloud.com|public.boxcloud.com|api.box.com|upload.app.box.com|upload.box.com' --mode regular@8082
```

and fill properties
```
l10n.boxclient.proxyHost=127.0.0.1
l10n.boxclient.proxyPort=8082
l10n.boxclient.proxyUser=mojito
l10n.boxclient.proxyPassword=mojito
```

6. Run
```
./mvnw test -Dtest='DropServiceBoxTest' -DfailIfNoTests=false
```
and observe requests in mitmproxy
