### PR TITLE
Add file type for VSCode Extension

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileTypes.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/FileTypes.java
@@ -25,6 +25,7 @@ public enum FileTypes {
   JSON_NOBASENAME(JSONNoBasenameFileType.class),
   CHROME_EXT_JSON(ChromeExtensionJSONFileType.class),
   FORMATJS_JSON_NOBASENAME(FormatJSJSONNoBasenameFileType.class),
+  VSCODE_EXTENSION_JSON(VSCodeFileType.class),
   I18NEXT_PARSER_JSON(I18NextFileType.class),
   TS(TSFileType.class),
   YAML(YamlFileType.class),

--- a/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/VSCodeFileType.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/filefinder/file/VSCodeFileType.java
@@ -1,0 +1,38 @@
+package com.box.l10n.mojito.cli.filefinder.file;
+
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.BASE_NAME;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.DOT;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
+
+import com.box.l10n.mojito.cli.filefinder.locale.AnyLocaleType;
+
+/**
+ * https://github.com/microsoft/vscode-extension-samples/tree/main/l10n-sample
+ *
+ * @author jaurambault
+ */
+public class VSCodeFileType extends JSONFileType {
+
+  public VSCodeFileType() {
+    this.baseNamePattern = "(package\\.nls|bundle\\.l10n)";
+    this.sourceFilePatternTemplate =
+        "{" + PARENT_PATH + "}{" + BASE_NAME + "}" + DOT + "{" + FILE_EXTENSION + "}";
+    this.targetFilePatternTemplate =
+        "{"
+            + PARENT_PATH
+            + "}{"
+            + BASE_NAME
+            + "}"
+            + DOT
+            + "{"
+            + LOCALE
+            + "}"
+            + DOT
+            + "{"
+            + FILE_EXTENSION
+            + "}";
+    this.localeType = new AnyLocaleType();
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest.java
@@ -907,6 +907,48 @@ public class ImportLocalizedAssetCommandTest extends CLITestBase {
   }
 
   @Test
+  public void importJsonVSCodeExtension() throws Exception {
+
+    Repository repository = createTestRepoUsingRepoService();
+
+    getL10nJCommander()
+        .run(
+            "push",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-ft",
+            "VSCODE_EXTENSION_JSON");
+
+    getL10nJCommander()
+        .run(
+            "import",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-t",
+            getInputResourcesTestDir("translations").getAbsolutePath(),
+            "-ft",
+            "VSCODE_EXTENSION_JSON");
+
+    getL10nJCommander()
+        .run(
+            "pull",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-t",
+            getTargetTestDir().getAbsolutePath(),
+            "-ft",
+            "VSCODE_EXTENSION_JSON");
+
+    checkExpectedGeneratedResources();
+  }
+
+  @Test
   public void importXcodeXliff() throws Exception {
 
     Repository repository = createTestRepoUsingRepoService();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/PullCommandTest.java
@@ -1820,6 +1820,57 @@ public class PullCommandTest extends CLITestBase {
   }
 
   @Test
+  public void pullJsonVSCodeExtension() throws Exception {
+
+    Repository repository = createTestRepoUsingRepoService();
+
+    getL10nJCommander()
+        .run(
+            "push",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-ft",
+            "VSCODE_EXTENSION_JSON");
+
+    Asset asset = assetClient.getAssetByPathAndRepositoryId("package.nls.json", repository.getId());
+    importTranslations(asset.getId(), "source-xliff_", "fr-FR");
+    importTranslations(asset.getId(), "source-xliff_", "ja-JP");
+
+    Asset asset2 =
+        assetClient.getAssetByPathAndRepositoryId("l10n/bundle.l10n.json", repository.getId());
+    importTranslations(asset2.getId(), "source-xliff_", "fr-FR");
+    importTranslations(asset2.getId(), "source-xliff_", "ja-JP");
+
+    getL10nJCommander()
+        .run(
+            "pull",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source").getAbsolutePath(),
+            "-t",
+            getTargetTestDir("target").getAbsolutePath(),
+            "-ft",
+            "VSCODE_EXTENSION_JSON");
+
+    getL10nJCommander()
+        .run(
+            "pull",
+            "-r",
+            repository.getName(),
+            "-s",
+            getInputResourcesTestDir("source_modified").getAbsolutePath(),
+            "-t",
+            getTargetTestDir("target_modified").getAbsolutePath(),
+            "-ft",
+            "VSCODE_EXTENSION_JSON");
+
+    checkExpectedGeneratedResources();
+  }
+
+  @Test
   public void pullFullyTranslated() throws Exception {
 
     Repository repository = createTestRepoUsingRepoService();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/filefinder/file/VSCodeFileTypeTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/filefinder/file/VSCodeFileTypeTest.java
@@ -1,0 +1,60 @@
+package com.box.l10n.mojito.cli.filefinder.file;
+
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.BASE_NAME;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.FILE_EXTENSION;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.LOCALE;
+import static com.box.l10n.mojito.cli.filefinder.FilePattern.PARENT_PATH;
+
+import com.box.l10n.mojito.cli.filefinder.FilePattern;
+import java.util.regex.Matcher;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VSCodeFileTypeTest {
+
+  @Test
+  public void testSourcePattern() {
+    VSCodeFileType vSCodeFileType = new VSCodeFileType();
+    FilePattern sourceFilePattern = vSCodeFileType.getSourceFilePattern();
+    Matcher matcher = sourceFilePattern.getPattern().matcher("/l10n/bundle.l10n.json");
+    Assert.assertTrue(matcher.matches());
+    Assert.assertEquals("/l10n/", matcher.group(PARENT_PATH));
+    Assert.assertEquals("bundle.l10n", matcher.group(BASE_NAME));
+    Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+  }
+
+  @Test
+  public void testSourcePatternPakcage() {
+    VSCodeFileType vSCodeFileType = new VSCodeFileType();
+    FilePattern sourceFilePattern = vSCodeFileType.getSourceFilePattern();
+    Matcher matcher = sourceFilePattern.getPattern().matcher("package.nls.json");
+    Assert.assertTrue(matcher.matches());
+    Assert.assertEquals("", matcher.group(PARENT_PATH));
+    Assert.assertEquals("package.nls", matcher.group(BASE_NAME));
+    Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+  }
+
+  @Test
+  public void testTargetPattern() {
+    VSCodeFileType vSCodeFileType = new VSCodeFileType();
+    Matcher matcher =
+        vSCodeFileType.getTargetFilePattern().getPattern().matcher("/l10n/bundle.l10n.fr.json");
+    Assert.assertTrue(matcher.matches());
+    Assert.assertEquals("fr", matcher.group(LOCALE));
+    Assert.assertEquals("/l10n/", matcher.group(PARENT_PATH));
+    Assert.assertEquals("bundle.l10n", matcher.group(BASE_NAME));
+    Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+  }
+
+  @Test
+  public void testTargetPatternBcp47() {
+    VSCodeFileType vSCodeFileType = new VSCodeFileType();
+    Matcher matcher =
+        vSCodeFileType.getTargetFilePattern().getPattern().matcher("/l10n/bundle.l10n.fr-FR.json");
+    Assert.assertTrue(matcher.matches());
+    Assert.assertEquals("fr-FR", matcher.group(LOCALE));
+    Assert.assertEquals("/l10n/", matcher.group(PARENT_PATH));
+    Assert.assertEquals("bundle.l10n", matcher.group(BASE_NAME));
+    Assert.assertEquals("json", matcher.group(FILE_EXTENSION));
+  }
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/l10n/bundle.l10n.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/l10n/bundle.l10n.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/l10n/bundle.l10n.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/l10n/bundle.l10n.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/l10n/bundle.l10n.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/l10n/bundle.l10n.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/package.nls.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/package.nls.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/package.nls.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/package.nls.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/package.nls.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/expected/package.nls.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/source/l10n/bundle.l10n.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/source/l10n/bundle.l10n.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100 character description:",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 day",
+  "1_hour_duration": "1 hour",
+  "1_month_duration": "1 month"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/source/package.nls.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/source/package.nls.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100 character description:",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 day",
+  "1_hour_duration": "1 hour",
+  "1_month_duration": "1 month"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/l10n/bundle.l10n.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/l10n/bundle.l10n.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/l10n/bundle.l10n.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/l10n/bundle.l10n.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/l10n/bundle.l10n.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/l10n/bundle.l10n.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/package.nls.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/package.nls.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/package.nls.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/package.nls.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/package.nls.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/ImportLocalizedAssetCommandTest_IO/importJsonVSCodeExtension/input/translations/package.nls.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/l10n/bundle.l10n.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/l10n/bundle.l10n.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/l10n/bundle.l10n.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/l10n/bundle.l10n.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/l10n/bundle.l10n.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/l10n/bundle.l10n.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/package.nls.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/package.nls.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/package.nls.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/package.nls.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/package.nls.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target/package.nls.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/l10n/bundle.l10n.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/l10n/bundle.l10n.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/l10n/bundle.l10n.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/l10n/bundle.l10n.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 jour",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/l10n/bundle.l10n.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/l10n/bundle.l10n.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_day_duration": "1日",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/package.nls.fr-CA.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/package.nls.fr-CA.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois",
+  "something_new": "Something new"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/package.nls.fr-FR.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/package.nls.fr-FR.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "Description de 100 caractères :",
+  "15_min_duration": "15 min",
+  "1_hour_duration": "1 heure",
+  "1_month_duration": "1 mois",
+  "something_new": "Something new"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/package.nls.ja-JP.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/expected/target_modified/package.nls.ja-JP.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100文字の説明:",
+  "15_min_duration": "15分",
+  "1_hour_duration": "1時間",
+  "1_month_duration": "1か月",
+  "something_new": "Something new"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source/l10n/bundle.l10n.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source/l10n/bundle.l10n.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100 character description:",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 day",
+  "1_hour_duration": "1 hour",
+  "1_month_duration": "1 month"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source/package.nls.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source/package.nls.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100 character description:",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 day",
+  "1_hour_duration": "1 hour",
+  "1_month_duration": "1 month"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source_modified/l10n/bundle.l10n.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source_modified/l10n/bundle.l10n.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100 character description:",
+  "15_min_duration": "15 min",
+  "1_day_duration": "1 day",
+  "1_hour_duration": "1 hour",
+  "1_month_duration": "1 month"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source_modified/package.nls.json
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/source_modified/package.nls.json
@@ -1,0 +1,7 @@
+{
+  "100_character_description_": "100 character description:",
+  "15_min_duration": "15 min",
+  "1_hour_duration": "1 hour",
+  "1_month_duration": "1 month",
+  "something_new": "Something new"
+}

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/translations/source-xliff_fr-FR.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/translations/source-xliff_fr-FR.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:okp="okapi-framework:xliff-extensions" version="1.2">
+    <file original=""  source-language="en" target-language="fr-FR" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_" datatype="php">
+                <source>100 character description:</source>
+                <target>Description de 100 caractères :</target>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15 min</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_day_duration" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1 jour</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1 heure</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1 mois</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/translations/source-xliff_ja-JP.xliff
+++ b/cli/src/test/resources/com/box/l10n/mojito/cli/command/PullCommandTest_IO/pullJsonVSCodeExtension/input/translations/source-xliff_ja-JP.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:okp="okapi-framework:xliff-extensions" version="1.2">
+    <file original=""  source-language="en" target-language="ja-JP" datatype="x-undefined">
+        <body>
+            <trans-unit id="" resname="100_character_description_" datatype="php">
+                <source>100 character description:</source>
+                <target>100文字の説明:</target>
+            </trans-unit>
+            <trans-unit id="" resname="15_min_duration" datatype="x-javascript+php">
+                <source>15 min</source>
+                <target>15分</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_day_duration" datatype="x-javascript+php">
+                <source>1 day</source>
+                <target>1日</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_hour_duration" datatype="x-javascript+php">
+                <source>1 hour</source>
+                <target>1時間</target>
+            </trans-unit>
+            <trans-unit id="" resname="1_month_duration" datatype="x-javascript+php">
+                <source>1 month</source>
+                <target>1か月</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
VSCode Extension uses JSON with simple map id to source string. The source files are package.nls.json and l10n/bundle.l10n.json.

Also see docs: https://github.com/microsoft/vscode-extension-samples/tree/main/l10n-sample