### PR TITLE
Fix NPE in conditional Flyway repairs

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/FlyWayConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/FlyWayConfig.java
@@ -46,10 +46,11 @@ public class FlyWayConfig {
           flyway.migrate();
           logger.info("Flyway migrate() finished");
         } catch (FlywayException fe) {
-          if (flyway.info().current().getVersion().getVersion().equals("63")) {
-            tryToMigrateIfMysql8Migration(flyway, fe);
-          } else {
-            tryToMigrateIfSpringMigration(flyway, fe);
+          logger.debug("Flyway migrate() failed", fe);
+          if (!(tryToMigrateIfSpringMigration(flyway, fe)
+              || tryToMigrateIfMysql8Migration(flyway, fe))) {
+            // known fixes failed, rethrow
+            throw fe;
           }
         }
       }
@@ -74,33 +75,38 @@ public class FlyWayConfig {
     }
   }
 
-  void tryToMigrateIfSpringMigration(Flyway flyway, FlywayException fe) {
-    if (fe.getMessage()
-        .contains(
-            "but no schema history table. Use baseline() or set baselineOnMigrate to true to initialize the schema history table")) {
-      logger.info(
-          "There is no schema history table, we assume were migrating from Spring 1.x to 2.x");
+  boolean tryToMigrateIfSpringMigration(Flyway flyway, FlywayException fe) {
+    boolean shouldApply =
+        fe.getMessage()
+            .contains(
+                "but no schema history table. Use baseline() or set baselineOnMigrate to true to initialize the schema history table");
 
-      String baselineVersion = getBaselineVersionFromOldFlywayTable();
-      logger.info("version: {}", baselineVersion);
-      if (baselineVersion == null) {
-        throw new RuntimeException(
-            "Can't read the version from the database, you must provide a Flyway baseline version to upgrade Mojito using spring.flyway.baseline-version");
-      }
-
-      flyway = rebuildFlywayInstanceWithBaselineFromOldTable(flyway, baselineVersion);
-
-      logger.info(
-          "Run baseline() with version: {}",
-          flyway.getConfiguration().getBaselineVersion().getVersion());
-      flyway.baseline();
-
-      logger.info("Try Flyway migrate() again");
-      flyway.migrate();
-      logger.info("Flyway migrate() finished");
-    } else {
-      throw fe;
+    if (!shouldApply) {
+      return false;
     }
+
+    logger.info(
+        "There is no schema history table, we assume were migrating from Spring 1.x to 2.x");
+
+    String baselineVersion = getBaselineVersionFromOldFlywayTable();
+    logger.info("version: {}", baselineVersion);
+    if (baselineVersion == null) {
+      throw new RuntimeException(
+          "Can't read the version from the database, you must provide a Flyway baseline version to upgrade Mojito using spring.flyway.baseline-version");
+    }
+
+    flyway = rebuildFlywayInstanceWithBaselineFromOldTable(flyway, baselineVersion);
+
+    logger.info(
+        "Run baseline() with version: {}",
+        flyway.getConfiguration().getBaselineVersion().getVersion());
+    flyway.baseline();
+
+    logger.info("Try Flyway migrate() again");
+    flyway.migrate();
+    logger.info("Flyway migrate() finished");
+
+    return true;
   }
 
   Flyway rebuildFlywayInstanceWithBaselineFromOldTable(Flyway flyway, String baselineVersion) {
@@ -134,19 +140,26 @@ public class FlyWayConfig {
    * @param flyway
    * @param fe
    */
-  void tryToMigrateIfMysql8Migration(Flyway flyway, FlywayException fe) {
-    if (fe.getMessage()
-        .contains(
-            "Migration checksum mismatch for migration version 1\n"
-                + "-> Applied to database : 1443976515\n"
-                + "-> Resolved locally    : -998267617")) {
+  boolean tryToMigrateIfMysql8Migration(Flyway flyway, FlywayException fe) {
+    boolean shouldApply =
+        fe.getMessage()
+                .contains(
+                    "Migration checksum mismatch for migration version 1\n"
+                        + "-> Applied to database : 1443976515\n"
+                        + "-> Resolved locally    : -998267617")
+            && flyway.info().current().getVersion().getVersion().equals("63");
 
-      logger.info("Flyway repair()");
-      flyway.repair();
-      logger.info("Flyway repair() finished");
-    } else {
-      throw fe;
+    if (!shouldApply) {
+      return false;
     }
+
+    logger.info("Repairing Flyway schema for MySQL8 migration");
+
+    logger.info("Flyway repair()");
+    flyway.repair();
+    logger.info("Flyway repair() finished");
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
Conditional check for `tryToMigrateIfMysql8Migration` throws NPE when run against a Spring Boot 1 database:

```log
Caused by: java.lang.NullPointerException: Cannot invoke "org.flywaydb.core.api.MigrationInfo.getVersion()" because the return value of "org.flywaydb.core.api.MigrationInfoService.current()" is null
	at com.box.l10n.mojito.FlyWayConfig.lambda$0(FlyWayConfig.java:50)
	at org.springframework.boot.autoconfigure.flyway.FlywayMigrationInitializer.afterPropertiesSet(FlywayMigrationInitializer.java:62)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1815)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1764)
	... 16 common frames omitted
```

even though the first thrown `FlywayException` should actually be handled by `tryToMigrateIfSpringMigration`:

```log
org.flywaydb.core.api.FlywayException: Found non-empty schema(s) `mojito` but no schema history table. Use baseline() or set baselineOnMigrate to true to initialize the schema history table.
	at org.flywaydb.core.Flyway.lambda$migrate$0(Flyway.java:178)
	at org.flywaydb.core.FlywayExecutor.execute(FlywayExecutor.java:196)
	at org.flywaydb.core.Flyway.migrate(Flyway.java:140)
	at com.box.l10n.mojito.FlyWayConfig.lambda$0(FlyWayConfig.java:46)
	at org.springframework.boot.autoconfigure.flyway.FlywayMigrationInitializer.afterPropertiesSet(FlywayMigrationInitializer.java:62)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1815)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1764)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:596)
```

This commit:
* changes order of migration attempts (SpringMigration first)
* changes conditional MySQL8 migration to first check exception text, then attempt to retrieve schema version