### PR TITLE
Restrict access to endpoints for some roles

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.AdviceMode;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configurers.ldap.LdapAuthenticationProviderConfigurer;
@@ -174,6 +175,22 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authenticated()
                 . // user management is only allowed for ADMINs and PMs
                 antMatchers("/api/users/**")
+                .hasAnyRole("PM", "ADMIN")
+                . // Read-only access is OK for users
+                antMatchers(HttpMethod.GET, "/api/textunits/**")
+                .authenticated()
+                . // Searching is also OK for users
+                antMatchers(HttpMethod.POST, "/api/textunits/search")
+                .authenticated()
+                . // USERs are not allowed to change translations
+                antMatchers("/api/textunits/**")
+                .hasAnyRole("TRANSLATOR", "PM", "ADMIN")
+                . // Read-only is OK for everyone
+                antMatchers(HttpMethod.GET, "/api/**")
+                .authenticated()
+                . // However, all other methods require is PM and ADMIN only unless overwritten
+                // above
+                antMatchers("/api/**")
                 .hasAnyRole("PM", "ADMIN")
                 . // local access only for rotation management and logger config
                 antMatchers("/**")

--- a/webapp/src/main/resources/public/js/components/branches/BranchesPage.js
+++ b/webapp/src/main/resources/public/js/components/branches/BranchesPage.js
@@ -24,6 +24,7 @@ import Paginator from "../widgets/Paginator";
 import RepositoryStore from "../../stores/RepositoryStore";
 import SearchParamsStore from "../../stores/workbench/SearchParamsStore";
 import SearchConstants from "../../utils/SearchConstants";
+import AuthorityService from "../../utils/AuthorityService";
 
 
 class BranchesPage extends React.Component {
@@ -233,6 +234,7 @@ class BranchesPage extends React.Component {
                         onDelete={() => {
                             BranchesScreenshotViewerActions.delete();
                         }}
+                        disableDelete={!AuthorityService.canEditScreenshots()}
                     />
                 </AltContainer>
 

--- a/webapp/src/main/resources/public/js/components/drops/Drops.js
+++ b/webapp/src/main/resources/public/js/components/drops/Drops.js
@@ -26,6 +26,7 @@ import ImportDropConfig from "../../sdk/drop/ImportDropConfig";
 import NewDropModal from "./NewDropModal";
 import RepositoryActions from "../../actions/RepositoryActions";
 import ConfirmationModal from "../widgets/ConfirmationModal";
+import AuthorityService from "../../utils/AuthorityService";
 
 let Drops = createReactClass({
     displayName: 'Drops',
@@ -276,7 +277,7 @@ let Drops = createReactClass({
 
         return (
             <tr key={`Drops.repositoryRow.${drop.name}.${drop.repository.name}`} className={rowClass}>
-                <td>{drop.name}{this.getButtonControlBar(drop)}</td>
+                <td>{drop.name}{AuthorityService.canEditProjectRequests() && this.getButtonControlBar(drop)}</td>
                 <td>{drop.repository.name}</td>
                 <td><FormattedNumber value={wordCount}/></td>
                 <td><FormattedDate value={drop.createdDate} day="numeric" month="long" year="numeric"/></td>
@@ -463,7 +464,7 @@ let Drops = createReactClass({
         return (
             <div className="pull-right mrm mlm">
                 <Button bsStyle="primary" bsSize="small" className="new-request-button"
-                        onClick={this.onClickNewRequest}>
+                        onClick={this.onClickNewRequest} disabled={!AuthorityService.canEditProjectRequests()}>
                     <FormattedMessage id="drops.newRequest.btn"/>
                 </Button>
             </div>

--- a/webapp/src/main/resources/public/js/components/screenshots/Screenshot.js
+++ b/webapp/src/main/resources/public/js/components/screenshots/Screenshot.js
@@ -9,7 +9,7 @@ import {StatusCommonTypes} from "./StatusCommon";
 
 
 class Screenshot extends React.Component {
-    
+
     static propTypes = {
         "screenshot": PropTypes.object.isRequired,
         "onClick": PropTypes.func.isRequired,
@@ -18,6 +18,7 @@ class Screenshot extends React.Component {
         "onNameClick": PropTypes.func.isRequired,
         "onStatusChanged": PropTypes.func.isRequired,
         "onStatusGlyphClick": PropTypes.func.isRequired,
+        "statusGlyphDisabled": PropTypes.bool.isRequired,
     }
 
     componentDidMount() {
@@ -66,14 +67,14 @@ class Screenshot extends React.Component {
     render() {
 
         let screenshotClassName = "screenshot";
-        
+
         if (this.props.isSelected) {
            screenshotClassName += " screenshot-selected";
         }
 
         return (
-                <div 
-                    ref="screenshot" 
+                <div
+                    ref="screenshot"
                     className={screenshotClassName}
                     onClick={this.props.onClick}
                     tabIndex={0}
@@ -83,20 +84,21 @@ class Screenshot extends React.Component {
                         <img src={this.props.screenshot.src} />
                     </div>
                     <div className="screenshot-description">
-                        <Label bsStyle='primary' 
-                               bsSize='large' 
+                        <Label bsStyle='primary'
+                               bsSize='large'
                                className="mrxs mtl clickable"
                                onClick={(e) => this.onLocaleClick(e)}>
                             {this.props.screenshot.locale.bcp47Tag}
-                        </Label> 
-                
+                        </Label>
+
                         <span onClick={(e) => this.onNameClick(e)} className="clickable">
                             {this.props.screenshot.name}
                         </span>
                     </div>
                     <span className="screenshot-glyph">
-                        <StatusGlyph status={this.props.screenshot.status} 
+                        <StatusGlyph status={this.props.screenshot.status}
                                      onClick={this.props.onStatusGlyphClick}
+                                     disabled={this.props.statusGlyphDisabled}
                                     />
                     </span >
                 </div>

--- a/webapp/src/main/resources/public/js/components/screenshots/ScreenshotViewerModal.js
+++ b/webapp/src/main/resources/public/js/components/screenshots/ScreenshotViewerModal.js
@@ -17,7 +17,8 @@ class ScreenshotViewerModal extends React.Component {
         "onGoToPrevious": PropTypes.func.isRequired,
         "onGoToNext": PropTypes.func.isRequired,
         "onDelete": PropTypes.func.isRequired,
-        "error": PropTypes.bool
+        "error": PropTypes.bool,
+        "disableDelete": PropTypes.bool.isRequired,
     }
 
     popover() {
@@ -96,7 +97,7 @@ class ScreenshotViewerModal extends React.Component {
                         <div className="branches-screenshotviewer-modal-delete-container">
                             {this.props.isDeleting ? <span className="glyphicon glyphicon-refresh spinning"/> :
                                 <OverlayTrigger trigger="click" placement="top" overlay={this.popover()}>
-                                    <Button bsStyle="danger" style={{fontSize: 11}}>
+                                    <Button bsStyle="danger" style={{fontSize: 11}} disabled={this.props.disableDelete}>
                                         <FormattedMessage id="label.delete"/>
                                     </Button>
                                 </OverlayTrigger>}

--- a/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsGrid.js
+++ b/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsGrid.js
@@ -8,7 +8,7 @@ import Screenshot from "./Screenshot";
 import ScreenshotsTextUnit from "./ScreenshotsTextUnit";
 
 class ScreenshotsGrid extends React.Component {
-    
+
     static propTypes = {
         "screenshotsData": PropTypes.array.isRequired,
         "selectedScreenshotIdx": PropTypes.number,
@@ -18,9 +18,10 @@ class ScreenshotsGrid extends React.Component {
         "onLocaleClick": PropTypes.func.isRequired,
         "onNameClick": PropTypes.func.isRequired,
         "onStatusGlyphClick": PropTypes.func.isRequired,
-        "onStatusChanged": PropTypes.func.isRequired
+        "onStatusChanged": PropTypes.func.isRequired,
+        "statusGlyphDisabled": PropTypes.bool.isRequired,
     }
-    
+
     getSelectedScreenshot() {
         let selectedScreenshot = null;
 
@@ -51,9 +52,9 @@ class ScreenshotsGrid extends React.Component {
 
                     let locale = this.getSelectedScreenshot().locale.bcp47Tag;
 
-                    return <ScreenshotsTextUnit 
+                    return <ScreenshotsTextUnit
                         key={textUnit.id}
-                        textUnit={textUnit} 
+                        textUnit={textUnit}
                         onNameClick={(e) => this.props.onScreenshotsTextUnitNameClick(e, textUnit, locale)}
                         onTargetClick={(e) => this.props.onScreenshotsTextUnitTargetClick(e, textUnit, locale)}
                         />
@@ -66,13 +67,14 @@ class ScreenshotsGrid extends React.Component {
         return this.props.screenshotsData.map((screenshot, idx) =>
             <Screenshot
                 key={screenshot.name + '_' + idx}
-                screenshot={screenshot} 
-                isSelected={idx === this.props.selectedScreenshotIdx} 
+                screenshot={screenshot}
+                isSelected={idx === this.props.selectedScreenshotIdx}
                 onClick={() => this.props.onScreenshotClicked(idx)}
                 onLocaleClick={ () => this.props.onLocaleClick([screenshot.locale.bcp47Tag])}
                 onNameClick={() => this.props.onNameClick(screenshot.name)}
                 onStatusGlyphClick={() => this.props.onStatusGlyphClick(idx)}
                 onStatusChanged={(status) => this.props.onStatusChanged({status: status, idx: idx})}
+                statusGlyphDisabled={this.props.statusGlyphDisabled}
                 />)
     }
 
@@ -92,16 +94,16 @@ class ScreenshotsGrid extends React.Component {
 
         return (
                 <div>
-                    <ReactSidebarResponsive 
-                        ref="sideBarScreenshot" 
+                    <ReactSidebarResponsive
+                        ref="sideBarScreenshot"
                         sidebar={this.renderSideBar()}
                         rootClassName="side-bar-root-container-screenshot"
                         sidebarClassName="side-bar-container-screenshot"
                         contentClassName="side-bar-main-content-container-screenshot"
                         docked={true} pullRight={true} transitions={false}>
-                
+
                         {this.renderScreenshots()}
-                
+
                     </ReactSidebarResponsive>
                 </div>);
     }
@@ -111,7 +113,7 @@ class ScreenshotsGrid extends React.Component {
      */
     render() {
         var res;
-        
+
         if (this.props.searching) {
             res = null;
         } else if (this.props.screenshotsData.length > 0) {
@@ -119,7 +121,7 @@ class ScreenshotsGrid extends React.Component {
         } else {
             res =this.renderNoResults();
         }
-        
+
         return res;
     }
 }

--- a/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsPage.js
+++ b/webapp/src/main/resources/public/js/components/screenshots/ScreenshotsPage.js
@@ -26,6 +26,7 @@ import StatusDropdown from "./StatusDropdown";
 import ScreenshotReviewModal from "./ScreenshotReviewModal";
 import ScreenshotsRepositoryActions from "../../actions/screenshots/ScreenshotsRepositoryActions";
 import ScreenshotsLocaleStore from "../../stores/screenshots/ScreenshotsLocaleStore";
+import AuthorityService from "../../utils/AuthorityService";
 
 class ScreenshotsPage extends React.Component {
 
@@ -281,9 +282,13 @@ class ScreenshotsPage extends React.Component {
                                                     ScreenshotsPageActions.performSearch();
                             }}
                             onStatusGlyphClick={(screenshotIdx) => {
+                                                        if (!AuthorityService.canEditScreenshots()) {
+                                                            return;
+                                                        }
                                                         ScreenshotsReviewModalActions.openWithScreenshot(screenshotIdx);
                             }}
                             onStatusChanged={ScreenshotActions.changeStatus}
+                            statusGlyphDisabled={!AuthorityService.canEditScreenshots()}
                             />
                     </AltContainer>
 

--- a/webapp/src/main/resources/public/js/components/screenshots/StatusGlyph.js
+++ b/webapp/src/main/resources/public/js/components/screenshots/StatusGlyph.js
@@ -37,10 +37,11 @@ class StatusGlyph extends React.Component {
      */
     render() {
         return (
-                <Glyphicon 
-                    glyph={this.getGlyph(this.props.status)} 
-                    title={StatusCommon.getScreenshotStatusIntl(this.props.intl, this.props.status)} 
+                <Glyphicon
+                    glyph={this.getGlyph(this.props.status)}
+                    title={StatusCommon.getScreenshotStatusIntl(this.props.intl, this.props.status)}
                     onClick={this.props.onClick}
+                    disabled={this.props.disabled}
                     className="btn"
                     />
                 );

--- a/webapp/src/main/resources/public/js/components/users/UserManagement.js
+++ b/webapp/src/main/resources/public/js/components/users/UserManagement.js
@@ -7,7 +7,7 @@ import AuthorityService from "../../utils/AuthorityService";
 
 class UserManagement extends React.Component {
     render() {
-        if (!AuthorityService.hasPermissionsForUserManagement()) {
+        if (!AuthorityService.canViewUserManagement()) {
             return (
                 <div className="ptl">
                     <h3 className="text-center mtl"><FormattedMessage id="users.forbidden"/></h3>

--- a/webapp/src/main/resources/public/js/components/workbench/SearchResults.js
+++ b/webapp/src/main/resources/public/js/components/workbench/SearchResults.js
@@ -22,6 +22,7 @@ import AltContainer from "alt-container";
 import ViewModeStore from "../../stores/workbench/ViewModeStore";
 import ViewModeDropdown from "./ViewModeDropdown";
 import ViewModeActions from "../../actions/workbench/ViewModeActions";
+import AuthorityService from "../../utils/AuthorityService";
 
 let SearchResults = createReactClass({
     displayName: 'SearchResults',
@@ -559,7 +560,8 @@ let SearchResults = createReactClass({
         let numberOfSelectedTextUnits = selectedTextUnits.length;
         let isAtLeastOneTextUnitSelected = numberOfSelectedTextUnits >= 1;
 
-        let actionButtonsDisabled = isSearching || !isAtLeastOneTextUnitSelected;
+        let selectorCheckBoxDisabled = !AuthorityService.canEditTranslations();
+        let actionButtonsDisabled = isSearching || !isAtLeastOneTextUnitSelected || !AuthorityService.canEditTranslations();
         let nextPageButtonDisabled = isSearching || noMoreResults;
         let previousPageButtonDisabled = isSearching || isFirstPage;
 
@@ -595,7 +597,7 @@ let SearchResults = createReactClass({
                                 <ViewModeDropdown onModeSelected={(mode) => ViewModeActions.changeViewMode(mode)}/>
                             </AltContainer>
 
-                            <TextUnitSelectorCheckBox numberOfSelectedTextUnits={numberOfSelectedTextUnits}/>
+                            <TextUnitSelectorCheckBox numberOfSelectedTextUnits={numberOfSelectedTextUnits} disabled={selectorCheckBoxDisabled}/>
                             <Button bsSize="small" disabled={previousPageButtonDisabled}
                                     onClick={this.onFetchPreviousPageClicked}><span
                                 className="glyphicon glyphicon-chevron-left"></span></Button>

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnit.js
@@ -18,6 +18,7 @@ import WorkbenchActions from "../../actions/workbench/WorkbenchActions";
 import GitBlameActions from "../../actions/workbench/GitBlameActions";
 import TranslationHistoryActions from "../../actions/workbench/TranslationHistoryActions";
 import Locales from "../../utils/Locales";
+import AuthorityService from "../../utils/AuthorityService";
 import {
     Grid,
     Row,
@@ -450,7 +451,7 @@ let TextUnit = createReactClass({
             }
             ui = (
                 <Glyphicon glyph={glyphType} id="reviewStringButton" title={glyphTitle} className="btn"
-                           onClick={this.onTextUnitGlyphClicked}/>
+                           onClick={this.onTextUnitGlyphClicked} disabled={!AuthorityService.canEditTranslations()}/>
             );
         }
 
@@ -520,6 +521,9 @@ let TextUnit = createReactClass({
     editStringClicked(e) {
         e.stopPropagation();
 
+        if (!AuthorityService.canEditTranslations()) {
+            return;
+        }
         this.setState({
             isEditMode: true
         }, () => {
@@ -535,7 +539,7 @@ let TextUnit = createReactClass({
      */
     getTargetStringUI() {
         let ui;
-        if (this.state.isEditMode) {
+        if (this.state.isEditMode && AuthorityService.canEditTranslations()) {
             ui = this.getUIForEditMode();
         } else {
             let targetString = this.hasTargetChanged() ? this.state.translation : this.props.translation;
@@ -544,7 +548,10 @@ let TextUnit = createReactClass({
             let trailingWhitespacesSymbol = "";
 
             let noTranslation = false;
-            let targetClassName = "pts pls pbs textunit-string textunit-target";
+            let targetClassName = "pts pls pbs textunit-string";
+            if (AuthorityService.canEditTranslations()) {
+                targetClassName += " textunit-target"
+            }
             if (targetString == null) {
                 noTranslation = true;
                 dir = Locales.getLanguageDirection(Locales.getCurrentLocale());
@@ -699,6 +706,10 @@ let TextUnit = createReactClass({
      * @param {SyntheticEvent} e
      */
     onTextUnitClick(e) {
+        if (!AuthorityService.canEditTranslations()) {
+            return;
+        }
+
         // NOTE: if text has been selected for this textunit, don't activate it because the user's intention is to
         // select text, not activate textunit.
         if (!window.getSelection().toString()) {
@@ -711,7 +722,7 @@ let TextUnit = createReactClass({
      */
     getTextUnitReviewModal() {
         let ui = "";
-        if (this.state.isShowModal) {
+        if (this.state.isShowModal && AuthorityService.canEditTranslations()) {
             let textUnitArray = [this.getCloneOfTextUnitFromProps()];
             ui = (
                 <TextUnitsReviewModal isShowModal={this.state.isShowModal}
@@ -1002,7 +1013,7 @@ let TextUnit = createReactClass({
                     <div className="text-unit-root">
                         <div className="left mls">
                             <span style={{gridArea: "cb"}} className="mrxs">
-                                <input type="checkbox" checked={isSelected} readOnly={true}/>
+                                <input type="checkbox" checked={isSelected} readOnly={true} disabled={!AuthorityService.canEditTranslations()}/>
                             </span>
                             <div style={{gridArea: "locale"}}>
                                 <Label bsStyle='primary' bsSize='large' className="clickable" onClick={this.onLocaleLabelClick}>

--- a/webapp/src/main/resources/public/js/components/workbench/TextUnitSelectorCheckBox.js
+++ b/webapp/src/main/resources/public/js/components/workbench/TextUnitSelectorCheckBox.js
@@ -42,7 +42,7 @@ class TextUnitSelectorCheckBox extends React.Component {
 
     render() {
         return (
-            <DropdownButton id="Text" title={this.getTitle()} onSelect={this.selectionChanged}>
+            <DropdownButton id="Text" title={this.getTitle()} onSelect={this.selectionChanged} disabled={this.props.disabled}>
                 <MenuItem eventKey={this.SELECT_ALL_IN_PAGE}><FormattedMessage id="workbench.toolbar.selectAllInPage"/></MenuItem>
                 <MenuItem eventKey={this.CLEAR_ALL_IN_PAGE}><FormattedMessage
                     id="workbench.toolbar.clearAllInPage"/></MenuItem>

--- a/webapp/src/main/resources/public/js/components/workbench/Workbench.js
+++ b/webapp/src/main/resources/public/js/components/workbench/Workbench.js
@@ -22,6 +22,7 @@ import ShareSearchParamsModalStore from "../../stores/workbench/ShareSearchParam
 import ShareSearchParamsModal from "./ShareSearchParamsModal";
 import ShareSearchParamsModalActions from "../../actions/workbench/ShareSearchParamsModalActions";
 import ShareSearchParamsButton from "./ShareSearchParamsButton";
+import AuthorityService from "../../utils/AuthorityService";
 
 let Workbench = createReactClass({
     displayName: 'Workbench',
@@ -62,6 +63,7 @@ let Workbench = createReactClass({
                         onDelete={() => {
                             GitBlameScreenshotViewerActions.delete();
                         }}
+                        disableDelete={!AuthorityService.canEditScreenshots()}
                     />
                 </AltContainer>
                 <AltContainer store={TranslationHistoryStore}>

--- a/webapp/src/main/resources/public/js/utils/AuthorityService.js
+++ b/webapp/src/main/resources/public/js/utils/AuthorityService.js
@@ -15,16 +15,33 @@ class AuthorityService {
         let level=[];
 
         switch (componentName) {
+            case "edit-screenshots":
+            case "project-requests":
             case "user-management":
                 level.push(admin, pm);
+                break;
+            case "edit-translations":
+                level.push(translator, admin, pm);
                 break;
         }
 
         return level;
     }
 
-    static hasPermissionsForUserManagement() {
+    static canViewUserManagement() {
         return this.userHasPermission("user-management");
+    }
+
+    static canEditProjectRequests() {
+        return this.userHasPermission("project-requests");
+    }
+
+    static canEditTranslations() {
+        return this.userHasPermission("edit-translations");
+    }
+
+    static canEditScreenshots() {
+        return this.userHasPermission("edit-screenshots");
     }
 }
 


### PR DESCRIPTION
Restrict access to endpoints for some roles:

- `USER`s can only view and not edit
- `TRANSLATOR`s can translate
- `ADMIN`s and `PM`s can use more management functions