### PR TITLE
Fix NPE when trying to access nullable Branch creation date 

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/AssetExtractionService.java
@@ -1041,7 +1041,9 @@ public class AssetExtractionService {
         .name(
             localBranchToEntityBranchConverter.branchEntityToLocalBranchName(
                 assetContent.getBranch()))
-        .createdAt(assetContent.getBranch().getCreatedDate())
+        .createdAt(
+            localBranchToEntityBranchConverter.branchEntityToLocalCreatedDate(
+                assetContent.getBranch()))
         .build();
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/LocalBranchToEntityBranchConverter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/LocalBranchToEntityBranchConverter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class LocalBranchToEntityBranchConverter {
 
   public static final String NULL_BRANCH_TEXT_PLACEHOLDER = "$$MOJITO_DEFAULT$$";
-  public static final ZonedDateTime NULL_BRANCH_DATE_PLACEHODLER =
+  public static final ZonedDateTime NULL_BRANCH_DATE_PLACEHOLDER =
       JSR310Migration.newDateTimeCtorAtEpoch();
 
   /** logger */
@@ -33,12 +33,12 @@ public class LocalBranchToEntityBranchConverter {
 
   public ZonedDateTime entityBranchCreatedDateToLocalBranchCreatedDate(
       ZonedDateTime localBranchCreatedDate) {
-    return localBranchCreatedDate == null ? NULL_BRANCH_DATE_PLACEHODLER : localBranchCreatedDate;
+    return localBranchCreatedDate == null ? NULL_BRANCH_DATE_PLACEHOLDER : localBranchCreatedDate;
   }
 
   public ZonedDateTime branchEntityToLocalCreatedDate(com.box.l10n.mojito.entity.Branch branch) {
     return branch == null
-        ? NULL_BRANCH_DATE_PLACEHODLER
+        ? NULL_BRANCH_DATE_PLACEHOLDER
         : entityBranchCreatedDateToLocalBranchCreatedDate(branch.getCreatedDate());
   }
 
@@ -47,11 +47,11 @@ public class LocalBranchToEntityBranchConverter {
 
     if (b == null) {
       // This currently can be null in test, shouldn't be in real case
-      builder.name(NULL_BRANCH_TEXT_PLACEHOLDER).createdAt(NULL_BRANCH_DATE_PLACEHODLER);
+      builder.name(NULL_BRANCH_TEXT_PLACEHOLDER).createdAt(NULL_BRANCH_DATE_PLACEHOLDER);
     } else {
       String branchName = b.getName() == null ? NULL_BRANCH_TEXT_PLACEHOLDER : b.getName();
       ZonedDateTime createdDate =
-          b.getCreatedDate() != null ? b.getCreatedDate() : NULL_BRANCH_DATE_PLACEHODLER;
+          b.getCreatedDate() != null ? b.getCreatedDate() : NULL_BRANCH_DATE_PLACEHOLDER;
       builder.name(branchName).createdAt(createdDate);
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/LocalBranchToEntityBranchConverter.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetExtraction/LocalBranchToEntityBranchConverter.java
@@ -31,6 +31,17 @@ public class LocalBranchToEntityBranchConverter {
         : entityBranchNameToLocalBranchName(branch.getName());
   }
 
+  public ZonedDateTime entityBranchCreatedDateToLocalBranchCreatedDate(
+      ZonedDateTime localBranchCreatedDate) {
+    return localBranchCreatedDate == null ? NULL_BRANCH_DATE_PLACEHODLER : localBranchCreatedDate;
+  }
+
+  public ZonedDateTime branchEntityToLocalCreatedDate(com.box.l10n.mojito.entity.Branch branch) {
+    return branch == null
+        ? NULL_BRANCH_DATE_PLACEHODLER
+        : entityBranchCreatedDateToLocalBranchCreatedDate(branch.getCreatedDate());
+  }
+
   public Branch convertEntityBranchToLocaleBranch(com.box.l10n.mojito.entity.Branch b) {
     Branch.Builder builder = Branch.builder();
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/MultiBranchStateServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetExtraction/MultiBranchStateServiceTest.java
@@ -1,6 +1,6 @@
 package com.box.l10n.mojito.service.assetExtraction;
 
-import static com.box.l10n.mojito.service.assetExtraction.LocalBranchToEntityBranchConverter.NULL_BRANCH_DATE_PLACEHODLER;
+import static com.box.l10n.mojito.service.assetExtraction.LocalBranchToEntityBranchConverter.NULL_BRANCH_DATE_PLACEHOLDER;
 import static com.box.l10n.mojito.service.assetExtraction.LocalBranchToEntityBranchConverter.NULL_BRANCH_TEXT_PLACEHOLDER;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -56,7 +56,7 @@ public class MultiBranchStateServiceTest extends ServiceTestBase {
                 ImmutableSet.of(
                     Branch.builder()
                         .name(NULL_BRANCH_TEXT_PLACEHOLDER)
-                        .createdAt(NULL_BRANCH_DATE_PLACEHODLER)
+                        .createdAt(NULL_BRANCH_DATE_PLACEHOLDER)
                         .build()))
             .withBranchStateTextUnits(
                 ImmutableList.of(


### PR DESCRIPTION
Attempt to run `mojito-cli push` with a repository which created in November 2016 resulted in the following NPE:

---

<details>

<summary>Click here to see the logs</summary>

## CLI logs

Executed:

```sh
mojito-cli push -r <redacted-repository-name> -s ./<redacted-directory-name> -ft PROPERTIES_NOBASENAME -sl en-US -sr <redacted-file-name>.properties
```

Got:

```log
17:14:17  Push assets to repository: <redacted-repository-name>
17:14:17  
17:14:17   - Uploading: <redacted-file-name>.properties
17:14:18   --> asset id: 681, task: 43895579
17:14:18  
17:14:18  Running, task id: 43895579 
17:14:18  Process asset content, id: 36680 (43895580) Running
17:14:18    Extracting text units from asset (43895581) Running
17:14:18  Process asset content, id: 36680 (43895580) Running
17:14:18    Extracting text units from asset (43895581) Running
17:14:19  Process asset content, id: 36680 (43895580) Failed
17:14:19  An unexpected error happened, task=43895580
17:14:19  Error stack
17:14:19  java.lang.NullPointerException: createdAt
17:14:19  	at java.base/java.util.Objects.requireNonNull(Objects.java:259)
17:14:19  	at com.box.l10n.mojito.localtm.merger.Branch$Builder.createdAt(Branch.java:208)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.AssetExtractionService.convertBranchToLocalTmBranch(AssetExtractionService.java:1044)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.AssetExtractionService.convertAssetContentToMultiBranchState_aroundBody18(AssetExtractionService.java:1032)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.AssetExtractionService$AjcClosure19.run(AssetExtractionService.java:1)
17:14:19  	at org.aspectj.runtime.reflect.JoinPointImpl.proceed(JoinPointImpl.java:270)
17:14:19  	at com.box.l10n.mojito.service.pollableTask.PollableCallable.call(PollableCallable.java:50)
17:14:19  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
17:14:19  	at com.box.l10n.mojito.service.pollableTask.PollableAspect.syncExecute(PollableAspect.java:111)
17:14:19  	at com.box.l10n.mojito.service.pollableTask.PollableAspect.ajc$inlineAccessMethod$com_box_l10n_mojito_service_pollableTask_PollableAspect$com_box_l10n_mojito_service_pollableTask_PollableAspect$syncExecute(PollableAspect.java:1)
17:14:19  	at com.box.l10n.mojito.service.pollableTask.PollableAspect.createPollableWrapper(PollableAspect.java:79)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.AssetExtractionService.convertAssetContentToMultiBranchState(AssetExtractionService.java:1023)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.AssetExtractionService.processAsset(AssetExtractionService.java:206)
17:14:19  	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
17:14:19  	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
17:14:19  	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:343)
17:14:19  	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
17:14:19  	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
17:14:19  	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:751)
17:14:19  	at org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor.invoke(AnnotationAwareRetryOperationsInterceptor.java:164)
17:14:19  	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
17:14:19  	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:751)
17:14:19  	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:703)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.AssetExtractionService$$SpringCGLIB$$0.processAsset(<generated>)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.ProcessAssetJob.call(ProcessAssetJob.java:18)
17:14:19  	at com.box.l10n.mojito.service.assetExtraction.ProcessAssetJob.call(ProcessAssetJob.java:1)
17:14:19  	at com.box.l10n.mojito.quartz.QuartzPollableJob.execute(QuartzPollableJob.java:93)
17:14:19  	at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
17:14:19  	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

</details>

---

Error log indicates that a nullable value was not handled correctly. This is because branch creation date was only added in 142cf90d717fecf0f5056645033a55169d6f92c1 ([release v0.97](https://github.com/box/mojito/releases/tag/v0.97)).

This PR fixes null Branch handling by extending the default value fallback pattern introduced in `LocalBranchToEntityBranchConverter#branchEntityToLocalBranchName` (introduced in ab96577559dc0ae14b52914a983e8cb0e358ade6 and ade755e2ea8194bcc211e50f22efa5271282c417).