### PR TITLE
Allow disabling server rotation health check and rotation toggle API

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/rest/rotation/HealthRotation.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/rotation/HealthRotation.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ import java.util.concurrent.TimeUnit;
  * @author jaurambault
  */
 @Component
+@ConditionalOnProperty("rotation.enabled")
 public class HealthRotation implements HealthIndicator {
 
     /**

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/rotation/RotationConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/rotation/RotationConfiguration.java
@@ -1,0 +1,25 @@
+package com.box.l10n.mojito.rest.rotation;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("rotation")
+public class RotationConfiguration {
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Enable support for server rotation.
+     * When enabled, server can be toggled in and out of rotation through an API endpoint {@link RotationWS#setRotation}.
+     * Putting server out of rotation will be reflected in its actuator health status {@link HealthRotation}.
+     */
+    boolean enabled = true;
+
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/rotation/RotationWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/rotation/RotationWS.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.rest.rotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author jaurambault
  */
 @RestController
+@ConditionalOnProperty("rotation.enabled")
 public class RotationWS {
 
     /**

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -47,6 +47,9 @@ spring.mail.host=localhost
 # Activate shutdown entry point. The security config make the entry point only accessible on 127.0.0.1
 endpoints.shutdown.enabled=true
 
+# Activate support for server rotation.
+rotation.enabled=true
+
 # ----------------------------------------
 # L10N PROPERTIES
 # ----------------------------------------


### PR DESCRIPTION
In a single-pod setup, server rotation is not useful. Having it be down by default requires an additional step of issuing an API request upon pod start just to make health check useable. In order not to change the default behaviour, this PR instead adds support to disable rotation support altogether (i.e. disable rotation health indicator and the toggle API endpoint).

Rotation support can be disabled through properties `rotation.enabled=false`.