### PR TITLE
Fix Flyway mismatch workaround in legacy branch

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/FlyWayConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/FlyWayConfig.java
@@ -82,9 +82,9 @@ public class FlyWayConfig {
     void tryToMigrateIfMysql8Migration(Flyway flyway, FlywayException fe) {
         if (fe.getMessage()
                 .contains(
-                        "Migration checksum mismatch for migration version 1\n"
-                                + "-> Applied to database : 1443976515\n"
-                                + "-> Resolved locally    : -998267617")) {
+                        "Migration Checksum mismatch for migration 1\n"
+                                + "-> Applied to database : 147381909\n"
+                                + "-> Resolved locally    : -1294323746")) {
 
             logger.info("Flyway repair()");
             flyway.repair();


### PR DESCRIPTION
Workaround cherry-picked in https://github.com/box/mojito/pull/1034 is fragile because it relies on a specific error message. It turns out that this error message is different in legacy Mojito (probably due to older Spring Boot and Flyway). This PR adjusts the message content matched by workaround to make it work properly in legacy Mojito.

Actual error message that we got in logs is:
```log
caused by: org.flywaydb.core.api.flywayexception: validate failed. migration checksum mismatch for migration 1
-> applied to database : 147381909
-> resolved locally    : -1294323746
	at org.flywaydb.core.flyway.dovalidate(flyway.java:1108)
	at org.flywaydb.core.flyway.access$300(flyway.java:62)
	at org.flywaydb.core.flyway$1.execute(flyway.java:1012)
	at org.flywaydb.core.flyway$1.execute(flyway.java:1006)
	at org.flywaydb.core.flyway.execute(flyway.java:1418)
	at org.flywaydb.core.flyway.migrate(flyway.java:1006)
	at com.box.l10n.mojito.flywayconfig$1.migrate(flywayconfig.java:50)
	at org.springframework.boot.autoconfigure.flyway.flywaymigrationinitializer.afterpropertiesset(flywaymigrationinitializer.java:63)
	at org.springframework.beans.factory.support.abstractautowirecapablebeanfactory.invokeinitmethods(abstractautowirecapablebeanfactory.java:1637)
	at org.springframework.beans.factory.support.abstractautowirecapablebeanfactory.initializebean(abstractautowirecapablebeanfactory.java:1574)
	... 179 more
```