### PR TITLE
Update Box SDK and add proxy support

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>com.box</groupId>
             <artifactId>box-java-sdk</artifactId>
-            <version>2.1.1</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
@@ -2,11 +2,7 @@ package com.box.l10n.mojito.boxsdk;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import com.box.sdk.BoxAPIConnection;
-import com.box.sdk.BoxDeveloperEditionAPIConnection;
-import com.box.sdk.IAccessTokenCache;
-import com.box.sdk.InMemoryLRUAccessTokenCache;
-import com.box.sdk.JWTEncryptionPreferences;
+import com.box.sdk.*;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Objects;
@@ -61,9 +57,10 @@ public class BoxAPIConnectionProvider {
     JWTEncryptionPreferences encryptionPref =
         boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
 
-    BoxAPIConnection connection =
-        BoxDeveloperEditionAPIConnection.getUserConnection(
+    BoxDeveloperEditionAPIConnection connection =
+        new BoxDeveloperEditionAPIConnection(
             boxSDKServiceConfig.getAppUserId(),
+            DeveloperEditionEntityType.USER,
             boxSDKServiceConfig.getClientId(),
             boxSDKServiceConfig.getClientSecret(),
             encryptionPref,
@@ -83,6 +80,8 @@ public class BoxAPIConnectionProvider {
             boxSDKServiceConfig.getProxyUser(), boxSDKServiceConfig.getProxyPassword());
       }
     }
+
+    connection.authenticate();
 
     return connection;
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
@@ -59,7 +59,7 @@ public class BoxAPIConnectionProvider {
     JWTEncryptionPreferences encryptionPref =
         boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
 
-    return BoxDeveloperEditionAPIConnection.getAppUserConnection(
+    return BoxDeveloperEditionAPIConnection.getUserConnection(
         boxSDKServiceConfig.getAppUserId(),
         boxSDKServiceConfig.getClientId(),
         boxSDKServiceConfig.getClientSecret(),

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
@@ -7,6 +7,8 @@ import com.box.sdk.BoxDeveloperEditionAPIConnection;
 import com.box.sdk.IAccessTokenCache;
 import com.box.sdk.InMemoryLRUAccessTokenCache;
 import com.box.sdk.JWTEncryptionPreferences;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,12 +61,30 @@ public class BoxAPIConnectionProvider {
     JWTEncryptionPreferences encryptionPref =
         boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
 
-    return BoxDeveloperEditionAPIConnection.getUserConnection(
-        boxSDKServiceConfig.getAppUserId(),
-        boxSDKServiceConfig.getClientId(),
-        boxSDKServiceConfig.getClientSecret(),
-        encryptionPref,
-        getAccessTokenCache());
+    BoxAPIConnection connection =
+        BoxDeveloperEditionAPIConnection.getUserConnection(
+            boxSDKServiceConfig.getAppUserId(),
+            boxSDKServiceConfig.getClientId(),
+            boxSDKServiceConfig.getClientSecret(),
+            encryptionPref,
+            getAccessTokenCache());
+
+    if (boxSDKServiceConfig.getProxyHost() != null && boxSDKServiceConfig.getProxyPort() != null) {
+      logger.debug("Setting proxy for Box API connection");
+      Proxy proxy =
+          new Proxy(
+              Proxy.Type.HTTP,
+              new InetSocketAddress(
+                  boxSDKServiceConfig.getProxyHost(), boxSDKServiceConfig.getProxyPort()));
+      connection.setProxy(proxy);
+
+      if (boxSDKServiceConfig.getProxyUser() != null) {
+        connection.setProxyBasicAuthentication(
+            boxSDKServiceConfig.getProxyUser(), boxSDKServiceConfig.getProxyPassword());
+      }
+    }
+
+    return connection;
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProvider.java
@@ -52,19 +52,7 @@ public class BoxAPIConnectionProvider {
    */
   protected BoxAPIConnection createBoxAPIConnection() throws BoxSDKServiceException {
     logger.debug("Getting a new App User Connection using the current config");
-
-    BoxSDKServiceConfig boxSDKServiceConfig = boxSDKServiceConfigProvider.getConfig();
-    JWTEncryptionPreferences encryptionPref =
-        boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
-
-    BoxDeveloperEditionAPIConnection connection =
-        new BoxDeveloperEditionAPIConnection(
-            boxSDKServiceConfig.getAppUserId(),
-            DeveloperEditionEntityType.USER,
-            boxSDKServiceConfig.getClientId(),
-            boxSDKServiceConfig.getClientSecret(),
-            encryptionPref,
-            getAccessTokenCache());
+    BoxDeveloperEditionAPIConnection connection = createUserConnection();
 
     if (boxSDKServiceConfig.getProxyHost() != null && boxSDKServiceConfig.getProxyPort() != null) {
       logger.debug("Setting proxy for Box API connection");
@@ -75,7 +63,9 @@ public class BoxAPIConnectionProvider {
                   boxSDKServiceConfig.getProxyHost(), boxSDKServiceConfig.getProxyPort()));
       connection.setProxy(proxy);
 
-      if (boxSDKServiceConfig.getProxyUser() != null) {
+      if (boxSDKServiceConfig.getProxyUser() != null
+          && boxSDKServiceConfig.getProxyPassword() != null) {
+        logger.debug("Setting proxy basic auth for Box API connection");
         connection.setProxyBasicAuthentication(
             boxSDKServiceConfig.getProxyUser(), boxSDKServiceConfig.getProxyPassword());
       }
@@ -84,6 +74,19 @@ public class BoxAPIConnectionProvider {
     connection.authenticate();
 
     return connection;
+  }
+
+  protected BoxDeveloperEditionAPIConnection createUserConnection() {
+    JWTEncryptionPreferences encryptionPref =
+        boxSDKJWTProvider.getJWTEncryptionPreferences(boxSDKServiceConfig);
+
+    return new BoxDeveloperEditionAPIConnection(
+        boxSDKServiceConfig.getAppUserId(),
+        DeveloperEditionEntityType.USER,
+        boxSDKServiceConfig.getClientId(),
+        boxSDKServiceConfig.getClientSecret(),
+        encryptionPref,
+        getAccessTokenCache());
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKService.java
@@ -7,6 +7,7 @@ import com.box.sdk.BoxFile;
 import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
 import com.box.sdk.BoxSharedLink;
+import com.box.sdk.sharedlink.BoxSharedLinkRequest;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.ByteArrayOutputStream;
@@ -82,7 +83,7 @@ public class BoxSDKService {
     BoxFolder createFolder = createFolder(folderName, parentId);
 
     try {
-      createFolder.createSharedLink(BoxSharedLink.Access.OPEN, null, null);
+      createFolder.createSharedLink(new BoxSharedLinkRequest().access(BoxSharedLink.Access.OPEN));
       return createFolder;
     } catch (BoxAPIException e) {
       throw new BoxSDKServiceException(
@@ -151,7 +152,7 @@ public class BoxSDKService {
         logger.debug("Uploaded new file, id: " + uploadFile.getID() + ", name: " + filename);
       } else {
         logger.debug("Upload a new version of file named: {} to folder: {}", filename, folderId);
-        uploadFile.uploadVersion(IOUtils.toInputStream(filecontent, StandardCharsets.UTF_8));
+        uploadFile.uploadNewVersion(IOUtils.toInputStream(filecontent, StandardCharsets.UTF_8));
 
         logger.debug(
             "Uploaded new version of file, id: " + uploadFile.getID() + ", name: " + filename);

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfig.java
@@ -54,4 +54,24 @@ public interface BoxSDKServiceConfig {
    * @return The folder ID to contain all the drops
    */
   String getDropsFolderId();
+
+  /**
+   * @return Host of an HTTP proxy to use when connecting to API
+   */
+  String getProxyHost();
+
+  /**
+   * @return Port of an HTTP proxy to use when connecting to API
+   */
+  Integer getProxyPort();
+
+  /**
+   * @return Username to use for an HTTP proxy that requires basic auth
+   */
+  String getProxyUser();
+
+  /**
+   * @return Password to use for an HTTP proxy that requires basic auth
+   */
+  String getProxyPassword();
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfigFromProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/boxsdk/BoxSDKServiceConfigFromProperties.java
@@ -26,6 +26,10 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
   String privateKeyPassword;
   String enterpriseId;
   String appUserId;
+  String proxyHost;
+  Integer proxyPort;
+  String proxyUser;
+  String proxyPassword;
 
   /**
    * The folder ID of the Box root folder, for the active profile. It is different from the "All The
@@ -82,6 +86,22 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
     return dropsFolderId;
   }
 
+  public String getProxyHost() {
+    return proxyHost;
+  }
+
+  public Integer getProxyPort() {
+    return proxyPort;
+  }
+
+  public String getProxyUser() {
+    return proxyUser;
+  }
+
+  public String getProxyPassword() {
+    return proxyPassword;
+  }
+
   public void setClientId(String clientId) {
     this.clientId = clientId;
   }
@@ -118,6 +138,22 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
     this.dropsFolderId = dropsFolderId;
   }
 
+  public void setProxyHost(String proxyHost) {
+    this.proxyHost = proxyHost;
+  }
+
+  public void setProxyPort(Integer proxyPort) {
+    this.proxyPort = proxyPort;
+  }
+
+  public void setProxyUser(String proxyUser) {
+    this.proxyUser = proxyUser;
+  }
+
+  public void setProxyPassword(String proxyPassword) {
+    this.proxyPassword = proxyPassword;
+  }
+
   @Override
   public int hashCode() {
     int hash = 5;
@@ -131,6 +167,10 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
     hash = 41 * hash + Objects.hashCode(this.appUserId);
     hash = 41 * hash + Objects.hashCode(this.rootFolderId);
     hash = 41 * hash + Objects.hashCode(this.dropsFolderId);
+    hash = 41 * hash + Objects.hashCode(this.proxyHost);
+    hash = 41 * hash + Objects.hashCode(this.proxyPort);
+    hash = 41 * hash + Objects.hashCode(this.proxyUser);
+    hash = 41 * hash + Objects.hashCode(this.proxyPassword);
     return hash;
   }
 
@@ -174,6 +214,18 @@ public class BoxSDKServiceConfigFromProperties implements BoxSDKServiceConfig {
       return false;
     }
     if (!Objects.equals(this.dropsFolderId, other.dropsFolderId)) {
+      return false;
+    }
+    if (!Objects.equals(this.proxyHost, other.proxyHost)) {
+      return false;
+    }
+    if (!Objects.equals(this.proxyPort, other.proxyPort)) {
+      return false;
+    }
+    if (!Objects.equals(this.proxyUser, other.proxyUser)) {
+      return false;
+    }
+    if (!Objects.equals(this.proxyPassword, other.proxyPassword)) {
       return false;
     }
     return true;

--- a/webapp/src/main/java/com/box/l10n/mojito/entity/BoxSDKServiceConfigEntity.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/BoxSDKServiceConfigEntity.java
@@ -149,6 +149,26 @@ public class BoxSDKServiceConfigEntity extends AuditableEntity implements BoxSDK
     this.dropsFolderId = dropsFolderId;
   }
 
+  public String getProxyHost() {
+    /* TODO add proxy support */
+    return null;
+  }
+
+  public Integer getProxyPort() {
+    /* TODO add proxy support */
+    return null;
+  }
+
+  public String getProxyUser() {
+    /* TODO add proxy support */
+    return null;
+  }
+
+  public String getProxyPassword() {
+    /* TODO add proxy support */
+    return null;
+  }
+
   public Boolean getBootstrap() {
     return bootstrap;
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
@@ -4,12 +4,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.l10n.mojito.boxsdk.BoxSDKJWTProvider;
 import com.box.l10n.mojito.boxsdk.BoxSDKServiceException;
-import com.box.sdk.BoxAPIException;
-import com.box.sdk.BoxDeveloperEditionAPIConnection;
-import com.box.sdk.BoxUser;
-import com.box.sdk.CreateUserParams;
-import com.box.sdk.InMemoryLRUAccessTokenCache;
-import com.box.sdk.JWTEncryptionPreferences;
+import com.box.sdk.*;
 import com.ibm.icu.text.MessageFormat;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -56,8 +51,9 @@ public class BoxSDKAppUserService {
           boxSDKJWTProvider.getJWTEncryptionPreferences(
               publicKeyId, privateKey, privateKeyPassword);
       BoxDeveloperEditionAPIConnection appEnterpriseConnection =
-          BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(
+          new BoxDeveloperEditionAPIConnection(
               enterpriseId,
+              DeveloperEditionEntityType.ENTERPRISE,
               clientId,
               clientSecret,
               jwtEncryptionPreferences,
@@ -72,6 +68,8 @@ public class BoxSDKAppUserService {
           appEnterpriseConnection.setProxyBasicAuthentication(proxyUser, proxyPassword);
         }
       }
+
+      appEnterpriseConnection.authenticate();
 
       CreateUserParams createUserParams = new CreateUserParams();
       createUserParams.setSpaceAmount(UNLIMITED_SPACE);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKAppUserService.java
@@ -11,6 +11,8 @@ import com.box.sdk.CreateUserParams;
 import com.box.sdk.InMemoryLRUAccessTokenCache;
 import com.box.sdk.JWTEncryptionPreferences;
 import com.ibm.icu.text.MessageFormat;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -41,7 +43,11 @@ public class BoxSDKAppUserService {
       String publicKeyId,
       String privateKey,
       String privateKeyPassword,
-      String enterpriseId)
+      String enterpriseId,
+      String proxyHost,
+      Integer proxyPort,
+      String proxyUser,
+      String proxyPassword)
       throws BoxSDKServiceException {
 
     try {
@@ -56,6 +62,16 @@ public class BoxSDKAppUserService {
               clientSecret,
               jwtEncryptionPreferences,
               new InMemoryLRUAccessTokenCache(5));
+
+      if (proxyHost != null && proxyPort != null) {
+        logger.debug("Setting proxy for Box API connection");
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+        appEnterpriseConnection.setProxy(proxy);
+
+        if (proxyUser != null) {
+          appEnterpriseConnection.setProxyBasicAuthentication(proxyUser, proxyPassword);
+        }
+      }
 
       CreateUserParams createUserParams = new CreateUserParams();
       createUserParams.setSpaceAmount(UNLIMITED_SPACE);

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKServiceConfigEntityService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKServiceConfigEntityService.java
@@ -108,7 +108,11 @@ public class BoxSDKServiceConfigEntityService {
             boxSDKServiceConfig.getPublicKeyId(),
             boxSDKServiceConfig.getPrivateKey(),
             boxSDKServiceConfig.getPrivateKeyPassword(),
-            boxSDKServiceConfig.getEnterpriseId());
+            boxSDKServiceConfig.getEnterpriseId(),
+            boxSDKServiceConfig.getProxyHost(),
+            boxSDKServiceConfig.getProxyPort(),
+            boxSDKServiceConfig.getProxyUser(),
+            boxSDKServiceConfig.getProxyPassword());
 
     boxSDKServiceConfig.setAppUserId(appUser.getID());
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKServiceConfigEntityService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/boxsdk/BoxSDKServiceConfigEntityService.java
@@ -17,6 +17,7 @@ import com.box.sdk.BoxAPIException;
 import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxSharedLink;
 import com.box.sdk.BoxUser;
+import com.box.sdk.sharedlink.BoxSharedLinkRequest;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -252,7 +253,8 @@ public class BoxSDKServiceConfigEntityService {
       BoxAPIConnection apiConnection = boxAPIConnectionProvider.getConnection();
       BoxFolder mojitoFolder = new BoxFolder(apiConnection, boxSDKServiceConfig.getRootFolderId());
       BoxSharedLink sharedLink =
-          mojitoFolder.createSharedLink(BoxSharedLink.Access.COLLABORATORS, null, null);
+          mojitoFolder.createSharedLink(
+              new BoxSharedLinkRequest().access(BoxSharedLink.Access.COLLABORATORS));
 
       boxSDKServiceConfig.setRootFolderUrl(sharedLink.getURL());
       boxSDKServiceConfig.setValidated(true);

--- a/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.boxsdk;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.box.sdk.BoxAPIConnection;
+import com.box.sdk.BoxDeveloperEditionAPIConnection;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,17 @@ public class BoxAPIConnectionProviderTest {
         .doReturn(boxAPIConnection2)
         .when(providerSpy)
         .createBoxAPIConnection();
+    return providerSpy;
+  }
+
+  public BoxAPIConnectionProvider createUserConnectionProviderMock() throws BoxSDKServiceException {
+    BoxAPIConnection boxAPIConnection = Mockito.mock(BoxAPIConnection.class);
+    BoxAPIConnection boxAPIConnection2 = Mockito.mock(BoxAPIConnection.class);
+    BoxAPIConnectionProvider providerSpy = Mockito.spy(boxAPIConnectionProvider);
+    Mockito.doReturn(boxAPIConnection)
+        .doReturn(boxAPIConnection2)
+        .when(providerSpy)
+        .createUserConnection();
     return providerSpy;
   }
 
@@ -104,6 +116,41 @@ public class BoxAPIConnectionProviderTest {
     Mockito.verify(providerSpy, Mockito.times(2)).createBoxAPIConnection();
   }
 
-  // TODO testGetConnectionWillCreateProxiedConnection()
-  // TODO testGetConnectionWillCreateAuthenticatedProxiedConnection()
+  @Test
+  public void testGetConnectionWillCreateProxiedConnection() throws Exception {
+    BoxSDKServiceConfig config = Mockito.mock(BoxSDKServiceConfigFromProperties.class);
+    Mockito.when(config.getProxyHost()).thenReturn("proxy-host");
+    Mockito.when(config.getProxyPort()).thenReturn(9999);
+    Mockito.when(boxSDKServiceConfigProvider.getConfig()).thenReturn(config);
+
+    BoxAPIConnection boxAPIConnectionMock = Mockito.mock(BoxDeveloperEditionAPIConnection.class);
+
+    BoxAPIConnectionProvider providerSpy = Mockito.spy(boxAPIConnectionProvider);
+    Mockito.doReturn(boxAPIConnectionMock).when(providerSpy).createUserConnection();
+
+    providerSpy.getConnection();
+
+    Mockito.verify(boxAPIConnectionMock, Mockito.times(1)).setProxy(Mockito.any());
+  }
+
+  @Test
+  public void testGetConnectionWillCreateAuthenticatedProxiedConnection() throws Exception {
+    BoxSDKServiceConfig config = Mockito.mock(BoxSDKServiceConfigFromProperties.class);
+    Mockito.when(config.getProxyHost()).thenReturn("proxy-host");
+    Mockito.when(config.getProxyPort()).thenReturn(9999);
+    Mockito.when(config.getProxyUser()).thenReturn("proxy-user");
+    Mockito.when(config.getProxyPassword()).thenReturn("proxy-password");
+    Mockito.when(boxSDKServiceConfigProvider.getConfig()).thenReturn(config);
+
+    BoxAPIConnection boxAPIConnectionMock = Mockito.mock(BoxDeveloperEditionAPIConnection.class);
+
+    BoxAPIConnectionProvider providerSpy = Mockito.spy(boxAPIConnectionProvider);
+    Mockito.doReturn(boxAPIConnectionMock).when(providerSpy).createUserConnection();
+
+    providerSpy.getConnection();
+
+    Mockito.verify(boxAPIConnectionMock, Mockito.times(1)).setProxy(Mockito.any());
+    Mockito.verify(boxAPIConnectionMock, Mockito.times(1))
+        .setProxyBasicAuthentication(Mockito.anyString(), Mockito.anyString());
+  }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/boxsdk/BoxAPIConnectionProviderTest.java
@@ -103,4 +103,7 @@ public class BoxAPIConnectionProviderTest {
         "Box API connection should only be created twice.  The first time getConnection was called and when config was changed.");
     Mockito.verify(providerSpy, Mockito.times(2)).createBoxAPIConnection();
   }
+
+  // TODO testGetConnectionWillCreateProxiedConnection()
+  // TODO testGetConnectionWillCreateAuthenticatedProxiedConnection()
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropFile.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropFile.java
@@ -1,0 +1,10 @@
+package com.box.l10n.mojito.service.drop;
+
+import com.box.l10n.mojito.boxsdk.BoxSDKServiceException;
+import java.io.IOException;
+
+public interface DropFile {
+  String getName();
+
+  String getContent() throws BoxSDKServiceException, IOException;
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceBoxTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceBoxTest.java
@@ -1,22 +1,22 @@
 package com.box.l10n.mojito.service.drop;
 
-import com.box.l10n.mojito.boxsdk.BoxFileWithContent;
+import static com.box.l10n.mojito.service.drop.exporter.DropExporterDirectories.*;
+import static org.junit.Assert.assertNotEquals;
+
 import com.box.l10n.mojito.boxsdk.BoxSDKService;
+import com.box.l10n.mojito.boxsdk.BoxSDKServiceConfigFromProperties;
 import com.box.l10n.mojito.boxsdk.BoxSDKServiceException;
 import com.box.l10n.mojito.entity.Drop;
-import com.box.l10n.mojito.okapi.XliffState;
 import com.box.l10n.mojito.service.drop.exporter.BoxDropExporter;
 import com.box.l10n.mojito.service.drop.exporter.BoxDropExporterConfig;
 import com.box.l10n.mojito.service.drop.exporter.DropExporterException;
-import com.box.l10n.mojito.test.XliffUtils;
 import com.box.l10n.mojito.test.category.BoxSDKTest;
 import com.box.l10n.mojito.test.category.SlowTest;
 import com.box.sdk.BoxFile;
 import java.util.List;
-import org.junit.Assume;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,138 +30,65 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"l10n.dropexporter.type=BOX"})
+@Category({BoxSDKTest.class, SlowTest.class})
 public class DropServiceBoxTest extends DropServiceTest {
 
   static Logger logger = LoggerFactory.getLogger(DropServiceBoxTest.class);
+
+  @Autowired BoxSDKServiceConfigFromProperties boxSDKServiceConfigFromProperties;
 
   @Autowired BoxSDKService boxSDKService;
 
   @Before
   public void checkBoxConfig() {
-    // TODO(P1) here we'll need to check if Box credential are available, if not don't run tests
-    Assume.assumeTrue(true);
-  }
-
-  @Test
-  @Category({BoxSDKTest.class, SlowTest.class})
-  @Override
-  public void testCreateDrop() throws Exception {
-    super.testCreateDrop();
-  }
-
-  @Test
-  @Category({BoxSDKTest.class, SlowTest.class})
-  @Override
-  public void forTranslation() throws Exception {
-    super.forTranslation();
-  }
-
-  @Test
-  @Category({BoxSDKTest.class, SlowTest.class})
-  @Override
-  public void forTranslationWithTranslationAddedAfterExport() throws Exception {
-    super.forTranslationWithTranslationAddedAfterExport();
-  }
-
-  @Test
-  @Category({BoxSDKTest.class, SlowTest.class})
-  @Override
-  public void forReview() throws Exception {
-    super.forTranslation();
-  }
-
-  @Test
-  @Category({BoxSDKTest.class, SlowTest.class})
-  @Override
-  public void allWithSevereError() throws Exception {
-    super.allWithSevereError();
+    assertNotEquals("", boxSDKServiceConfigFromProperties.getRootFolderId());
   }
 
   @Override
-  public void localizeDropFiles(Drop drop, int round)
+  public List<DropFile> getDropFiles(Drop drop, String dropFolder)
+      throws DropExporterException, BoxSDKServiceException {
+    return boxSDKService.listFiles(getDropFolderIdForName(drop, dropFolder)).stream()
+        .map(boxFile -> new BoxDropFile(boxFile, boxSDKService))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void writeDropFile(Drop drop, String dropFolder, String fileName, String content)
       throws BoxSDKServiceException, DropExporterException {
-
-    logger.debug("Localize files in a drop for testing");
-
-    BoxDropExporter boxDropExporter =
-        (BoxDropExporter) dropExporterService.recreateDropExporter(drop);
-    BoxDropExporterConfig boxDropExporterConfig = boxDropExporter.getBoxDropExporterConfig();
-
-    List<BoxFile> sourceFiles = boxSDKService.listFiles(boxDropExporterConfig.getSourceFolderId());
-
-    for (BoxFile sourceFile : sourceFiles) {
-      BoxFileWithContent fileContent = boxSDKService.getFileContent(sourceFile);
-      String localizedContent = fileContent.getContent();
-
-      if (sourceFile.getInfo().getName().startsWith("ko-KR")) {
-        logger.debug(
-            "For the Korean file, don't translate but add a corrupted text unit (invalid id) at the end");
-        localizedContent =
-            localizedContent.replaceAll(
-                "</body>",
-                "<trans-unit id=\"badid\" resname=\"TEST2\">\n"
-                    + "<source xml:lang=\"en\">Content2</source>\n"
-                    + "<target xml:lang=\"ko-kr\">Import Drop"
-                    + round
-                    + " -  Content2 ko-kr</target>\n"
-                    + "</trans-unit>\n"
-                    + "</body>");
-      } else if (sourceFile.getInfo().getName().startsWith("it-IT")) {
-        logger.debug("For the Italien file, don't translate but add a corrupted xml");
-        localizedContent = localizedContent.replaceAll("</body>", "</bod");
-      } else {
-        localizedContent = XliffUtils.localizeTarget(localizedContent, "Import Drop" + round);
-      }
-
-      boxSDKService.uploadFile(
-          boxDropExporterConfig.getLocalizedFolderId(),
-          sourceFile.getInfo().getName(),
-          localizedContent);
-    }
+    boxSDKService.uploadFile(getDropFolderIdForName(drop, dropFolder), fileName, content);
   }
 
-  @Override
-  public void reviewDropFiles(Drop drop) throws DropExporterException, BoxSDKServiceException {
-
-    logger.debug("Review files in a drop for testing");
-
+  public String getDropFolderIdForName(Drop drop, String dropFolderName)
+      throws DropExporterException {
     BoxDropExporter boxDropExporter =
         (BoxDropExporter) dropExporterService.recreateDropExporter(drop);
     BoxDropExporterConfig boxDropExporterConfig = boxDropExporter.getBoxDropExporterConfig();
 
-    List<BoxFile> sourceFiles = boxSDKService.listFiles(boxDropExporterConfig.getSourceFolderId());
+    return switch (dropFolderName) {
+      case DROP_FOLDER_SOURCE_FILES_NAME -> boxDropExporterConfig.getSourceFolderId();
+      case DROP_FOLDER_LOCALIZED_FILES_NAME -> boxDropExporterConfig.getLocalizedFolderId();
+      case DROP_FOLDER_IMPORTED_FILES_NAME -> boxDropExporterConfig.getImportedFolderId();
+      case DROP_FOLDER_QUERIES_NAME -> boxDropExporterConfig.getQueriesFolderId();
+      case DROP_FOLDER_QUOTES_NAME -> boxDropExporterConfig.getQuotesFolderId();
+      default -> null;
+    };
+  }
+}
 
-    for (BoxFile sourceFile : sourceFiles) {
-      BoxFileWithContent fileContent = boxSDKService.getFileContent(sourceFile);
-      String reviewedContent = fileContent.getContent();
+class BoxDropFile implements DropFile {
+  private final BoxFile boxFile;
+  private final BoxSDKService boxSDKService;
 
-      reviewedContent =
-          XliffUtils.replaceTargetState(reviewedContent, XliffState.SIGNED_OFF.toString());
-
-      boxSDKService.uploadFile(
-          boxDropExporterConfig.getLocalizedFolderId(),
-          sourceFile.getInfo().getName(),
-          reviewedContent);
-    }
+  BoxDropFile(BoxFile boxFile, BoxSDKService boxSDKService) {
+    this.boxFile = boxFile;
+    this.boxSDKService = boxSDKService;
   }
 
-  @Override
-  public void checkImportedFilesContent(Drop drop, int round)
-      throws BoxSDKServiceException, DropExporterException {
+  public String getName() {
+    return boxFile.getInfo().getName();
+  }
 
-    logger.debug("Check imported files contains text unit variant ids");
-
-    BoxDropExporter boxDropExporter =
-        (BoxDropExporter) dropExporterService.recreateDropExporter(drop);
-    BoxDropExporterConfig boxDropExporterConfig = boxDropExporter.getBoxDropExporterConfig();
-
-    List<BoxFile> importedFiles =
-        boxSDKService.listFiles(boxDropExporterConfig.getImportedFolderId());
-
-    for (BoxFile importedFile : importedFiles) {
-      BoxFileWithContent fileWithContent = boxSDKService.getFileContent(importedFile);
-      checkImportedFilesContent(
-          importedFile.getInfo().getName(), fileWithContent.getContent(), round);
-    }
+  public String getContent() throws BoxSDKServiceException {
+    return boxSDKService.getFileContent(boxFile).getContent();
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -1,8 +1,6 @@
 package com.box.l10n.mojito.service.drop;
 
-import static com.box.l10n.mojito.service.drop.exporter.DropExporterDirectories.DROP_FOLDER_IMPORTED_FILES_NAME;
-import static com.box.l10n.mojito.service.drop.exporter.DropExporterDirectories.DROP_FOLDER_LOCALIZED_FILES_NAME;
-import static com.box.l10n.mojito.service.drop.exporter.DropExporterDirectories.DROP_FOLDER_SOURCE_FILES_NAME;
+import static com.box.l10n.mojito.service.drop.exporter.DropExporterDirectories.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -48,12 +46,13 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -448,20 +447,22 @@ public class DropServiceTest extends ServiceTestBase {
     Drop drop = startExportProcess.get();
 
     // Make sure no French xliff was generated
+    assertFalse(
+        getDropFiles(drop, DROP_FOLDER_SOURCE_FILES_NAME).stream()
+            .anyMatch(dropFile -> dropFile.getName().equals("fr-FR.xliff")));
+  }
+
+  public List<DropFile> getDropFiles(Drop drop, String dropFolder)
+      throws DropExporterException, BoxSDKServiceException {
     FileSystemDropExporter fileSystemDropExporter =
         (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
     FileSystemDropExporterConfig fileSystemDropExporterConfig =
         fileSystemDropExporter.getFileSystemDropExporterConfig();
 
-    File frFR =
-        new File(
-            Paths.get(
-                    fileSystemDropExporterConfig.getDropFolderPath(),
-                    DROP_FOLDER_SOURCE_FILES_NAME,
-                    "fr-FR.xliff")
-                .toString());
-
-    assertFalse(frFR.exists());
+    File folder = Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), dropFolder).toFile();
+    File[] files = folder.listFiles();
+    assertNotNull(files);
+    return Arrays.stream(files).map(FileSystemDropFile::new).collect(Collectors.toList());
   }
 
   public void checkNumberOfUntranslatedTextUnit(
@@ -499,19 +500,8 @@ public class DropServiceTest extends ServiceTestBase {
 
     logger.debug("Localize files in a drop for testing");
 
-    FileSystemDropExporter fileSystemDropExporter =
-        (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
-    FileSystemDropExporterConfig fileSystemDropExporterConfig =
-        fileSystemDropExporter.getFileSystemDropExporterConfig();
-
-    File[] sourceFiles =
-        Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), DROP_FOLDER_SOURCE_FILES_NAME)
-            .toFile()
-            .listFiles();
-
-    for (File sourceFile : sourceFiles) {
-
-      String localizedContent = Files.toString(sourceFile, StandardCharsets.UTF_8);
+    for (DropFile sourceFile : getDropFiles(drop, DROP_FOLDER_SOURCE_FILES_NAME)) {
+      String localizedContent = sourceFile.getContent();
 
       if (sourceFile.getName().startsWith("ko-KR")) {
         logger.debug(
@@ -537,15 +527,19 @@ public class DropServiceTest extends ServiceTestBase {
 
       localizedContent = XliffUtils.replaceTargetState(localizedContent, xliffState);
 
-      // TODO(P1) this logic is being duplicated everywhere maybe it should go back into the config
-      // or service.
-      Path localizedFolderPath =
-          Paths.get(
-              fileSystemDropExporterConfig.getDropFolderPath(),
-              DROP_FOLDER_LOCALIZED_FILES_NAME,
-              sourceFile.getName());
-      Files.write(localizedContent, localizedFolderPath.toFile(), StandardCharsets.UTF_8);
+      writeDropFile(drop, DROP_FOLDER_LOCALIZED_FILES_NAME, sourceFile.getName(), localizedContent);
     }
+  }
+
+  public void writeDropFile(Drop drop, String dropFolder, String fileName, String content)
+      throws BoxSDKServiceException, IOException, DropExporterException {
+    FileSystemDropExporter fileSystemDropExporter =
+        (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
+    FileSystemDropExporterConfig fileSystemDropExporterConfig =
+        fileSystemDropExporter.getFileSystemDropExporterConfig();
+    File file =
+        Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), dropFolder, fileName).toFile();
+    Files.write(content, file, StandardCharsets.UTF_8);
   }
 
   public void reviewDropFiles(Drop drop)
@@ -553,30 +547,12 @@ public class DropServiceTest extends ServiceTestBase {
 
     logger.debug("Review files in a drop for testing");
 
-    FileSystemDropExporter fileSystemDropExporter =
-        (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
-    FileSystemDropExporterConfig fileSystemDropExporterConfig =
-        fileSystemDropExporter.getFileSystemDropExporterConfig();
-
-    File[] sourceFiles =
-        Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), DROP_FOLDER_SOURCE_FILES_NAME)
-            .toFile()
-            .listFiles();
-
-    for (File sourceFile : sourceFiles) {
-
-      String reviewedContent = Files.toString(sourceFile, StandardCharsets.UTF_8);
+    for (DropFile sourceFile : getDropFiles(drop, DROP_FOLDER_SOURCE_FILES_NAME)) {
+      String reviewedContent = sourceFile.getContent();
       reviewedContent =
           XliffUtils.replaceTargetState(reviewedContent, XliffState.SIGNED_OFF.toString());
 
-      // TODO(P1) this logic is being duplicated everywhere maybe it should go back into the config
-      // or service.
-      Path localizedFolderPath =
-          Paths.get(
-              fileSystemDropExporterConfig.getDropFolderPath(),
-              DROP_FOLDER_LOCALIZED_FILES_NAME,
-              sourceFile.getName());
-      Files.write(reviewedContent, localizedFolderPath.toFile(), StandardCharsets.UTF_8);
+      writeDropFile(drop, DROP_FOLDER_LOCALIZED_FILES_NAME, sourceFile.getName(), reviewedContent);
     }
   }
 
@@ -585,23 +561,13 @@ public class DropServiceTest extends ServiceTestBase {
 
     logger.debug("Check imported files contains text unit variant ids");
 
-    FileSystemDropExporter fileSystemDropExporter =
-        (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
-    FileSystemDropExporterConfig fileSystemDropExporterConfig =
-        fileSystemDropExporter.getFileSystemDropExporterConfig();
-
-    File[] importedFiles =
-        Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), DROP_FOLDER_IMPORTED_FILES_NAME)
-            .toFile()
-            .listFiles();
-
-    for (File importedFile : importedFiles) {
+    for (DropFile importedFile : getDropFiles(drop, DROP_FOLDER_IMPORTED_FILES_NAME)) {
 
       if (!importedFile.getName().endsWith("xliff")) {
         continue;
       }
 
-      String importedContent = Files.toString(importedFile, StandardCharsets.UTF_8);
+      String importedContent = importedFile.getContent();
       checkImportedFilesContent(importedFile.getName(), importedContent, round);
     }
   }
@@ -734,23 +700,13 @@ public class DropServiceTest extends ServiceTestBase {
       throws DropExporterException, BoxSDKServiceException, IOException {
     logger.debug("Check imported files contains text unit variant ids");
 
-    FileSystemDropExporter fileSystemDropExporter =
-        (FileSystemDropExporter) dropExporterService.recreateDropExporter(drop);
-    FileSystemDropExporterConfig fileSystemDropExporterConfig =
-        fileSystemDropExporter.getFileSystemDropExporterConfig();
-
-    File[] importedFiles =
-        Paths.get(fileSystemDropExporterConfig.getDropFolderPath(), DROP_FOLDER_IMPORTED_FILES_NAME)
-            .toFile()
-            .listFiles();
-
-    for (File importedFile : importedFiles) {
+    for (DropFile importedFile : getDropFiles(drop, DROP_FOLDER_IMPORTED_FILES_NAME)) {
 
       if (!importedFile.getName().endsWith("xliff")) {
         continue;
       }
 
-      String importedContent = Files.toString(importedFile, StandardCharsets.UTF_8);
+      String importedContent = importedFile.getContent();
 
       if (importedFile.getName().startsWith("fr-FR")) {
 
@@ -939,5 +895,21 @@ public class DropServiceTest extends ServiceTestBase {
 
     logger.debug("Wait for cancellation to finish");
     pollableTaskService.waitForPollableTask(cancelDropPollableTask.getId(), 600000L);
+  }
+}
+
+class FileSystemDropFile implements DropFile {
+  private final File file;
+
+  FileSystemDropFile(File file) {
+    this.file = file;
+  }
+
+  public String getName() {
+    return file.getName();
+  }
+
+  public String getContent() throws IOException {
+    return Files.toString(file, StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
This PR is a reimplementation of PRs #980 and #981 on top of upstream Mojito.

Updated `box-java-sdk` to version 4.6.0 and added support for proxying connection to Box API.