### PR TITLE
Fix paginated Drop data fetching

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/entity/Drop.java
@@ -36,7 +36,8 @@ import org.springframework.data.annotation.CreatedBy;
       @NamedAttributeNode(value = "repository", subgraph = "Drop.legacy.repository"),
       @NamedAttributeNode(value = "importPollableTask", subgraph = "Drop.legacy.subTask"),
       @NamedAttributeNode(value = "exportPollableTask", subgraph = "Drop.legacy.subTask"),
-      @NamedAttributeNode(value = "translationKits", subgraph = "Drop.legacy.translationKits")
+      @NamedAttributeNode(value = "translationKits", subgraph = "Drop.legacy.translationKits"),
+      @NamedAttributeNode(value = "createdByUser")
     },
     subgraphs = {
       @NamedSubgraph(

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java
@@ -77,7 +77,7 @@ public class DropWS {
       throws Exception {
 
     Page<Drop> findAll =
-        dropRepository.findAll(
+        dropService.findAll(
             where(ifParamNotNull(repositoryIdEquals(repositoryId)))
                 .and(ifParamNotNull(isImported(importedFilter)))
                 .and(ifParamNotNull(isCanceled(canceledFilter))),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropRepository.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropRepository.java
@@ -17,8 +17,12 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource(exported = false)
 public interface DropRepository extends JpaRepository<Drop, Long>, JpaSpecificationExecutor<Drop> {
 
+  // Note: Cannot use an EntityGraph with pagination as it triggers the following warning:
+  // HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory
+  // @EntityGraph(value = "Drop.legacy", type = EntityGraphType.FETCH)
+  //
+  // See {@link com.box.l10n.mojito.service.drop.DropService#findAll()} for manual initialization
   @Override
-  @EntityGraph(value = "Drop.legacy", type = EntityGraphType.FETCH)
   Page<Drop> findAll(Specification<Drop> spec, Pageable pageable);
 
   @Override

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -34,9 +34,13 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import net.sf.okapi.common.exceptions.OkapiBadFilterInputException;
 import net.sf.okapi.common.exceptions.OkapiIOException;
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -494,5 +498,37 @@ public class DropService {
   public void completeDrop(Drop drop) {
     drop.setPartiallyImported(Boolean.FALSE);
     dropRepository.save(drop);
+  }
+
+  /**
+   * Cannot use an EntityGraph with pagination as it triggers the following warning: HHH90003004:
+   * firstResult/maxResults specified with collection fetch; applying in memory
+   *
+   * @param spec
+   * @param pageable
+   */
+  public Page<Drop> findAll(Specification<Drop> spec, Pageable pageable) {
+    final Page<Drop> drops = dropRepository.findAll(spec, pageable);
+    drops.forEach(
+        drop -> {
+          Hibernate.initialize(drop.getCreatedByUser());
+          if (drop.getRepository() != null) {
+            Hibernate.initialize(drop.getRepository());
+            Hibernate.initialize(drop.getRepository().getCreatedByUser());
+          }
+          if (drop.getImportPollableTask() != null) {
+            Hibernate.initialize(drop.getImportPollableTask());
+            Hibernate.initialize(drop.getImportPollableTask().getSubTasks());
+          }
+          if (drop.getExportPollableTask() != null) {
+            Hibernate.initialize(drop.getExportPollableTask());
+            Hibernate.initialize(drop.getExportPollableTask().getSubTasks());
+          }
+          Hibernate.initialize(drop.getTranslationKits());
+          if (drop.getTranslationKits() != null) {
+            drop.getTranslationKits().forEach(tk -> Hibernate.initialize(tk.getLocale()));
+          }
+        });
+    return drops;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/drop/DropService.java
@@ -28,10 +28,8 @@ import com.box.l10n.mojito.service.tm.UpdateTMWithXLIFFResult;
 import com.box.l10n.mojito.service.translationkit.TranslationKitAsXliff;
 import com.box.l10n.mojito.service.translationkit.TranslationKitService;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
+import java.util.stream.Stream;
 import net.sf.okapi.common.exceptions.OkapiBadFilterInputException;
 import net.sf.okapi.common.exceptions.OkapiIOException;
 import org.hibernate.Hibernate;
@@ -511,23 +509,25 @@ public class DropService {
     final Page<Drop> drops = dropRepository.findAll(spec, pageable);
     drops.forEach(
         drop -> {
-          Hibernate.initialize(drop.getCreatedByUser());
-          if (drop.getRepository() != null) {
-            Hibernate.initialize(drop.getRepository());
-            Hibernate.initialize(drop.getRepository().getCreatedByUser());
-          }
-          if (drop.getImportPollableTask() != null) {
-            Hibernate.initialize(drop.getImportPollableTask());
-            Hibernate.initialize(drop.getImportPollableTask().getSubTasks());
-          }
-          if (drop.getExportPollableTask() != null) {
-            Hibernate.initialize(drop.getExportPollableTask());
-            Hibernate.initialize(drop.getExportPollableTask().getSubTasks());
-          }
-          Hibernate.initialize(drop.getTranslationKits());
-          if (drop.getTranslationKits() != null) {
-            drop.getTranslationKits().forEach(tk -> Hibernate.initialize(tk.getLocale()));
-          }
+          Stream.ofNullable(drop.getRepository())
+              .peek(Hibernate::initialize)
+              .map(Repository::getCreatedByUser)
+              .forEach(Hibernate::initialize);
+
+          Stream.of(drop.getImportPollableTask(), drop.getExportPollableTask())
+              .filter(Objects::nonNull)
+              .peek(Hibernate::initialize)
+              .map(PollableTask::getSubTasks)
+              .forEach(Hibernate::initialize);
+
+          Stream.ofNullable(drop.getTranslationKits())
+              .peek(Hibernate::initialize)
+              .flatMap(Collection::stream)
+              .filter(Objects::nonNull)
+              .map(TranslationKit::getLocale)
+              .forEach(Hibernate::initialize);
+
+          Stream.ofNullable(drop.getCreatedByUser()).forEach(Hibernate::initialize);
         });
     return drops;
   }


### PR DESCRIPTION
## Lazy loading of `Drop#createdByUser`

API response for `GET /api/drops` sometimes returns `createdByUser: null`, even when corresponding database field (column `created_by_user_id` in table `drops`) has correct data. This causes `/project-requests` page to crash with `TypeError` when accessing `createdByUser.getDisplayName()` here: https://github.com/box/mojito/blob/2e3b87fa2b409438ee73643e6f131f7485d0c8f7/webapp/src/main/resources/public/js/components/drops/Drops.js#L284

Retrieval of drops is done through JPA Hibernate - specifically using `DropRepository#findAll` (https://github.com/box/mojito/blob/2e3b87fa2b409438ee73643e6f131f7485d0c8f7/webapp/src/main/java/com/box/l10n/mojito/rest/drop/DropWS.java#L80). In legacy Mojito (v0.110) this was a builtin Hibernate method, but it was overriden to use a NamedEntityGraph in https://github.com/box/mojito/commit/1d95b1049391d8ef57bab54738764a8df45ccc34 (as a followup/bugfix to changes introduced in https://github.com/box/mojito/commit/33e88bc52c0a9f3207e75ba94d8ac9330ec58f7d).

Because this graph does not include `createdByUser`, `DropWS#getDrops` response would sometimes not include User data due to lazy loading. We should update the code to ensure that User data is always included in the response.

This PR updates NamedEntityGraph `Drop.legacy` to include `createdByUser` to ensure eager User loading for Drops.

## Inefficient Drop pagination

In addition to the above, we've discovered that calling `DropRepository#findAll` results in the following warning log:

```log
HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory
```

This is a limitation of Hibernate, which can't apply pagination at the database level when fetching collections. Due to that, it falls back to fetching ALL matching drops from the database (along with other data specified in the EntityGraph) and then applying pagination in memory. This is inefficient and can even cause OOM issues.

This PR reverts the EntityGraph addition from paginated `DropRepository#findAll`. Instead, it implements manual data initialization _after_ the paginated query result is retrieved. This behaviour is encapsulated in `DropService#findAll`.

Note that this pattern of manual data initialization has previously been implemented in the codebase for UserRepository (as described in https://github.com/box/mojito/blob/33e88bc52c0a9f3207e75ba94d8ac9330ec58f7d/webapp/src/main/java/com/box/l10n/mojito/service/security/user/UserRepository.java#L29-L33).