### PR TITLE
Always show the asset path in the workbench

### DIFF
--- a/webapp/src/main/resources/properties/de.properties
+++ b/webapp/src/main/resources/properties/de.properties
@@ -216,6 +216,13 @@ search.result.empty=Es gibt keine Ergebnisse. Aktualisieren Sie Ihre Parametersu
 # Message displayed when the user has not selected repository and locales
 search.result.selectRepoAndLocale=Wählen Sie mindestens ein Speicher und Locale aus bevor Sie suchen können.
 
+search.viewMode.title=Ansichtsmodus: {mode}
+
+search.viewMode.FULL=Voll
+search.viewMode.REDUCED=Reduziert
+search.viewMode.STANDARD=Standard
+search.viewMode.COMPACT=Kompakt
+
 # Label used in the header loggedInUser dropdown to show user's profile
 header.loggedInUser.profile=Mein Profil
 
@@ -335,6 +342,9 @@ textUnit.saveVirtualAssetTextUnit.failed=Couldn't not set translate attribute, c
 
 # Confirmation message
 textUnit.cancel.confirmation=Sind Sie sicher, dass Sie die Bearbeitung abbrechen möchten? Sie werden ihre Änderungen verlieren.
+
+textUnit.tag.repo=repo
+textUnit.tag.asset=asset
 
 # Label displayed on the repositories dropdown in the workbench
 search.repository.btn.text={numberOfSelectedRepositories, plural, =0{Repositories} =1{1 repository} other{# repositories}}

--- a/webapp/src/main/resources/properties/en.properties
+++ b/webapp/src/main/resources/properties/en.properties
@@ -225,6 +225,13 @@ search.result.empty=There are no results. Update your search parameter to find w
 # Message displayed when the user has not selected repository and locales
 search.result.selectRepoAndLocale=Select at least one repository and locale before you can search.
 
+search.viewMode.title=View mode: {mode}
+
+search.viewMode.FULL=Full
+search.viewMode.REDUCED=Reduced
+search.viewMode.STANDARD=Standard
+search.viewMode.COMPACT=Compact
+
 # Label used in the header loggedInUser dropdown to show user's profile
 header.loggedInUser.profile=My Profile
 
@@ -361,6 +368,9 @@ textUnit.saveVirtualAssetTextUnit.failed=Couldn't not set translate attribute, c
 
 # Confirmation message
 textUnit.cancel.confirmation=Are you sure you want to cancel editing? You will lose the changes you've made.
+
+textUnit.tag.repo=repo
+textUnit.tag.asset=asset
 
 # Label displayed on the repositories dropdown in the workbench
 search.repository.btn.text={numberOfSelectedRepositories, plural, =0{Repositories} =1{1 repository} other{# repositories}}

--- a/webapp/src/main/resources/public/js/actions/workbench/ViewModeActions.js
+++ b/webapp/src/main/resources/public/js/actions/workbench/ViewModeActions.js
@@ -1,0 +1,12 @@
+import alt from "../../alt";
+
+class ViewModeActions {
+
+    constructor() {
+        this.generateActions(
+            "changeViewMode",
+        );
+    }
+}
+
+export default alt.createActions(ViewModeActions);

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.js
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.js
@@ -18,6 +18,10 @@ import TextUnitSelectorCheckBox from "./TextUnitSelectorCheckBox";
 import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 import ReviewTextUnitsDTO from "../../stores/workbench/ReviewTextUnitsDTO";
 import TextUnitSDK from "../../sdk/TextUnit";
+import AltContainer from "alt-container";
+import ViewModeStore from "../../stores/workbench/ViewModeStore";
+import ViewModeDropdown from "./ViewModeDropdown";
+import ViewModeActions from "../../actions/workbench/ViewModeActions";
 
 let SearchResults = createReactClass({
     displayName: 'SearchResults',
@@ -513,14 +517,16 @@ let SearchResults = createReactClass({
     createTextUnitComponent(textUnit, arrayIndex) {
 
         return (
-            <TextUnit key={this.getTextUnitComponentKey(textUnit)}
-                      textUnit={textUnit} textUnitIndex={arrayIndex}
-                      translation={textUnit.getTarget()}
-                      isActive={arrayIndex === this.state.activeTextUnitIndex}
-                      isSelected={this.isTextUnitSelected(textUnit)}
-                      onEditModeSetToTrue={this.onTextUnitEditModeSetToTrue}
-                      onEditModeSetToFalse={this.onTextUnitEditModeSetToFalse}
-            />
+            <AltContainer key={this.getTextUnitComponentKey(textUnit)} stores={{"viewMode": ViewModeStore}}>
+                <TextUnit
+                        textUnit={textUnit} textUnitIndex={arrayIndex}
+                        translation={textUnit.getTarget()}
+                        isActive={arrayIndex === this.state.activeTextUnitIndex}
+                        isSelected={this.isTextUnitSelected(textUnit)}
+                        onEditModeSetToTrue={this.onTextUnitEditModeSetToTrue}
+                        onEditModeSetToFalse={this.onTextUnitEditModeSetToFalse}
+                />
+            </AltContainer>
         );
     },
 
@@ -584,12 +590,16 @@ let SearchResults = createReactClass({
                                 </DropdownButton>
                             </ButtonToolbar>
                         </div>
-                        <div className="pull-right">
+                        <div className="pull-right" style={{display: "flex", alignItems: "center", "gap": "15px"}}>
+                            <AltContainer store={ViewModeStore}>
+                                <ViewModeDropdown onModeSelected={(mode) => ViewModeActions.changeViewMode(mode)}/>
+                            </AltContainer>
+
                             <TextUnitSelectorCheckBox numberOfSelectedTextUnits={numberOfSelectedTextUnits}/>
                             <Button bsSize="small" disabled={previousPageButtonDisabled}
                                     onClick={this.onFetchPreviousPageClicked}><span
                                 className="glyphicon glyphicon-chevron-left"></span></Button>
-                            <label className="mls mrs default-label current-pageNumber">
+                            <label className="default-label current-pageNumber">
                                 {this.displayCurrentPageNumber()}
                             </label>
                             <Button bsSize="small" disabled={nextPageButtonDisabled}

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnitSelectorCheckBox.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnitSelectorCheckBox.js
@@ -42,7 +42,7 @@ class TextUnitSelectorCheckBox extends React.Component {
 
     render() {
         return (
-            <DropdownButton id="Text" title={this.getTitle()} className="mrl" onSelect={this.selectionChanged}>
+            <DropdownButton id="Text" title={this.getTitle()} onSelect={this.selectionChanged}>
                 <MenuItem eventKey={this.SELECT_ALL_IN_PAGE}><FormattedMessage id="workbench.toolbar.selectAllInPage"/></MenuItem>
                 <MenuItem eventKey={this.CLEAR_ALL_IN_PAGE}><FormattedMessage
                     id="workbench.toolbar.clearAllInPage"/></MenuItem>

--- a/webapp/src/main/resources/public/js/components/workbench/ViewModeDropdown.js
+++ b/webapp/src/main/resources/public/js/components/workbench/ViewModeDropdown.js
@@ -1,0 +1,34 @@
+import _ from "lodash";
+import React from "react";
+import createReactClass from 'create-react-class';
+import {FormattedMessage, injectIntl} from 'react-intl';
+import {DropdownButton, MenuItem} from "react-bootstrap";
+
+import ViewModeStore from "../../stores/workbench/ViewModeStore";
+
+let ViewModeDropdown = createReactClass({
+    renderModeMenuItem(mode) {
+        return (
+            <MenuItem eventKey={mode} active={this.props.viewMode === mode} onSelect={this.props.onModeSelected}>
+                <FormattedMessage id={"search.viewMode." + mode} />
+            </MenuItem>
+        );
+    },
+
+    render() {
+        return (
+            <DropdownButton
+                id="WorkbenchStatusDropdown"
+                title={this.props.intl.formatMessage({id: "search.viewMode.title"}, {mode: this.props.intl.formatMessage({id: "search.viewMode." + this.props.viewMode})})}
+            >
+                {this.renderModeMenuItem(ViewModeStore.VIEW_MODE.FULL)}
+                {this.renderModeMenuItem(ViewModeStore.VIEW_MODE.REDUCED)}
+                {this.renderModeMenuItem(ViewModeStore.VIEW_MODE.STANDARD)}
+                {this.renderModeMenuItem(ViewModeStore.VIEW_MODE.COMPACT)}
+            </DropdownButton>
+        );
+    },
+});
+
+
+export default injectIntl(ViewModeDropdown);

--- a/webapp/src/main/resources/public/js/stores/workbench/TextUnitStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/TextUnitStore.js
@@ -110,6 +110,10 @@ class TextUnitStore {
      * @param {TextUnit} textUnit
      */
     resetErrorState(textUnit) {
+        if (!textUnit) {
+            this.errorsKeyedByTextUnitKey = [];
+            return;
+        }
         delete this.errorsKeyedByTextUnitKey[textUnit.getTextUnitKey()];
     }
 

--- a/webapp/src/main/resources/public/js/stores/workbench/ViewModeStore.js
+++ b/webapp/src/main/resources/public/js/stores/workbench/ViewModeStore.js
@@ -1,0 +1,28 @@
+import alt from "../../alt";
+import ViewModeActions from "../../actions/workbench/ViewModeActions";
+
+class ViewModeStore {
+    constructor() {
+        this.viewMode = window.localStorage.getItem("viewMode");
+        if (this.viewMode == null) {
+            this.viewMode = ViewModeStore.VIEW_MODE.STANDARD;
+            window.localStorage.setItem("viewMode", this.viewMode)
+        }
+
+        this.bindActions(ViewModeActions);
+    }
+
+    changeViewMode(viewMode) {
+        this.viewMode = viewMode;
+        window.localStorage.setItem("viewMode", this.viewMode)
+    }
+}
+
+ViewModeStore.VIEW_MODE = {
+    "FULL": "FULL",
+    "REDUCED": "REDUCED",
+    "STANDARD": "STANDARD",
+    "COMPACT": "COMPACT",
+}
+
+export default alt.createStore(ViewModeStore, 'ViewModeStore');

--- a/webapp/src/main/resources/sass/mojito.scss
+++ b/webapp/src/main/resources/sass/mojito.scss
@@ -420,7 +420,7 @@ div.textunit label {
 }
 
 .textunit-string {
-    width: 90%;
+    width: 100%;
     white-space: pre-wrap;
 }
 
@@ -462,13 +462,49 @@ div.textunit label {
     border: 1px dotted gray;
 }
 
-.textunit-actionbar {
-    position: absolute;
-    right: 0;
-}
-
 .textunit-comment {
     white-space: pre-wrap;
+}
+
+.text-unit-root {
+    display: grid;
+    align-items: center;
+    width: 100%;
+    gap: 15px;
+
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: min-content;
+}
+
+.text-unit-root .left {
+    flex-grow: 1;
+    height: 100%;
+    display: grid;
+    gap: 7px;
+    align-items: center;
+
+    grid-template-columns: min-content min-content min-content fit-content(100%) 1fr min-content min-content;
+    grid-template-rows: min-content 1fr min-content min-content 1fr;
+    grid-template-areas:
+        "cb locale  labels  name    .        res      repo"
+        "cb .       .       .       .        .        ."
+        "cb source  source  source  source   source   ."
+        "cb comment comment comment .        .        ."
+        "cb .       .       .       .        .        ."
+    ;
+}
+
+.text-unit-root .right {
+    flex-grow: 1;
+    display: grid;
+    align-items: center;
+    justify-items: stretch;
+
+    grid-template-columns: 1fr 33px min-content;
+    grid-template-rows: min-content;
+    grid-template-areas:
+        "target . review"
+    ;
 }
 
 div.textunit div.targetstring-container {


### PR DESCRIPTION
This moves the resource button next to the locale. Additionally, the resource path of a text is now always shown and not hidden behind a tooltip:

![tmp](https://github.com/box/mojito/assets/3407462/c92a3896-ae64-45f4-aa38-b4b2ceb2a9d9)