### PR TITLE
Support unicode escape with \uXXXX format in Android strings

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/AndroidFilter.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/AndroidFilter.java
@@ -157,6 +157,7 @@ public class AndroidFilter extends XMLFilter {
     String unescapedSourceString;
 
     unescapedSourceString = sourceString.trim();
+    unescapedSourceString = unescapeUtils.replaceEscapedUnicode(unescapedSourceString);
 
     if (StringUtils.startsWith(unescapedSourceString, "\"")
         && StringUtils.endsWith(unescapedSourceString, "\"")) {

--- a/common/src/main/java/com/box/l10n/mojito/okapi/filters/UnescapeUtils.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/filters/UnescapeUtils.java
@@ -19,6 +19,7 @@ public class UnescapeUtils {
   private static final Pattern ESCAPED_QUOTES = Pattern.compile("\\\\(\"|')");
   private static final Pattern ESCAPED_BACKQUOTES = Pattern.compile("\\\\(`)");
   private static final Pattern ESCAPED_CHARACTERS = Pattern.compile("\\\\(.)?");
+  private static final Pattern ESCAPED_UNICODE = Pattern.compile("\\\\u([0-9a-fA-F]{4})");
   private static final Pattern SPACES = Pattern.compile("\\s+");
   private static final Pattern LINE_FEED = Pattern.compile("\n");
 
@@ -64,9 +65,24 @@ public class UnescapeUtils {
   }
 
   /**
+   * Replace unicode escape character of the form \\uXXXX.
+   *
+   * <p>Must be call before calling other method that would unescape the "u" letter like {@link
+   * #replaceEscapedCharacters(String)} (String)}
+   *
+   * @param text
+   * @return
+   */
+  String replaceEscapedUnicode(String text) {
+    return ESCAPED_UNICODE
+        .matcher(text)
+        .replaceAll(match -> new String(Character.toChars(Integer.parseInt(match.group(1), 16))));
+  }
+
+  /**
    * Replace other escape character with the character itself.
    *
-   * <p>Must be call after replacing espace sequence that need a different treatment like {@link
+   * <p>Must be call after replacing escape sequence that need a different treatment like {@link
    * #replaceEscapedLineFeed(String)}
    *
    * @param text

--- a/common/src/test/java/com/box/l10n/mojito/okapi/filters/AndroidFilterTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/okapi/filters/AndroidFilterTest.java
@@ -96,6 +96,10 @@ public class AndroidFilterTest {
 
     // multi lines and spaces
     testUnescaping("\n line1   \n   line2 \n", "line1 line2");
+
+    // unicode escape
+    var str = "Unicode\\u00A0escape";
+    testUnescaping("Unicode\\u00A0escape", "Unicode\u00A0escape");
   }
 
   void testUnescaping(String input, String expected) {


### PR DESCRIPTION
As per doc https://developer.android.com/guide/topics/resources/string-resource#FormattingAndStyling

Note on the output, whatever is used as input: \u00A0, &#x00a0;, &#160; or &#xa0; is output will be &#x00a0;