### PR TITLE
Refactor DropServiceTest suite to decouple it from TMServiceTest data creation

### DIFF
--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -11,13 +11,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import com.box.l10n.mojito.boxsdk.BoxSDKServiceException;
-import com.box.l10n.mojito.entity.Drop;
-import com.box.l10n.mojito.entity.PollableTask;
-import com.box.l10n.mojito.entity.Repository;
-import com.box.l10n.mojito.entity.TMTextUnitCurrentVariant;
-import com.box.l10n.mojito.entity.TMTextUnitVariant;
+import com.box.l10n.mojito.entity.*;
 import com.box.l10n.mojito.entity.TMTextUnitVariant.Status;
-import com.box.l10n.mojito.entity.TranslationKit;
 import com.box.l10n.mojito.okapi.XliffState;
 import com.box.l10n.mojito.service.assetExtraction.ServiceTestBase;
 import com.box.l10n.mojito.service.drop.exporter.DropExporterException;
@@ -46,7 +41,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -110,13 +104,14 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Test
   public void forNotTranslated() throws Exception {
+    List<String> locales = List.of("fr-FR", "ko-KR", "ja-JP");
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 4);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -133,7 +128,7 @@ public class DropServiceTest extends ServiceTestBase {
         dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is still untranslated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 4);
     checkTranslationKitImported(drop.getId(), false);
 
     logger.debug("Force complete");
@@ -164,13 +159,14 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Test
   public void forTranslation() throws Exception {
+    List<String> locales = List.of("fr-FR", "ko-KR", "ja-JP");
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 4);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -187,7 +183,7 @@ public class DropServiceTest extends ServiceTestBase {
         dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 0);
     checkImportedFilesContent(drop, 1);
     checkTranslationKitStatistics(drop);
 
@@ -198,7 +194,7 @@ public class DropServiceTest extends ServiceTestBase {
         dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 0);
 
     checkImportedFilesContent(drop, 2);
     checkTranslationKitStatistics(drop);
@@ -206,13 +202,14 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Test
   public void forTranslationWithTranslationAddedAfterExport() throws Exception {
+    List<String> locales = List.of("fr-FR", "ko-KR", "ja-JP");
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 4);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -225,19 +222,20 @@ public class DropServiceTest extends ServiceTestBase {
     localizeDropFiles(drop, 1);
 
     logger.debug("Translate one of the entry, will check later that this string wasn't overriden");
+    Long tmTextUnitId =
+        dropTestData.tmTextUnits.get("zuora_error_message_verify_state_province").getId();
+    Long localeId = dropTestData.findLocaleForTag("fr-FR").getId();
 
     TMTextUnitVariant translationAddedAfterTheImport =
         tmService.addCurrentTMTextUnitVariant(
-            dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
-            dropTestData.frFR.getId(),
-            "string added while the drop is translated");
+            tmTextUnitId, localeId, "string added while the drop is translated");
 
     logger.debug("Import drop");
     awaitPollableProcess(
         dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 0);
 
     checkImportedFilesContent(drop, 1);
 
@@ -250,9 +248,7 @@ public class DropServiceTest extends ServiceTestBase {
     logger.debug(
         "Check that the current translation is the one that was added after the export and before the import and not coming from the TK");
     TMTextUnitCurrentVariant currentTranslation =
-        tmTextUnitCurrentVariantRepository.findByLocale_IdAndTmTextUnit_Id(
-            dropTestData.frFR.getId(),
-            dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId());
+        tmTextUnitCurrentVariantRepository.findByLocale_IdAndTmTextUnit_Id(localeId, tmTextUnitId);
 
     assertEquals(
         "The translation that has been added between the export and import must be kept",
@@ -262,14 +258,32 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Test
   public void forReview() throws Exception {
+    List<String> locales = List.of("fr-FR", "ko-KR", "ja-JP");
 
-    DropTestData dropTestData = createDataForReview();
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    logger.debug("Mark on translated string as need review");
+    Long tmTextUnitId =
+        dropTestData.tmTextUnits.get("zuora_error_message_verify_state_province").getId();
+    Locale locale = dropTestData.findLocaleForTag("fr-FR");
+    String currentTranslation =
+        dropTestData
+            .addCurrentTMTextUnitVariants
+            .get(locale)
+            .get("zuora_error_message_verify_state_province")
+            .getContent();
+    tmService.addTMTextUnitCurrentVariant(
+        tmTextUnitId,
+        locale.getId(),
+        currentTranslation,
+        null,
+        TMTextUnitVariant.Status.REVIEW_NEEDED);
+
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
     exportDropConfig.setType(TranslationKit.Type.REVIEW);
 
     logger.debug("Check inital number of needs review");
-    checkNumberOfNeedsReviewTextUnit(dropTestData, 1);
+    checkNumberOfNeedsReviewTextUnit(dropTestData, locales, 1);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -287,30 +301,18 @@ public class DropServiceTest extends ServiceTestBase {
         dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
-    checkNumberOfNeedsReviewTextUnit(dropTestData, 0);
+    checkNumberOfNeedsReviewTextUnit(dropTestData, locales, 0);
 
     checkImportedFilesForReviewContent(drop);
   }
 
-  @Transactional
-  DropTestData createDataForReview() {
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
-    logger.debug("Mark on translated string as need review");
-    tmService.addTMTextUnitCurrentVariant(
-        dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
-        dropTestData.addCurrentTMTextUnitVariant1FrFR.getLocale().getId(),
-        dropTestData.addCurrentTMTextUnitVariant1FrFR.getContent(),
-        null,
-        TMTextUnitVariant.Status.REVIEW_NEEDED);
-    return dropTestData;
-  }
-
   @Test
   public void allWithSevereError() throws Exception {
+    List<String> locales = List.of("fr-FR");
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -365,20 +367,24 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Test
   public void forNoEmptyXliffs() throws Exception {
+    List<String> locales = List.of("fr-FR", "ja-JP");
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ja-JP"));
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
     // make French be fully translated and Japanese not
-    dropTestData.addCurrentTMTextUnitVariant1FrFR.setStatus(Status.APPROVED);
+    Locale locale = dropTestData.findLocaleForTag("fr-FR");
+    dropTestData
+        .addCurrentTMTextUnitVariants
+        .get(locale)
+        .get("zuora_error_message_verify_state_province")
+        .setStatus(Status.APPROVED);
     tmService.addCurrentTMTextUnitVariant(
-        dropTestData.addTMTextUnit2.getId(),
-        localeService.findByBcp47Tag("fr-FR").getId(),
-        "French stuff here.");
+        dropTestData.tmTextUnits.get("TEST2").getId(), locale.getId(), "French stuff here.");
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 2);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 2);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -409,14 +415,16 @@ public class DropServiceTest extends ServiceTestBase {
   }
 
   public void checkNumberOfUntranslatedTextUnit(
-      DropTestData dropTestData, int expectedNumberOfUnstranslated) {
-    List<TextUnitDTO> search = dropTestData.getTextUnitsForStatus(StatusFilter.UNTRANSLATED);
+      DropTestData dropTestData, List<String> locales, int expectedNumberOfUnstranslated) {
+    List<TextUnitDTO> search =
+        dropTestData.getTextUnitsForStatus(StatusFilter.UNTRANSLATED, locales);
     assertEquals(expectedNumberOfUnstranslated, search.size());
   }
 
   public void checkNumberOfNeedsReviewTextUnit(
-      DropTestData dropTestData, int expectedNumberOfUnstranslated) {
-    List<TextUnitDTO> search = dropTestData.getTextUnitsForStatus(StatusFilter.REVIEW_NEEDED);
+      DropTestData dropTestData, List<String> locales, int expectedNumberOfUnstranslated) {
+    List<TextUnitDTO> search =
+        dropTestData.getTextUnitsForStatus(StatusFilter.REVIEW_NEEDED, locales);
     assertEquals(expectedNumberOfUnstranslated, search.size());
   }
 
@@ -752,14 +760,14 @@ public class DropServiceTest extends ServiceTestBase {
   }
 
   @Test
-  public void testCancelDrop()
-      throws DropExporterException, InterruptedException, ExecutionException, CancelDropException {
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
+  public void testCancelDrop() throws Exception {
+    List<String> locales = List.of("fr-FR");
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 1);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 1);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =
@@ -779,18 +787,19 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Test(expected = PollableTaskExecutionException.class)
   @Ignore("flaky test")
-  public void testCancelDropException()
-      throws DropExporterException, ExecutionException, InterruptedException, CancelDropException {
+  public void testCancelDropException() throws Exception {
 
     DropService dropServiceSpy = spy(dropService);
     doReturn(true).when(dropServiceSpy).isDropBeingProcessed(any(Drop.class));
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
+    List<String> locales = List.of("fr-FR");
 
-    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
+    DropTestData dropTestData = DropTestData.createWithDefaultData(testIdWatcher);
+
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
 
     logger.debug("Check initial number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, 1);
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 1);
 
     logger.debug("Create an initial drop for the repository");
     Drop drop =

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -32,7 +32,6 @@ import com.box.l10n.mojito.service.pollableTask.PollableTaskService;
 import com.box.l10n.mojito.service.repository.RepositoryRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.service.tm.TMService;
-import com.box.l10n.mojito.service.tm.TMTestData;
 import com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantRepository;
 import com.box.l10n.mojito.service.tm.search.StatusFilter;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
@@ -106,9 +105,9 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forNotTranslated() throws Exception {
 
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
@@ -175,9 +174,9 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forTranslation() throws Exception {
 
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
@@ -235,9 +234,9 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forTranslationWithTranslationAddedAfterExport() throws Exception {
 
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
@@ -268,8 +267,8 @@ public class DropServiceTest extends ServiceTestBase {
 
     TMTextUnitVariant translationAddedAfterTheImport =
         tmService.addCurrentTMTextUnitVariant(
-            tmTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
-            tmTestData.frFR.getId(),
+            dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
+            dropTestData.frFR.getId(),
             "string added while the drop is translated");
 
     logger.debug("Import drop");
@@ -297,8 +296,8 @@ public class DropServiceTest extends ServiceTestBase {
         "Check that the current translation is the one that was added after the export and before the import and not coming from the TK");
     TMTextUnitCurrentVariant currentTranslation =
         tmTextUnitCurrentVariantRepository.findByLocale_IdAndTmTextUnit_Id(
-            tmTestData.frFR.getId(),
-            tmTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId());
+            dropTestData.frFR.getId(),
+            dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId());
 
     assertEquals(
         "The translation that has been added between the export and import must be kept",
@@ -353,13 +352,13 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Transactional
   Repository createDataForReview() {
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
-    Repository repository = tmTestData.repository;
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    Repository repository = dropTestData.repository;
     logger.debug("Mark on translated string as need review");
     tmService.addTMTextUnitCurrentVariant(
-        tmTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
-        tmTestData.addCurrentTMTextUnitVariant1FrFR.getLocale().getId(),
-        tmTestData.addCurrentTMTextUnitVariant1FrFR.getContent(),
+        dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
+        dropTestData.addCurrentTMTextUnitVariant1FrFR.getLocale().getId(),
+        dropTestData.addCurrentTMTextUnitVariant1FrFR.getContent(),
         null,
         TMTextUnitVariant.Status.REVIEW_NEEDED);
     return repository;
@@ -368,9 +367,9 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void allWithSevereError() throws Exception {
 
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
@@ -436,14 +435,14 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forNoEmptyXliffs() throws Exception {
 
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     // make French be fully translated and Japanese not
-    tmTestData.addCurrentTMTextUnitVariant1FrFR.setStatus(Status.APPROVED);
+    dropTestData.addCurrentTMTextUnitVariant1FrFR.setStatus(Status.APPROVED);
     tmService.addCurrentTMTextUnitVariant(
-        tmTestData.addTMTextUnit2.getId(),
+        dropTestData.addTMTextUnit2.getId(),
         localeService.findByBcp47Tag("fr-FR").getId(),
         "French stuff here.");
 
@@ -847,9 +846,9 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void testCancelDrop()
       throws DropExporterException, InterruptedException, ExecutionException, CancelDropException {
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
@@ -893,9 +892,9 @@ public class DropServiceTest extends ServiceTestBase {
     DropService dropServiceSpy = spy(dropService);
     doReturn(true).when(dropServiceSpy).isDropBeingProcessed(any(Drop.class));
 
-    TMTestData tmTestData = new TMTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = tmTestData.repository;
+    Repository repository = dropTestData.repository;
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
@@ -100,19 +99,14 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forNotTranslated() throws Exception {
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
-
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-    bcp47Tags.add("ko-KR");
-    bcp47Tags.add("ja-JP");
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
 
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(dropTestData.repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -135,7 +129,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is still untranslated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
     checkTranslationKitImported(drop.getId(), false);
 
     logger.debug("Force complete");
@@ -167,21 +161,16 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forTranslation() throws Exception {
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
 
     Repository repository = dropTestData.repository;
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-    bcp47Tags.add("ko-KR");
-    bcp47Tags.add("ja-JP");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -204,7 +193,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 0);
     checkImportedFilesContent(drop, 1);
     checkTranslationKitStatistics(drop);
 
@@ -218,7 +207,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop3.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 0);
 
     checkImportedFilesContent(drop, 2);
     checkTranslationKitStatistics(drop);
@@ -227,21 +216,16 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forTranslationWithTranslationAddedAfterExport() throws Exception {
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
 
     Repository repository = dropTestData.repository;
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-    bcp47Tags.add("ko-KR");
-    bcp47Tags.add("ja-JP");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 4);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -272,7 +256,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 0);
 
     checkImportedFilesContent(drop, 1);
 
@@ -303,18 +287,13 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = createDataForReview();
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-    bcp47Tags.add("ko-KR");
-    bcp47Tags.add("ja-JP");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(dropTestData.repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
     exportDropConfig.setType(TranslationKit.Type.REVIEW);
 
     logger.debug("Check inital number of needs review");
-    checkNumberOfNeedsReviewTextUnit(dropTestData, bcp47Tags, 1);
+    checkNumberOfNeedsReviewTextUnit(dropTestData, 1);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -338,15 +317,14 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfNeedsReviewTextUnit(dropTestData, bcp47Tags, 0);
+    checkNumberOfNeedsReviewTextUnit(dropTestData, 0);
 
     checkImportedFilesForReviewContent(drop);
   }
 
   @Transactional
   DropTestData createDataForReview() {
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
-    Repository repository = dropTestData.repository;
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
     logger.debug("Mark on translated string as need review");
     tmService.addTMTextUnitCurrentVariant(
         dropTestData.addCurrentTMTextUnitVariant1FrFR.getTmTextUnit().getId(),
@@ -360,16 +338,13 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void allWithSevereError() throws Exception {
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
 
     Repository repository = dropTestData.repository;
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -428,7 +403,7 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forNoEmptyXliffs() throws Exception {
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ja-JP"));
 
     Repository repository = dropTestData.repository;
 
@@ -439,16 +414,12 @@ public class DropServiceTest extends ServiceTestBase {
         localeService.findByBcp47Tag("fr-FR").getId(),
         "French stuff here.");
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-    bcp47Tags.add("ja-JP");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 2);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 2);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -482,16 +453,14 @@ public class DropServiceTest extends ServiceTestBase {
   }
 
   public void checkNumberOfUntranslatedTextUnit(
-      DropTestData dropTestData, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {
-    List<TextUnitDTO> search =
-        dropTestData.getTextUnitsForStatus(bcp47Tags, StatusFilter.UNTRANSLATED);
+      DropTestData dropTestData, int expectedNumberOfUnstranslated) {
+    List<TextUnitDTO> search = dropTestData.getTextUnitsForStatus(StatusFilter.UNTRANSLATED);
     assertEquals(expectedNumberOfUnstranslated, search.size());
   }
 
   public void checkNumberOfNeedsReviewTextUnit(
-      DropTestData dropTestData, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {
-    List<TextUnitDTO> search =
-        dropTestData.getTextUnitsForStatus(bcp47Tags, StatusFilter.REVIEW_NEEDED);
+      DropTestData dropTestData, int expectedNumberOfUnstranslated) {
+    List<TextUnitDTO> search = dropTestData.getTextUnitsForStatus(StatusFilter.REVIEW_NEEDED);
     assertEquals(expectedNumberOfUnstranslated, search.size());
   }
 
@@ -829,19 +798,16 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void testCancelDrop()
       throws DropExporterException, InterruptedException, ExecutionException, CancelDropException {
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
 
     Repository repository = dropTestData.repository;
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 1);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 1);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -875,19 +841,16 @@ public class DropServiceTest extends ServiceTestBase {
     DropService dropServiceSpy = spy(dropService);
     doReturn(true).when(dropServiceSpy).isDropBeingProcessed(any(Drop.class));
 
-    DropTestData dropTestData = new DropTestData(testIdWatcher);
+    DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
 
     Repository repository = dropTestData.repository;
 
-    List<String> bcp47Tags = new ArrayList<>();
-    bcp47Tags.add("fr-FR");
-
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(bcp47Tags);
+    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
 
     logger.debug("Check initial number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 1);
+    checkNumberOfUntranslatedTextUnit(dropTestData, 1);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -96,6 +96,18 @@ public class DropServiceTest extends ServiceTestBase {
     assertNotNull(createDrop.getCreatedByUser());
   }
 
+  public <T> PollableFuture<T> awaitPollableProcess(PollableFuture<T> process)
+      throws InterruptedException, PollableTaskException {
+    String processName = process.getClass().getName();
+    logger.debug("Starting process [{}]", processName);
+    PollableTask pollableTask = process.getPollableTask();
+    Long taskId = pollableTask.getId();
+    logger.debug("Wait for process [{}] task [{}] to finish", processName, taskId);
+    pollableTaskService.waitForPollableTask(taskId, 600000L);
+    logger.debug("Process [{}] finished", processName);
+    return process;
+  }
+
   @Test
   public void forNotTranslated() throws Exception {
 
@@ -107,24 +119,18 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box without updating the state");
-    Drop drop = startExportProcess.get();
     localizeDropFiles(drop, 1, "new", false);
 
     logger.debug("Import drop");
-    PollableFuture<Void> startImportDrop =
-        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-
-    logger.debug("Wait for import to finish");
-    pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is still untranslated");
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
@@ -167,24 +173,18 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box");
-    Drop drop = startExportProcess.get();
     localizeDropFiles(drop, 1);
 
     logger.debug("Import drop");
-    PollableFuture<Void> startImportDrop =
-        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-
-    logger.debug("Wait for import to finish");
-    pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
     checkNumberOfUntranslatedTextUnit(dropTestData, 0);
@@ -194,11 +194,8 @@ public class DropServiceTest extends ServiceTestBase {
     logger.debug(
         "Perform a third import drop with changes (must be able to re-import as many time as wanted)");
     localizeDropFiles(drop, 2);
-    PollableFuture<Void> startImportDrop3 =
-        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-
-    logger.debug("Wait for import to finish");
-    pollableTaskService.waitForPollableTask(startImportDrop3.getPollableTask().getId(), 60000L);
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
     checkNumberOfUntranslatedTextUnit(dropTestData, 0);
@@ -218,16 +215,13 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box");
-    Drop drop = startExportProcess.get();
     localizeDropFiles(drop, 1);
 
     logger.debug("Translate one of the entry, will check later that this string wasn't overriden");
@@ -239,11 +233,8 @@ public class DropServiceTest extends ServiceTestBase {
             "string added while the drop is translated");
 
     logger.debug("Import drop");
-    PollableFuture<Void> startImportDrop =
-        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-
-    logger.debug("Wait for import to finish");
-    pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
     checkNumberOfUntranslatedTextUnit(dropTestData, 0);
@@ -253,11 +244,8 @@ public class DropServiceTest extends ServiceTestBase {
     checkTranslationKitStatistics(drop);
 
     logger.debug("Perform a second import drop (must be able to re-import as many time as wanted)");
-    PollableFuture<Void> startImportDrop2 =
-        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-
-    logger.debug("Wait for import to finish");
-    pollableTaskService.waitForPollableTask(startImportDrop2.getPollableTask().getId(), 60000L);
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug(
         "Check that the current translation is the one that was added after the export and before the import and not coming from the TK");
@@ -284,25 +272,19 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfNeedsReviewTextUnit(dropTestData, 1);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box");
-    Drop drop = startExportProcess.get();
 
     reviewDropFiles(drop);
 
     logger.debug("Import drop");
-    PollableFuture<Void> startImportDrop =
-        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-
-    logger.debug("Wait for import to finish");
-    pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
 
     logger.debug("Check everything is now translated");
     checkNumberOfNeedsReviewTextUnit(dropTestData, 0);
@@ -331,16 +313,13 @@ public class DropServiceTest extends ServiceTestBase {
     ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box");
-    Drop drop = startExportProcess.get();
     localizeDropFiles(drop, 1, "translated", true); // introduce syntax error!
 
     logger.debug("Import drop");
@@ -349,7 +328,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     logger.debug("Wait for import to finish");
     try {
-      pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
+      awaitPollableProcess(startImportDrop);
       fail();
     } catch (PollableTaskException pte) {
       PollableTask importPollableTask =
@@ -372,7 +351,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     logger.debug("Wait for import to finish");
     try {
-      pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
+      awaitPollableProcess(startImportDrop);
       fail();
     } catch (PollableTaskException pte) {
       PollableTask importPollableTask =
@@ -402,16 +381,13 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfUntranslatedTextUnit(dropTestData, 2);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box without updating the state");
-    Drop drop = startExportProcess.get();
 
     // Make sure no French xliff was generated
     assertFalse(
@@ -786,26 +762,18 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfUntranslatedTextUnit(dropTestData, 1);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropService.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
-
-    PollableTask pollableTask = startExportProcess.getPollableTask();
-
-    logger.debug("Wait for export to finish");
-    pollableTaskService.waitForPollableTask(pollableTask.getId(), 600000L);
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
     logger.debug("Drop export finished, localize files in Box");
-    Drop drop = startExportProcess.get();
 
-    PollableFuture<Drop> dropPollableFuture =
-        dropService.cancelDrop(drop.getId(), PollableTask.INJECT_CURRENT_TASK);
-    PollableTask cancelDropPollableTask = dropPollableFuture.getPollableTask();
-    pollableTaskService.getPollableTask(cancelDropPollableTask.getId());
+    Drop canceledDrop =
+        awaitPollableProcess(dropService.cancelDrop(drop.getId(), PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
-    logger.debug("Wait for cancellation to finish");
-    pollableTaskService.waitForPollableTask(cancelDropPollableTask.getId(), 600000L);
-
-    Drop canceledDrop = dropPollableFuture.get();
     Assert.assertTrue("Drop should be canceled", canceledDrop.getCanceled());
   }
 
@@ -825,17 +793,13 @@ public class DropServiceTest extends ServiceTestBase {
     checkNumberOfUntranslatedTextUnit(dropTestData, 1);
 
     logger.debug("Create an initial drop for the repository");
-    PollableFuture<Drop> startExportProcess =
-        dropServiceSpy.startDropExportProcess(exportDropConfig, PollableTask.INJECT_CURRENT_TASK);
+    Drop drop =
+        awaitPollableProcess(
+                dropServiceSpy.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
 
-    Drop drop = startExportProcess.get();
-
-    PollableFuture<Drop> dropPollableFuture =
-        dropServiceSpy.cancelDrop(drop.getId(), PollableTask.INJECT_CURRENT_TASK);
-    PollableTask cancelDropPollableTask = dropPollableFuture.getPollableTask();
-
-    logger.debug("Wait for cancellation to finish");
-    pollableTaskService.waitForPollableTask(cancelDropPollableTask.getId(), 600000L);
+    awaitPollableProcess(dropServiceSpy.cancelDrop(drop.getId(), PollableTask.INJECT_CURRENT_TASK));
   }
 
   @Test
@@ -845,19 +809,17 @@ public class DropServiceTest extends ServiceTestBase {
     // don't create any drops
     Long nonExistentDropId = 9999L;
 
-    PollableFuture<Drop> dropPollableFuture =
+    PollableFuture<Drop> startCancelDrop =
         dropService.cancelDrop(nonExistentDropId, PollableTask.INJECT_CURRENT_TASK);
-    PollableTask cancelDropPollableTask = dropPollableFuture.getPollableTask();
-    pollableTaskService.getPollableTask(cancelDropPollableTask.getId());
 
     try {
-      pollableTaskService.waitForPollableTask(cancelDropPollableTask.getId(), 60000L);
+      awaitPollableProcess(startCancelDrop);
       fail();
     } catch (PollableTaskException pte) {
-      PollableTask importPollableTask =
-          pollableTaskService.getPollableTask(cancelDropPollableTask.getId());
+      PollableTask cancelPollableTask =
+          pollableTaskService.getPollableTask(startCancelDrop.getPollableTask().getId());
       assertTrue(
-          importPollableTask
+          cancelPollableTask
               .getErrorMessage()
               .contains("Drop with ID [" + nonExistentDropId + "] does not exist"));
     }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -35,9 +35,6 @@ import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.TMTextUnitCurrentVariantRepository;
 import com.box.l10n.mojito.service.tm.search.StatusFilter;
 import com.box.l10n.mojito.service.tm.search.TextUnitDTO;
-import com.box.l10n.mojito.service.tm.search.TextUnitSearcher;
-import com.box.l10n.mojito.service.tm.search.TextUnitSearcherParameters;
-import com.box.l10n.mojito.service.tm.search.UsedFilter;
 import com.box.l10n.mojito.service.translationkit.TranslationKitRepository;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import com.box.l10n.mojito.test.XliffUtils;
@@ -80,8 +77,6 @@ public class DropServiceTest extends ServiceTestBase {
 
   @Autowired DropExporterService dropExporterService;
 
-  @Autowired TextUnitSearcher textUnitSearcher;
-
   @Autowired LocaleService localeService;
 
   @Autowired TranslationKitRepository translationKitRepository;
@@ -107,19 +102,17 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher);
 
-    Repository repository = dropTestData.repository;
-
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
     bcp47Tags.add("ko-KR");
     bcp47Tags.add("ja-JP");
 
     ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
+    exportDropConfig.setRepositoryId(dropTestData.repository.getId());
     exportDropConfig.setBcp47Tags(bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -142,7 +135,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is still untranslated");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
     checkTranslationKitImported(drop.getId(), false);
 
     logger.debug("Force complete");
@@ -188,7 +181,7 @@ public class DropServiceTest extends ServiceTestBase {
     exportDropConfig.setBcp47Tags(bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -211,7 +204,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 0);
     checkImportedFilesContent(drop, 1);
     checkTranslationKitStatistics(drop);
 
@@ -225,7 +218,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop3.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 0);
 
     checkImportedFilesContent(drop, 2);
     checkTranslationKitStatistics(drop);
@@ -248,7 +241,7 @@ public class DropServiceTest extends ServiceTestBase {
     exportDropConfig.setBcp47Tags(bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 4);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 4);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -279,7 +272,7 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 0);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 0);
 
     checkImportedFilesContent(drop, 1);
 
@@ -308,7 +301,7 @@ public class DropServiceTest extends ServiceTestBase {
   @Test
   public void forReview() throws Exception {
 
-    Repository repository = createDataForReview();
+    DropTestData dropTestData = createDataForReview();
 
     List<String> bcp47Tags = new ArrayList<>();
     bcp47Tags.add("fr-FR");
@@ -316,12 +309,12 @@ public class DropServiceTest extends ServiceTestBase {
     bcp47Tags.add("ja-JP");
 
     ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
+    exportDropConfig.setRepositoryId(dropTestData.repository.getId());
     exportDropConfig.setBcp47Tags(bcp47Tags);
     exportDropConfig.setType(TranslationKit.Type.REVIEW);
 
     logger.debug("Check inital number of needs review");
-    checkNumberOfNeedsReviewTextUnit(repository, bcp47Tags, 1);
+    checkNumberOfNeedsReviewTextUnit(dropTestData, bcp47Tags, 1);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -345,13 +338,13 @@ public class DropServiceTest extends ServiceTestBase {
     pollableTaskService.waitForPollableTask(startImportDrop.getPollableTask().getId(), 60000L);
 
     logger.debug("Check everything is now translated");
-    checkNumberOfNeedsReviewTextUnit(repository, bcp47Tags, 0);
+    checkNumberOfNeedsReviewTextUnit(dropTestData, bcp47Tags, 0);
 
     checkImportedFilesForReviewContent(drop);
   }
 
   @Transactional
-  Repository createDataForReview() {
+  DropTestData createDataForReview() {
     DropTestData dropTestData = new DropTestData(testIdWatcher);
     Repository repository = dropTestData.repository;
     logger.debug("Mark on translated string as need review");
@@ -361,7 +354,7 @@ public class DropServiceTest extends ServiceTestBase {
         dropTestData.addCurrentTMTextUnitVariant1FrFR.getContent(),
         null,
         TMTextUnitVariant.Status.REVIEW_NEEDED);
-    return repository;
+    return dropTestData;
   }
 
   @Test
@@ -455,7 +448,7 @@ public class DropServiceTest extends ServiceTestBase {
     exportDropConfig.setBcp47Tags(bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 2);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 2);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -489,26 +482,16 @@ public class DropServiceTest extends ServiceTestBase {
   }
 
   public void checkNumberOfUntranslatedTextUnit(
-      Repository repository, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {
-    TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
-    textUnitSearcherParameters.setRepositoryIds(repository.getId());
-    textUnitSearcherParameters.setStatusFilter(StatusFilter.UNTRANSLATED);
-    textUnitSearcherParameters.setUsedFilter(UsedFilter.USED);
-    textUnitSearcherParameters.setLocaleTags(bcp47Tags);
-
-    List<TextUnitDTO> search = textUnitSearcher.search(textUnitSearcherParameters);
+      DropTestData dropTestData, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {
+    List<TextUnitDTO> search =
+        dropTestData.getTextUnitsForStatus(bcp47Tags, StatusFilter.UNTRANSLATED);
     assertEquals(expectedNumberOfUnstranslated, search.size());
   }
 
   public void checkNumberOfNeedsReviewTextUnit(
-      Repository repository, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {
-    TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
-    textUnitSearcherParameters.setRepositoryIds(repository.getId());
-    textUnitSearcherParameters.setStatusFilter(StatusFilter.REVIEW_NEEDED);
-    textUnitSearcherParameters.setUsedFilter(UsedFilter.USED);
-    textUnitSearcherParameters.setLocaleTags(bcp47Tags);
-
-    List<TextUnitDTO> search = textUnitSearcher.search(textUnitSearcherParameters);
+      DropTestData dropTestData, List<String> bcp47Tags, int expectedNumberOfUnstranslated) {
+    List<TextUnitDTO> search =
+        dropTestData.getTextUnitsForStatus(bcp47Tags, StatusFilter.REVIEW_NEEDED);
     assertEquals(expectedNumberOfUnstranslated, search.size());
   }
 
@@ -858,7 +841,7 @@ public class DropServiceTest extends ServiceTestBase {
     exportDropConfig.setBcp47Tags(bcp47Tags);
 
     logger.debug("Check inital number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 1);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 1);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -904,7 +887,7 @@ public class DropServiceTest extends ServiceTestBase {
     exportDropConfig.setBcp47Tags(bcp47Tags);
 
     logger.debug("Check initial number of untranslated units");
-    checkNumberOfUntranslatedTextUnit(repository, bcp47Tags, 1);
+    checkNumberOfUntranslatedTextUnit(dropTestData, bcp47Tags, 1);
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -101,9 +101,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
 
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(dropTestData.repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Check inital number of untranslated units");
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
@@ -163,11 +161,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
 
-    Repository repository = dropTestData.repository;
-
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Check inital number of untranslated units");
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
@@ -218,11 +212,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ko-KR", "ja-JP"));
 
-    Repository repository = dropTestData.repository;
-
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Check inital number of untranslated units");
     checkNumberOfUntranslatedTextUnit(dropTestData, 4);
@@ -287,9 +277,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = createDataForReview();
 
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(dropTestData.repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
     exportDropConfig.setType(TranslationKit.Type.REVIEW);
 
     logger.debug("Check inital number of needs review");
@@ -340,11 +328,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
 
-    Repository repository = dropTestData.repository;
-
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Create an initial drop for the repository");
     PollableFuture<Drop> startExportProcess =
@@ -405,8 +389,6 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR", "ja-JP"));
 
-    Repository repository = dropTestData.repository;
-
     // make French be fully translated and Japanese not
     dropTestData.addCurrentTMTextUnitVariant1FrFR.setStatus(Status.APPROVED);
     tmService.addCurrentTMTextUnitVariant(
@@ -414,9 +396,7 @@ public class DropServiceTest extends ServiceTestBase {
         localeService.findByBcp47Tag("fr-FR").getId(),
         "French stuff here.");
 
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Check inital number of untranslated units");
     checkNumberOfUntranslatedTextUnit(dropTestData, 2);
@@ -800,11 +780,7 @@ public class DropServiceTest extends ServiceTestBase {
       throws DropExporterException, InterruptedException, ExecutionException, CancelDropException {
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
 
-    Repository repository = dropTestData.repository;
-
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Check inital number of untranslated units");
     checkNumberOfUntranslatedTextUnit(dropTestData, 1);
@@ -843,11 +819,7 @@ public class DropServiceTest extends ServiceTestBase {
 
     DropTestData dropTestData = new DropTestData(testIdWatcher, List.of("fr-FR"));
 
-    Repository repository = dropTestData.repository;
-
-    ExportDropConfig exportDropConfig = new ExportDropConfig();
-    exportDropConfig.setRepositoryId(repository.getId());
-    exportDropConfig.setBcp47Tags(dropTestData.bcp47Tags);
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig();
 
     logger.debug("Check initial number of untranslated units");
     checkNumberOfUntranslatedTextUnit(dropTestData, 1);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -204,4 +204,11 @@ public class DropTestData {
 
     return textUnitSearcher.search(textUnitSearcherParameters);
   }
+
+  public ExportDropConfig getExportDropConfig() {
+    ExportDropConfig exportDropConfig = new ExportDropConfig();
+    exportDropConfig.setRepositoryId(repository.getId());
+    exportDropConfig.setBcp47Tags(bcp47Tags);
+    return exportDropConfig;
+  }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -1,0 +1,193 @@
+package com.box.l10n.mojito.service.drop;
+
+import com.box.l10n.mojito.entity.Asset;
+import com.box.l10n.mojito.entity.AssetExtraction;
+import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.Locale;
+import com.box.l10n.mojito.entity.PollableTask;
+import com.box.l10n.mojito.entity.Repository;
+import com.box.l10n.mojito.entity.RepositoryLocale;
+import com.box.l10n.mojito.entity.TM;
+import com.box.l10n.mojito.entity.TMTextUnit;
+import com.box.l10n.mojito.entity.TMTextUnitVariant;
+import com.box.l10n.mojito.service.asset.AssetService;
+import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
+import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
+import com.box.l10n.mojito.service.assetExtraction.AssetMappingService;
+import com.box.l10n.mojito.service.locale.LocaleService;
+import com.box.l10n.mojito.service.pluralform.PluralFormService;
+import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
+import com.box.l10n.mojito.service.repository.RepositoryService;
+import com.box.l10n.mojito.service.tm.TMRepository;
+import com.box.l10n.mojito.service.tm.TMService;
+import com.box.l10n.mojito.test.TestIdWatcher;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author jaurambault, wadimw
+ */
+@Configurable
+public class DropTestData {
+
+  /** logger */
+  static Logger logger = LoggerFactory.getLogger(DropTestData.class);
+
+  @Autowired TMService tmService;
+
+  @Autowired TMRepository tmRepository;
+
+  @Autowired LocaleService localeService;
+
+  @Autowired AssetExtractionRepository assetExtractionRepository;
+
+  @Autowired AssetMappingService assetMappingService;
+
+  @Autowired AssetExtractionService assetExtractionService;
+
+  @Autowired AssetService assetService;
+
+  @Autowired RepositoryService repositoryService;
+
+  @Autowired RepositoryLocaleRepository repositoryLocaleRepository;
+
+  @Autowired PluralFormService pluralFormService;
+
+  public Repository repository;
+  public TM tm;
+  public TMTextUnit addTMTextUnit1;
+  public TMTextUnit addTMTextUnit2;
+  public TMTextUnit addTMTextUnit3;
+  public AssetTextUnit createAssetTextUnit1;
+  public AssetTextUnit createAssetTextUnit2;
+  public Asset asset;
+  public AssetExtraction assetExtraction;
+  public TMTextUnitVariant addCurrentTMTextUnitVariant1KoKR;
+  public TMTextUnitVariant addCurrentTMTextUnitVariant1FrFR;
+  public TMTextUnitVariant addCurrentTMTextUnitVariant3FrFR;
+  public TMTextUnitVariant addCurrentTMTextUnitVariant2FrCA;
+  public TMTextUnitVariant addCurrentTMTextUnitVariant3FrCA;
+  public Locale koKR;
+  public Locale frFR;
+  public Locale frCA;
+  public Locale jaJP;
+  public Locale en;
+  public RepositoryLocale repoLocaleFrFR;
+  public RepositoryLocale repoLocaleKoKR;
+
+  TestIdWatcher testIdWatcher;
+
+  public DropTestData(TestIdWatcher testIdWatcher) {
+    this.testIdWatcher = testIdWatcher;
+  }
+
+  @PostConstruct
+  @Transactional
+  private void createData() throws Exception {
+
+    logger.debug("Create data set tot test searches");
+
+    en = localeService.findByBcp47Tag("en");
+    koKR = localeService.findByBcp47Tag("ko-KR");
+    frFR = localeService.findByBcp47Tag("fr-FR");
+    frCA = localeService.findByBcp47Tag("fr-CA");
+    jaJP = localeService.findByBcp47Tag("ja-JP");
+
+    // This is to make sure data from other TM don't have side effects
+    Repository otherRepository =
+        repositoryService.createRepository(testIdWatcher.getEntityName("other-repository"));
+
+    TM otherTM = tmRepository.save(new TM());
+    Asset otherAsset =
+        assetService.createAssetWithContent(
+            otherRepository.getId(), "fake_for_test", "fake for test other tm repo");
+    TMTextUnit addTMTextUnitOther =
+        tmService.addTMTextUnit(
+            otherTM.getId(), otherAsset.getId(), "TEST1", "Content1", "Comment1");
+
+    AssetExtraction assetExtractionOther = assetExtractionRepository.save(new AssetExtraction());
+    AssetTextUnit createAssetTextUnitOther =
+        assetExtractionService.createAssetTextUnit(
+            assetExtractionOther, "TEST2", "Content2", "Comment2");
+
+    // This is the actual data that should be proccessed
+    repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+    repoLocaleKoKR = repositoryService.addRepositoryLocale(repository, koKR.getBcp47Tag());
+    repoLocaleFrFR = repositoryService.addRepositoryLocale(repository, frFR.getBcp47Tag());
+    repositoryService.addRepositoryLocale(repository, frCA.getBcp47Tag());
+    repositoryService.addRepositoryLocale(repository, jaJP.getBcp47Tag());
+
+    RepositoryLocale parentLocale =
+        repositoryLocaleRepository.findByRepositoryAndLocale(repository, frFR);
+    RepositoryLocale childLocale =
+        repositoryLocaleRepository.findByRepositoryAndLocale(repository, frCA);
+    childLocale.setParentLocale(parentLocale);
+    childLocale.setToBeFullyTranslated(false);
+    repositoryLocaleRepository.save(childLocale);
+
+    tm = repository.getTm();
+
+    asset =
+        assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
+    Long assetId = asset.getId();
+
+    addTMTextUnit1 =
+        tmService.addTMTextUnit(
+            tm.getId(),
+            assetId,
+            "zuora_error_message_verify_state_province",
+            "Please enter a valid state, region or province",
+            "Comment1");
+    addTMTextUnit2 = tmService.addTMTextUnit(tm.getId(), assetId, "TEST2", "Content2", "Comment2");
+    addTMTextUnit3 = tmService.addTMTextUnit(tm.getId(), assetId, "TEST3", "Content3", "Comment3");
+
+    assetExtraction = new AssetExtraction();
+    assetExtraction.setAsset(asset);
+    assetExtraction = assetExtractionRepository.save(assetExtraction);
+
+    createAssetTextUnit1 =
+        assetExtractionService.createAssetTextUnit(
+            assetExtraction,
+            "zuora_error_message_verify_state_province",
+            "Please enter a valid state, region or province",
+            "Comment1");
+    createAssetTextUnit2 =
+        assetExtractionService.createAssetTextUnit(
+            assetExtraction, "TEST2", "Content2", "Comment2");
+
+    assetMappingService.mapAssetTextUnitAndCreateTMTextUnit(
+        assetExtraction.getId(), tm.getId(), assetId, null, PollableTask.INJECT_CURRENT_TASK);
+    assetExtractionService.markAssetExtractionAsLastSuccessful(asset, assetExtraction);
+
+    addCurrentTMTextUnitVariant1KoKR =
+        tmService.addCurrentTMTextUnitVariant(
+            addTMTextUnit1.getId(), koKR.getId(), "올바른 국가, 지역 또는 시/도를 입력하십시오.");
+    addCurrentTMTextUnitVariant1FrFR =
+        tmService.addCurrentTMTextUnitVariant(
+            addTMTextUnit1.getId(),
+            frFR.getId(),
+            "Veuillez indiquer un état, une région ou une province valide.");
+    addCurrentTMTextUnitVariant3FrFR =
+        tmService.addCurrentTMTextUnitVariant(
+            addTMTextUnit3.getId(), frFR.getId(), "Content3 fr-FR");
+    addCurrentTMTextUnitVariant2FrCA =
+        tmService.addCurrentTMTextUnitVariant(
+            addTMTextUnit2.getId(), frCA.getId(), "Content2 fr-CA");
+    addCurrentTMTextUnitVariant3FrCA =
+        tmService.addCurrentTMTextUnitVariant(
+            addTMTextUnit3.getId(), frCA.getId(), "Content3 fr-CA");
+  }
+
+  @Transactional
+  public void addTextUnit(String name, String content, String comment) {
+    tmService.addTMTextUnit(tm.getId(), asset.getId(), name, content, comment);
+    assetExtractionService.createAssetTextUnit(assetExtraction, name, content, comment);
+    assetMappingService.mapAssetTextUnitAndCreateTMTextUnit(
+        assetExtraction.getId(), tm.getId(), asset.getId(), null, PollableTask.INJECT_CURRENT_TASK);
+    assetExtractionService.markAssetExtractionAsLastSuccessful(asset, assetExtraction);
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -186,15 +186,6 @@ public class DropTestData {
             addTMTextUnit3.getId(), frCA.getId(), "Content3 fr-CA");
   }
 
-  @Transactional
-  public void addTextUnit(String name, String content, String comment) {
-    tmService.addTMTextUnit(tm.getId(), asset.getId(), name, content, comment);
-    assetExtractionService.createAssetTextUnit(assetExtraction, name, content, comment);
-    assetMappingService.mapAssetTextUnitAndCreateTMTextUnit(
-        assetExtraction.getId(), tm.getId(), asset.getId(), null, PollableTask.INJECT_CURRENT_TASK);
-    assetExtractionService.markAssetExtractionAsLastSuccessful(asset, assetExtraction);
-  }
-
   public List<TextUnitDTO> getTextUnitsForStatus(StatusFilter statusFilter) {
     TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
     textUnitSearcherParameters.setRepositoryIds(repository.getId());

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -1,15 +1,7 @@
 package com.box.l10n.mojito.service.drop;
 
-import com.box.l10n.mojito.entity.Asset;
-import com.box.l10n.mojito.entity.AssetExtraction;
-import com.box.l10n.mojito.entity.AssetTextUnit;
+import com.box.l10n.mojito.entity.*;
 import com.box.l10n.mojito.entity.Locale;
-import com.box.l10n.mojito.entity.PollableTask;
-import com.box.l10n.mojito.entity.Repository;
-import com.box.l10n.mojito.entity.RepositoryLocale;
-import com.box.l10n.mojito.entity.TM;
-import com.box.l10n.mojito.entity.TMTextUnit;
-import com.box.l10n.mojito.entity.TMTextUnitVariant;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
@@ -17,13 +9,10 @@ import com.box.l10n.mojito.service.assetExtraction.AssetMappingService;
 import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
-import com.box.l10n.mojito.service.tm.TMRepository;
 import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.search.*;
 import com.box.l10n.mojito.test.TestIdWatcher;
-import jakarta.annotation.PostConstruct;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +29,6 @@ public class DropTestData {
   static Logger logger = LoggerFactory.getLogger(DropTestData.class);
 
   @Autowired TMService tmService;
-
-  @Autowired TMRepository tmRepository;
 
   @Autowired LocaleService localeService;
 
@@ -61,132 +48,128 @@ public class DropTestData {
 
   public Repository repository;
   public TM tm;
-  public TMTextUnit addTMTextUnit1;
-  public TMTextUnit addTMTextUnit2;
-  public TMTextUnit addTMTextUnit3;
-  public AssetTextUnit createAssetTextUnit1;
-  public AssetTextUnit createAssetTextUnit2;
   public Asset asset;
   public AssetExtraction assetExtraction;
-  public TMTextUnitVariant addCurrentTMTextUnitVariant1KoKR;
-  public TMTextUnitVariant addCurrentTMTextUnitVariant1FrFR;
-  public TMTextUnitVariant addCurrentTMTextUnitVariant3FrFR;
-  public TMTextUnitVariant addCurrentTMTextUnitVariant2FrCA;
-  public TMTextUnitVariant addCurrentTMTextUnitVariant3FrCA;
-  public Locale koKR;
-  public Locale frFR;
-  public Locale frCA;
-  public Locale jaJP;
-  public Locale en;
-  public RepositoryLocale repoLocaleFrFR;
-  public RepositoryLocale repoLocaleKoKR;
+  public List<Locale> locales;
+  public Map<String, TMTextUnit> tmTextUnits;
+  public Map<Locale, Map<String, TMTextUnitVariant>> addCurrentTMTextUnitVariants;
 
   TestIdWatcher testIdWatcher;
-  public final List<String> bcp47Tags;
 
-  public DropTestData(TestIdWatcher testIdWatcher, List<String> bcp47Tags) {
+  public DropTestData(TestIdWatcher testIdWatcher) {
     this.testIdWatcher = testIdWatcher;
-    this.bcp47Tags = Collections.unmodifiableList(bcp47Tags);
   }
 
-  @PostConstruct
   @Transactional
-  private void createData() throws Exception {
+  public static DropTestData createWithDefaultData(TestIdWatcher testIdWatcher) throws Exception {
+    var data = new DropTestData(testIdWatcher);
+    data.createRepository();
+    for (var localeTag : List.of("ko-KR", "fr-FR", "fr-CA", "ja-JP")) {
+      data.addLocale(localeTag);
+    }
+    data.setLocaleMapping("fr-FR", "fr-CA", false);
 
-    logger.debug("Create data set tot test searches");
-
-    en = localeService.findByBcp47Tag("en");
-    koKR = localeService.findByBcp47Tag("ko-KR");
-    frFR = localeService.findByBcp47Tag("fr-FR");
-    frCA = localeService.findByBcp47Tag("fr-CA");
-    jaJP = localeService.findByBcp47Tag("ja-JP");
-
-    // This is to make sure data from other TM don't have side effects
-    Repository otherRepository =
-        repositoryService.createRepository(testIdWatcher.getEntityName("other-repository"));
-
-    TM otherTM = tmRepository.save(new TM());
-    Asset otherAsset =
-        assetService.createAssetWithContent(
-            otherRepository.getId(), "fake_for_test", "fake for test other tm repo");
-    TMTextUnit addTMTextUnitOther =
-        tmService.addTMTextUnit(
-            otherTM.getId(), otherAsset.getId(), "TEST1", "Content1", "Comment1");
-
-    AssetExtraction assetExtractionOther = assetExtractionRepository.save(new AssetExtraction());
-    AssetTextUnit createAssetTextUnitOther =
-        assetExtractionService.createAssetTextUnit(
-            assetExtractionOther, "TEST2", "Content2", "Comment2");
-
-    // This is the actual data that should be proccessed
-    repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
-    repoLocaleKoKR = repositoryService.addRepositoryLocale(repository, koKR.getBcp47Tag());
-    repoLocaleFrFR = repositoryService.addRepositoryLocale(repository, frFR.getBcp47Tag());
-    repositoryService.addRepositoryLocale(repository, frCA.getBcp47Tag());
-    repositoryService.addRepositoryLocale(repository, jaJP.getBcp47Tag());
-
-    RepositoryLocale parentLocale =
-        repositoryLocaleRepository.findByRepositoryAndLocale(repository, frFR);
-    RepositoryLocale childLocale =
-        repositoryLocaleRepository.findByRepositoryAndLocale(repository, frCA);
-    childLocale.setParentLocale(parentLocale);
-    childLocale.setToBeFullyTranslated(false);
-    repositoryLocaleRepository.save(childLocale);
-
-    tm = repository.getTm();
-
-    asset =
-        assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
-    Long assetId = asset.getId();
-
-    addTMTextUnit1 =
-        tmService.addTMTextUnit(
-            tm.getId(),
-            assetId,
+    data.createUnits(
+        new TextUnitDefinition(
             "zuora_error_message_verify_state_province",
             "Please enter a valid state, region or province",
-            "Comment1");
-    addTMTextUnit2 = tmService.addTMTextUnit(tm.getId(), assetId, "TEST2", "Content2", "Comment2");
-    addTMTextUnit3 = tmService.addTMTextUnit(tm.getId(), assetId, "TEST3", "Content3", "Comment3");
+            "Comment1"),
+        new TextUnitDefinition("TEST2", "Content2", "Comment2"));
+    data.createTranslations(
+        "ko-KR",
+        new TranslationDefinition(
+            "zuora_error_message_verify_state_province", "올바른 국가, 지역 또는 시/도를 입력하십시오."));
+    data.createTranslations(
+        "fr-FR",
+        new TranslationDefinition(
+            "zuora_error_message_verify_state_province",
+            "Veuillez indiquer un état, une région ou une province valide."));
+    data.createTranslations("fr-CA", new TranslationDefinition("TEST2", "Content2 fr-CA"));
+    return data;
+  }
 
+  public Locale findLocaleForTag(String bcp47Tag) {
+    return localeService.findByBcp47Tag(bcp47Tag);
+  }
+
+  public List<String> getLocaleTags() {
+    return locales.stream().map(Locale::getBcp47Tag).toList();
+  }
+
+  @Transactional
+  public void createRepository() throws Exception {
+    repository = repositoryService.createRepository(testIdWatcher.getEntityName("repository"));
+    tm = repository.getTm();
+    locales = new ArrayList<>();
+  }
+
+  @Transactional
+  public void addLocale(String localeTag) throws Exception {
+    var locale = findLocaleForTag(localeTag);
+    repositoryService.addRepositoryLocale(repository, locale.getBcp47Tag());
+    locales.add(locale);
+  }
+
+  @Transactional
+  public void setLocaleMapping(
+      String parentLocaleTag, String childLocaleTag, boolean toBeFullyTranslated) {
+    RepositoryLocale parentLocale =
+        repositoryLocaleRepository.findByRepositoryAndLocale(
+            repository, findLocaleForTag(parentLocaleTag));
+    RepositoryLocale childLocale =
+        repositoryLocaleRepository.findByRepositoryAndLocale(
+            repository, findLocaleForTag(childLocaleTag));
+    childLocale.setParentLocale(parentLocale);
+    childLocale.setToBeFullyTranslated(toBeFullyTranslated);
+    repositoryLocaleRepository.save(childLocale);
+  }
+
+  @Transactional
+  public void createUnits(TextUnitDefinition... textUnits) {
+    asset =
+        assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
     assetExtraction = new AssetExtraction();
     assetExtraction.setAsset(asset);
     assetExtraction = assetExtractionRepository.save(assetExtraction);
 
-    createAssetTextUnit1 =
-        assetExtractionService.createAssetTextUnit(
-            assetExtraction,
-            "zuora_error_message_verify_state_province",
-            "Please enter a valid state, region or province",
-            "Comment1");
-    createAssetTextUnit2 =
-        assetExtractionService.createAssetTextUnit(
-            assetExtraction, "TEST2", "Content2", "Comment2");
+    tmTextUnits = new HashMap<>();
+    for (TextUnitDefinition textUnit : textUnits) {
+      var tmTextUnit =
+          tmService.addTMTextUnit(
+              tm.getId(), asset.getId(), textUnit.name, textUnit.content, textUnit.comment);
+      tmTextUnits.put(textUnit.name, tmTextUnit);
+
+      var assetTextUnit =
+          assetExtractionService.createAssetTextUnit(
+              assetExtraction, textUnit.name, textUnit.content, textUnit.comment);
+    }
 
     assetMappingService.mapAssetTextUnitAndCreateTMTextUnit(
-        assetExtraction.getId(), tm.getId(), assetId, null, PollableTask.INJECT_CURRENT_TASK);
+        assetExtraction.getId(), tm.getId(), asset.getId(), null, PollableTask.INJECT_CURRENT_TASK);
     assetExtractionService.markAssetExtractionAsLastSuccessful(asset, assetExtraction);
-
-    addCurrentTMTextUnitVariant1KoKR =
-        tmService.addCurrentTMTextUnitVariant(
-            addTMTextUnit1.getId(), koKR.getId(), "올바른 국가, 지역 또는 시/도를 입력하십시오.");
-    addCurrentTMTextUnitVariant1FrFR =
-        tmService.addCurrentTMTextUnitVariant(
-            addTMTextUnit1.getId(),
-            frFR.getId(),
-            "Veuillez indiquer un état, une région ou une province valide.");
-    addCurrentTMTextUnitVariant3FrFR =
-        tmService.addCurrentTMTextUnitVariant(
-            addTMTextUnit3.getId(), frFR.getId(), "Content3 fr-FR");
-    addCurrentTMTextUnitVariant2FrCA =
-        tmService.addCurrentTMTextUnitVariant(
-            addTMTextUnit2.getId(), frCA.getId(), "Content2 fr-CA");
-    addCurrentTMTextUnitVariant3FrCA =
-        tmService.addCurrentTMTextUnitVariant(
-            addTMTextUnit3.getId(), frCA.getId(), "Content3 fr-CA");
   }
 
-  public List<TextUnitDTO> getTextUnitsForStatus(StatusFilter statusFilter) {
+  @Transactional
+  public void createTranslations(String localeTag, TranslationDefinition... translations) {
+    var locale = findLocaleForTag(localeTag);
+    if (Objects.isNull(addCurrentTMTextUnitVariants)) {
+      addCurrentTMTextUnitVariants = new HashMap<>();
+    }
+
+    addCurrentTMTextUnitVariants.putIfAbsent(locale, new HashMap<>());
+    var variantsForLocale = addCurrentTMTextUnitVariants.get(locale);
+
+    for (TranslationDefinition translation : translations) {
+      var tmTextUnit = tmTextUnits.get(translation.name);
+      variantsForLocale.put(
+          translation.name,
+          tmService.addCurrentTMTextUnitVariant(
+              tmTextUnit.getId(), locale.getId(), translation.content));
+    }
+  }
+
+  public List<TextUnitDTO> getTextUnitsForStatus(
+      StatusFilter statusFilter, List<String> bcp47Tags) {
     TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
     textUnitSearcherParameters.setRepositoryIds(repository.getId());
     textUnitSearcherParameters.setStatusFilter(statusFilter);
@@ -196,10 +179,32 @@ public class DropTestData {
     return textUnitSearcher.search(textUnitSearcherParameters);
   }
 
-  public ExportDropConfig getExportDropConfig() {
+  public ExportDropConfig getExportDropConfig(List<String> bcp47Tags) {
     ExportDropConfig exportDropConfig = new ExportDropConfig();
     exportDropConfig.setRepositoryId(repository.getId());
     exportDropConfig.setBcp47Tags(bcp47Tags);
     return exportDropConfig;
+  }
+
+  public static class TextUnitDefinition {
+    public String name;
+    public String content;
+    public String comment;
+
+    public TextUnitDefinition(String name, String content, String comment) {
+      this.name = name;
+      this.content = content;
+      this.comment = comment;
+    }
+  }
+
+  public static class TranslationDefinition {
+    public String name;
+    public String content;
+
+    public TranslationDefinition(String name, String content) {
+      this.name = name;
+      this.content = content;
+    }
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -15,13 +15,14 @@ import com.box.l10n.mojito.service.assetExtraction.AssetExtractionRepository;
 import com.box.l10n.mojito.service.assetExtraction.AssetExtractionService;
 import com.box.l10n.mojito.service.assetExtraction.AssetMappingService;
 import com.box.l10n.mojito.service.locale.LocaleService;
-import com.box.l10n.mojito.service.pluralform.PluralFormService;
 import com.box.l10n.mojito.service.repository.RepositoryLocaleRepository;
 import com.box.l10n.mojito.service.repository.RepositoryService;
 import com.box.l10n.mojito.service.tm.TMRepository;
 import com.box.l10n.mojito.service.tm.TMService;
+import com.box.l10n.mojito.service.tm.search.*;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +56,7 @@ public class DropTestData {
 
   @Autowired RepositoryLocaleRepository repositoryLocaleRepository;
 
-  @Autowired PluralFormService pluralFormService;
+  @Autowired TextUnitSearcher textUnitSearcher;
 
   public Repository repository;
   public TM tm;
@@ -189,5 +190,16 @@ public class DropTestData {
     assetMappingService.mapAssetTextUnitAndCreateTMTextUnit(
         assetExtraction.getId(), tm.getId(), asset.getId(), null, PollableTask.INJECT_CURRENT_TASK);
     assetExtractionService.markAssetExtractionAsLastSuccessful(asset, assetExtraction);
+  }
+
+  public List<TextUnitDTO> getTextUnitsForStatus(
+      List<String> bcp47Tags, StatusFilter statusFilter) {
+    TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
+    textUnitSearcherParameters.setRepositoryIds(repository.getId());
+    textUnitSearcherParameters.setStatusFilter(statusFilter);
+    textUnitSearcherParameters.setUsedFilter(UsedFilter.USED);
+    textUnitSearcherParameters.setLocaleTags(bcp47Tags);
+
+    return textUnitSearcher.search(textUnitSearcherParameters);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -22,6 +22,7 @@ import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.search.*;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import jakarta.annotation.PostConstruct;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,9 +82,11 @@ public class DropTestData {
   public RepositoryLocale repoLocaleKoKR;
 
   TestIdWatcher testIdWatcher;
+  public final List<String> bcp47Tags;
 
-  public DropTestData(TestIdWatcher testIdWatcher) {
+  public DropTestData(TestIdWatcher testIdWatcher, List<String> bcp47Tags) {
     this.testIdWatcher = testIdWatcher;
+    this.bcp47Tags = Collections.unmodifiableList(bcp47Tags);
   }
 
   @PostConstruct
@@ -192,8 +195,7 @@ public class DropTestData {
     assetExtractionService.markAssetExtractionAsLastSuccessful(asset, assetExtraction);
   }
 
-  public List<TextUnitDTO> getTextUnitsForStatus(
-      List<String> bcp47Tags, StatusFilter statusFilter) {
+  public List<TextUnitDTO> getTextUnitsForStatus(StatusFilter statusFilter) {
     TextUnitSearcherParameters textUnitSearcherParameters = new TextUnitSearcherParameters();
     textUnitSearcherParameters.setRepositoryIds(repository.getId());
     textUnitSearcherParameters.setStatusFilter(statusFilter);


### PR DESCRIPTION
This PR partially refactors `DropServiceTest` suite and adds new test data setup to decouple it from `TMTestData`.  This is needed to later test handling of large drops (by adding code to generate test data with arbitrary amount of strings).

Old way:

`TMTestData` contained test data setup which was heavily coupled with existing tests in `TMServiceTest`. Specifically, it was holding properties with explicit references to text unit (source) and text unit variant (translation) objects (like `tmTestData.createAssetTextUnit1` and `tmTestData.addCurrentTMTextUnitVariant1FrFR`). It was not possible to add more translation units to this data without impacting tests both in  `DropServiceTest` and `TMServiceTest`.

New way:

This PR adds new class for test data generation `DropTestData`. Its inner logic is based on that of the old `TMTestData`, but it's compartmentalized into explicit methods for source and translation strings creation, which can be used for arbitrary test data setup. Explicit properties referencing created text unit and text unit variant objects (which are also required for some of the existing tests' setup and assertions) are now replaced with maps keyed by string ID (`tmTextUnits`) and translation locale (`addCurrentTMTextUnitVariants`).

Test dataset from `TMTestData` is unchanged to limit the scope of this refactoring task (due to some test assertions relying on its particular contents, like `DropServiceTest#checkImportedFilesContent`) - but it is now wrapped into a static factory method `DropTestData#createWithDefaultData`.