### PR TITLE
Fix empty drop creation when empty trans-units are pending translation

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
@@ -168,7 +168,7 @@ public class DropExportCommand extends Command {
         RepositoryStatistic repoStat = repository.getRepositoryStatistic();
         if (repoStat != null) {
             for (RepositoryLocaleStatistic repoLocaleStat : repoStat.getRepositoryLocaleStatistics()) {
-                if (bcp47TagsForTranslation.contains(repoLocaleStat.getLocale().getBcp47Tag()) && repoLocaleStat.getForTranslationCount() > 0L) {
+                if (bcp47TagsForTranslation.contains(repoLocaleStat.getLocale().getBcp47Tag()) && repoLocaleStat.getForTranslationWordCount() > 0L) {
                     createDrop = true;
                     break;
                 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/DropExportCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/DropExportCommandTest.java
@@ -82,6 +82,27 @@ public class DropExportCommandTest extends CLITestBase {
     }
 
     @Test
+    public void exportZeroWords() throws Exception {
+
+        Repository repository = createTestRepoUsingRepoService();
+
+        getL10nJCommander().run("push", "-r", repository.getName(),
+                "-s", getInputResourcesTestDir("source").getAbsolutePath());
+
+        // there should be a single string for translation, but with 0 words in it
+        waitForRepositoryToHaveStringsForTranslations(repository.getId());
+
+        Page<Drop> findAllBefore = dropClient.getDrops(repository.getId(), null, null, null);
+
+        getL10nJCommander().run("drop-export", "-r", repository.getName());
+
+        Page<Drop> findAllAfter = dropClient.getDrops(repository.getId(), null, null, null);
+
+        // drop export command should not trigger an export when there are 0 words for translation
+        assertEquals("A Drop should not have been added", findAllBefore.getTotalElements(), findAllAfter.getTotalElements());
+    }
+
+    @Test
     public void exportSelectFullyTranslatedLocales() throws Exception {
 
         Repository repository = createTestRepoUsingRepoService();

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropExportCommandTest/exportZeroWords/input/source/source-xliff.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/DropExportCommandTest/exportZeroWords/input/source/source-xliff.xliff
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0">
+ <file original="" source-language="en" datatype="x-undefined">
+  <body>
+   <trans-unit id="" resname="100_character_description_" datatype="php">
+    <source/>
+   </trans-unit>
+  </body>
+ </file>
+</xliff>

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/RepositoryLocaleStatistic.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/RepositoryLocaleStatistic.java
@@ -9,6 +9,8 @@ public class RepositoryLocaleStatistic {
     private Locale locale;
     private Long forTranslationCount = 0L;
 
+    private Long forTranslationWordCount = 0L;
+
     public Locale getLocale() {
         return locale;
     }
@@ -23,6 +25,14 @@ public class RepositoryLocaleStatistic {
 
     public void setForTranslationCount(Long forTranslationCount) {
         this.forTranslationCount = forTranslationCount;
+    }
+
+    public Long getForTranslationWordCount() {
+        return forTranslationWordCount;
+    }
+
+    public void setForTranslationWordCount(Long forTranslationWordCount) {
+        this.forTranslationWordCount = forTranslationWordCount;
     }
 
 }


### PR DESCRIPTION
## Scenario

An empty trans-unit gets pushed to Mojito.
```xml
<trans-unit id="" resname="100_character_description_" datatype="php">
    <source/>
</trans-unit>
```
It shows up with _Needs Translation_ status but has 0 words.

A drop export is triggered for the repository where all other trans-units have already been translated.

Drop will still get created, because Mojito sees that some trans-unit still needs translation - however, this drop will be empty because a 0-word trans-unit is not included in the drop.

## Fix

Updated drop-export command to check if any *words* need translation, rather than trans-units.