### PR TITLE
Allow configuring insecure access to K8s probes

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/security/ActuatorHealthConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/ActuatorHealthConfig.java
@@ -1,0 +1,24 @@
+package com.box.l10n.mojito.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures insecure access to Kubernetes probes.
+ *
+ * @author wadimw
+ */
+@Configuration
+@ConfigurationProperties("l10n.actuator.health")
+public class ActuatorHealthConfig {
+
+  boolean allowInsecureKubernetesProbes = false;
+
+  public boolean getAllowInsecureKubernetesProbes() {
+    return allowInsecureKubernetesProbes;
+  }
+
+  public void setAllowInsecureKubernetesProbes(boolean allowInsecureKubernetesProbes) {
+    this.allowInsecureKubernetesProbes = allowInsecureKubernetesProbes;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/security/WebSecurityConfig.java
@@ -58,6 +58,8 @@ public class WebSecurityConfig {
 
   @Autowired ActuatorHealthLegacyConfig actuatorHealthLegacyConfig;
 
+  @Autowired ActuatorHealthConfig actuatorHealthConfig;
+
   @Autowired UserDetailsContextMapperImpl userDetailsContextMapperImpl;
 
   @Autowired UserService userService;
@@ -217,8 +219,13 @@ public class WebSecurityConfig {
     http.csrf()
         .ignoringRequestMatchers("/actuator/shutdown", "/actuator/loggers/**", "/api/rotation");
 
-    setAuthorizationRequests(
-        http, getHealthcheckPatterns(actuatorHealthLegacyConfig.isForwarding()));
+    List<String> extraPermitAllPatterns =
+        new ArrayList<>(getHealthcheckPatterns(actuatorHealthLegacyConfig.isForwarding()));
+    if (actuatorHealthConfig.getAllowInsecureKubernetesProbes()) {
+      extraPermitAllPatterns.add("/actuator/health/liveness");
+      extraPermitAllPatterns.add("/actuator/health/readiness");
+    }
+    setAuthorizationRequests(http, extraPermitAllPatterns);
 
     logger.debug("For APIs, we don't redirect to login page. Instead we return a 401");
     http.exceptionHandling()


### PR DESCRIPTION
This PR adds the following configuration property

```properties
l10n.actuator.health.allowInsecureKubernetesProbes=true
```

which allows unauthenticated access to K8s Actuator endpoints `/actuator/health/liveness` and `/actuator/health/readiness`.

This behaviour is opt-in. It should be used along with other secure configurations, e.g.:
```properties
# expose actuator probes only for K8s
management.server.port=8081
management.endpoints.web.exposure.include=health
management.endpoint.health.show-details=never
# enable K8s probes
management.endpoint.health.probes.enabled=true
management.health.livenessState.enabled=true
management.health.readinessState.enabled=true
l10n.actuator.health.allowInsecureKubernetesProbes=true
# select health indicators
management.endpoint.health.group.readiness.include=readinessState,db,ldap
management.health.ldap.enabled=true
```