### PR TITLE
Initialize new branch to carry over patches from `legacy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Mojito 
 ====
 
+> :warning: **This branch holds experimental Mojito patches carried over from the [`legacy`](https://github.com/box/mojito/tree/legacy) branch.**
+
 [![Join the chat at https://gitter.im/box/mojito](https://badges.gitter.im/box/mojito.svg)](https://gitter.im/box/mojito?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Project Status](http://opensource.box.com/badges/active.svg)](http://opensource.box.com/badges)
 [![Build Status](https://travis-ci.org/box/mojito.svg?branch=master)](https://travis-ci.org/box/mojito/branches)

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,14 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-cli</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <name>Mojito - CLI</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.111-SNAPSHOT</version>
+        <version>0.111-patched-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -33,26 +33,26 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-webapp</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-restclient</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-common</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <name>Mojito - Common</name>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.111-SNAPSHOT</version>
+        <version>0.111-patched-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/mavenplugin/pom.xml
+++ b/mavenplugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-maven-plugin</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <name>Mojito - Maven Plugin</name>
     <packaging>maven-plugin</packaging>
     
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.111-SNAPSHOT</version>
+        <version>0.111-patched-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.box.l10n.mojito</groupId>
     <artifactId>mojito-parent</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Mojito</name>
 

--- a/restclient/pom.xml
+++ b/restclient/pom.xml
@@ -5,14 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-restclient</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <name>Mojito - RestClient</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.111-SNAPSHOT</version>
+        <version>0.111-patched-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-test-common</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <name>Mojito - Test common</name>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.111-SNAPSHOT</version>
+        <version>0.111-patched-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -5,14 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mojito-webapp</artifactId>
-    <version>0.111-SNAPSHOT</version>
+    <version>0.111-patched-SNAPSHOT</version>
     <name>Mojito - Webapp</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.box.l10n.mojito</groupId>
         <artifactId>mojito-parent</artifactId>
-        <version>0.111-SNAPSHOT</version>
+        <version>0.111-patched-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -257,20 +257,20 @@
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-restclient</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.box.l10n.mojito</groupId>
             <artifactId>mojito-test-common</artifactId>
-            <version>0.111-SNAPSHOT</version>
+            <version>0.111-patched-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This PR initializes a new Mojito branch to which patches from [`legacy`](https://github.com/box/mojito/tree/legacy) will be ported.

As these features are not well vetted for merging into actual upstream  [`master`](https://github.com/box/mojito/tree/master), they should be considered experimental.