### PR TITLE
Fix unexpected document end when importing drops with large XLIFF files

### DIFF
--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/DocumentIntegrityCheckStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/DocumentIntegrityCheckStep.java
@@ -1,0 +1,63 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import com.google.common.io.CharStreams;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+import net.sf.okapi.common.Event;
+import net.sf.okapi.common.pipeline.BasePipelineStep;
+import net.sf.okapi.common.resource.RawDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+
+/**
+ * @author aloison
+ */
+@Configurable
+public class DocumentIntegrityCheckStep extends BasePipelineStep {
+
+  /** Logger */
+  static Logger logger = LoggerFactory.getLogger(DocumentIntegrityCheckStep.class);
+
+  @Autowired IntegrityCheckerFactory integrityCheckerFactory;
+
+  @Override
+  public String getName() {
+    return "Document Integrity Check";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Runs document-level integrity checks to make sure a document is valid."
+        + " When an issue is detected, it will throw an IntegrityCheckException."
+        + " Expects: raw document. Sends back: raw document.";
+  }
+
+  @Override
+  protected Event handleRawDocument(Event event) {
+    logger.debug("Check integrity of document");
+    RawDocument document = event.getRawDocument();
+
+    String documentContent;
+    try {
+      Reader reader = document.getReader();
+      documentContent = CharStreams.toString(reader);
+      // CharStreams#toString does not close the readable implicitly
+      reader.close();
+    } catch (IOException e) {
+      logger.error("Error reading document content", e);
+      throw new RuntimeException("Error reading document content", e);
+    }
+
+    // TODO(P1): do not hardcode the type here
+    List<DocumentIntegrityChecker> documentIntegrityCheckers =
+        integrityCheckerFactory.getDocumentCheckers("xliff");
+    for (DocumentIntegrityChecker checker : documentIntegrityCheckers) {
+      checker.check(documentContent);
+    }
+
+    return super.handleRawDocument(event);
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/TextUnitIntegrityCheckStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/TextUnitIntegrityCheckStep.java
@@ -4,10 +4,7 @@ import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.entity.TMTextUnit;
 import com.box.l10n.mojito.entity.TMTextUnitVariantComment;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
-import com.google.common.io.CharStreams;
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import net.sf.okapi.common.Event;
@@ -16,7 +13,6 @@ import net.sf.okapi.common.pipeline.BasePipelineStep;
 import net.sf.okapi.common.pipeline.annotations.StepParameterMapping;
 import net.sf.okapi.common.pipeline.annotations.StepParameterType;
 import net.sf.okapi.common.resource.ITextUnit;
-import net.sf.okapi.common.resource.RawDocument;
 import net.sf.okapi.common.resource.TextContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,10 +23,10 @@ import org.springframework.beans.factory.annotation.Configurable;
  * @author aloison
  */
 @Configurable
-public class IntegrityCheckStep extends BasePipelineStep {
+public class TextUnitIntegrityCheckStep extends BasePipelineStep {
 
   /** Logger */
-  static Logger logger = LoggerFactory.getLogger(IntegrityCheckStep.class);
+  static Logger logger = LoggerFactory.getLogger(TextUnitIntegrityCheckStep.class);
 
   @Autowired TMTextUnitRepository tmTextUnitRepository;
 
@@ -39,7 +35,6 @@ public class IntegrityCheckStep extends BasePipelineStep {
   Map<Long, Set<TextUnitIntegrityChecker>> textUnitIntegrityCheckerMap = new HashMap<>();
 
   private LocaleId targetLocale;
-  private RawDocument rawDocument;
 
   @SuppressWarnings("deprecation")
   @StepParameterMapping(parameterType = StepParameterType.TARGET_LOCALE)
@@ -47,42 +42,15 @@ public class IntegrityCheckStep extends BasePipelineStep {
     this.targetLocale = targetLocale;
   }
 
-  @StepParameterMapping(parameterType = StepParameterType.INPUT_RAWDOC)
-  public void setInputDocument(RawDocument rawDocument) {
-    this.rawDocument = rawDocument;
-  }
-
   @Override
   public String getName() {
-    return "Integrity Check";
+    return "Text Unit Integrity Check";
   }
 
   @Override
   public String getDescription() {
     return "Updates the TM with the extracted new/changed variants."
-        + " Expects: raw document. Sends back: original events.";
-  }
-
-  @Override
-  protected Event handleStartDocument(Event event) {
-    logger.debug("Check integrity of document");
-
-    String documentContent = null;
-    try {
-      documentContent = CharStreams.toString(rawDocument.getReader());
-    } catch (IOException e) {
-      logger.error("Error reading document content", e);
-      throw new RuntimeException("Error reading document content", e);
-    }
-
-    // TODO(P1): do not hardcode the type here
-    List<DocumentIntegrityChecker> documentIntegrityCheckers =
-        integrityCheckerFactory.getDocumentCheckers("xliff");
-    for (DocumentIntegrityChecker checker : documentIntegrityCheckers) {
-      checker.check(documentContent);
-    }
-
-    return super.handleStartDocument(event);
+        + " Expects: Text unit events. Sends back: original events.";
   }
 
   @Override

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -47,7 +47,8 @@ import com.box.l10n.mojito.retry.DataIntegrityViolationExceptionRetryTemplate;
 import com.box.l10n.mojito.security.AuditorAwareImpl;
 import com.box.l10n.mojito.service.WordCountService;
 import com.box.l10n.mojito.service.asset.AssetRepository;
-import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.IntegrityCheckStep;
+import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.DocumentIntegrityCheckStep;
+import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.TextUnitIntegrityCheckStep;
 import com.box.l10n.mojito.service.locale.LocaleService;
 import com.box.l10n.mojito.service.pollableTask.InjectCurrentTask;
 import com.box.l10n.mojito.service.pollableTask.Pollable;
@@ -887,11 +888,14 @@ public class TMService {
     logger.debug("Configuring pipeline for localized XLIFF processing");
 
     IPipelineDriver driver = new PipelineDriver();
+
+    driver.addStep(new DocumentIntegrityCheckStep());
+
     driver.addStep(new RawDocumentToFilterEventsStep(new XLIFFFilter()));
 
+    driver.addStep(new TextUnitIntegrityCheckStep());
+
     driver.addStep(getConfiguredQualityStep());
-    IntegrityCheckStep integrityCheckStep = new IntegrityCheckStep();
-    driver.addStep(integrityCheckStep);
 
     abstractImportTranslationsStep.setImportWithStatus(importStatus);
     driver.addStep(abstractImportTranslationsStep);

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropServiceTest.java
@@ -257,6 +257,36 @@ public class DropServiceTest extends ServiceTestBase {
   }
 
   @Test
+  public void forTranslationLargeXliffFile() throws Exception {
+    List<String> locales = List.of("fr-FR");
+    int unitCount = 100;
+
+    DropTestData dropTestData =
+        DropTestData.createWithGeneratedUnits(testIdWatcher, locales, unitCount);
+
+    ExportDropConfig exportDropConfig = dropTestData.getExportDropConfig(locales);
+
+    logger.debug("Check inital number of untranslated units");
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, locales.size() * unitCount);
+
+    logger.debug("Create an initial drop for the repository");
+    Drop drop =
+        awaitPollableProcess(
+                dropService.startDropExportProcess(
+                    exportDropConfig, PollableTask.INJECT_CURRENT_TASK))
+            .get();
+
+    localizeDropFiles(drop, 1);
+
+    logger.debug("Import drop");
+    awaitPollableProcess(
+        dropService.importDrop(drop.getId(), null, PollableTask.INJECT_CURRENT_TASK));
+
+    logger.debug("Check everything is now translated");
+    checkNumberOfUntranslatedTextUnit(dropTestData, locales, 0);
+  }
+
+  @Test
   public void forReview() throws Exception {
     List<String> locales = List.of("fr-FR", "ko-KR", "ja-JP");
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/drop/DropTestData.java
@@ -13,6 +13,7 @@ import com.box.l10n.mojito.service.tm.TMService;
 import com.box.l10n.mojito.service.tm.search.*;
 import com.box.l10n.mojito.test.TestIdWatcher;
 import java.util.*;
+import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,21 +71,46 @@ public class DropTestData {
     data.setLocaleMapping("fr-FR", "fr-CA", false);
 
     data.createUnits(
-        new TextUnitDefinition(
-            "zuora_error_message_verify_state_province",
-            "Please enter a valid state, region or province",
-            "Comment1"),
-        new TextUnitDefinition("TEST2", "Content2", "Comment2"));
+        List.of(
+            new TextUnitDefinition(
+                "zuora_error_message_verify_state_province",
+                "Please enter a valid state, region or province",
+                "Comment1"),
+            new TextUnitDefinition("TEST2", "Content2", "Comment2")));
     data.createTranslations(
         "ko-KR",
-        new TranslationDefinition(
-            "zuora_error_message_verify_state_province", "올바른 국가, 지역 또는 시/도를 입력하십시오."));
+        List.of(
+            new TranslationDefinition(
+                "zuora_error_message_verify_state_province", "올바른 국가, 지역 또는 시/도를 입력하십시오.")));
     data.createTranslations(
         "fr-FR",
-        new TranslationDefinition(
-            "zuora_error_message_verify_state_province",
-            "Veuillez indiquer un état, une région ou une province valide."));
-    data.createTranslations("fr-CA", new TranslationDefinition("TEST2", "Content2 fr-CA"));
+        List.of(
+            new TranslationDefinition(
+                "zuora_error_message_verify_state_province",
+                "Veuillez indiquer un état, une région ou une province valide.")));
+    data.createTranslations("fr-CA", List.of(new TranslationDefinition("TEST2", "Content2 fr-CA")));
+    return data;
+  }
+
+  @Transactional
+  public static DropTestData createWithGeneratedUnits(
+      TestIdWatcher testIdWatcher, List<String> locales, int unitCount) throws Exception {
+    var data = new DropTestData(testIdWatcher);
+    data.createRepository();
+    for (var localeTag : locales) {
+      data.addLocale(localeTag);
+    }
+
+    data.createUnits(
+        IntStream.range(0, unitCount)
+            .mapToObj(
+                i ->
+                    new TextUnitDefinition(
+                        String.format("generated_unit_id_%,d", i),
+                        String.format("Content of generated unit %,d", i),
+                        String.format("Comment for generated unit %,d", i)))
+            .toList());
+
     return data;
   }
 
@@ -125,7 +151,7 @@ public class DropTestData {
   }
 
   @Transactional
-  public void createUnits(TextUnitDefinition... textUnits) {
+  public void createUnits(Collection<TextUnitDefinition> textUnits) {
     asset =
         assetService.createAssetWithContent(repository.getId(), "fake_for_test", "fake for test");
     assetExtraction = new AssetExtraction();
@@ -150,7 +176,7 @@ public class DropTestData {
   }
 
   @Transactional
-  public void createTranslations(String localeTag, TranslationDefinition... translations) {
+  public void createTranslations(String localeTag, Collection<TranslationDefinition> translations) {
     var locale = findLocaleForTag(localeTag);
     if (Objects.isNull(addCurrentTMTextUnitVariants)) {
       addCurrentTMTextUnitVariants = new HashMap<>();


### PR DESCRIPTION
This PR fixes the following error:

```log
com.box.l10n.mojito.service.drop.importdropexception: com.ctc.wstx.exc.wstxeofexception: unexpected eof; was expecting a close tag for element <note>
 at [row,col,system-id]: [128,206,"/some/file/path/to/be/read/from/db"]
```

which would occur when importing a drop containing XLIFF files larger than 8 KiB. On the UI side, this would appear as `Import Failed` in the `Project Requests` page, and would result in a partial import (translations for strings before the 8KiB mark would be imported correctly).

---

<details>

<summary>Click here to see the full stack trace</summary>

```log
2026-01-29t07:42:26.609-08:00 debug 97 --- [ pollabletask-5] c.b.l.mojito.service.drop.dropservice    : error when importing file, keep importing other files

com.box.l10n.mojito.service.drop.importdropexception: com.ctc.wstx.exc.wstxeofexception: unexpected eof; was expecting a close tag for element <note>
 at [row,col,system-id]: [128,206,"/some/file/path/to/be/read/from/db"]
	at com.box.l10n.mojito.service.drop.dropservice.updatetmwithlocalizedxliff_aroundbody10(dropservice.java:341)
	at com.box.l10n.mojito.service.drop.dropservice$ajcclosure11.run(dropservice.java:1)
	at org.aspectj.runtime.reflect.joinpointimpl.proceed(joinpointimpl.java:270)
	at com.box.l10n.mojito.service.pollabletask.pollablecallable.call(pollablecallable.java:50)
	at java.base/java.util.concurrent.futuretask.run(futuretask.java:317)
	at com.box.l10n.mojito.service.pollabletask.pollableaspect.syncexecute(pollableaspect.java:111)
	at com.box.l10n.mojito.service.pollabletask.pollableaspect.ajc$inlineaccessmethod$com_box_l10n_mojito_service_pollabletask_pollableaspect$com_box_l10n_mojito_service_pollabletask_pollableaspect$syncexecute(pollableaspect.java:1)
	at com.box.l10n.mojito.service.pollabletask.pollableaspect.createpollablewrapper(pollableaspect.java:79)
	at com.box.l10n.mojito.service.drop.dropservice.updatetmwithlocalizedxliff(dropservice.java:331)
	at com.box.l10n.mojito.service.drop.dropservice.importfile_aroundbody8(dropservice.java:313)
	at com.box.l10n.mojito.service.drop.dropservice$ajcclosure9.run(dropservice.java:1)
	at org.aspectj.runtime.reflect.joinpointimpl.proceed(joinpointimpl.java:270)
	at com.box.l10n.mojito.service.pollabletask.pollablecallable.call(pollablecallable.java:50)
	at java.base/java.util.concurrent.futuretask.run(futuretask.java:317)
	at com.box.l10n.mojito.service.pollabletask.pollableaspect.syncexecute(pollableaspect.java:111)
	at com.box.l10n.mojito.service.pollabletask.pollableaspect.ajc$inlineaccessmethod$com_box_l10n_mojito_service_pollabletask_pollableaspect$com_box_l10n_mojito_service_pollabletask_pollableaspect$syncexecute(pollableaspect.java:1)
	at com.box.l10n.mojito.service.pollabletask.pollableaspect.createpollablewrapper(pollableaspect.java:79)
	at com.box.l10n.mojito.service.drop.dropservice.importfile(dropservice.java:301)
	at com.box.l10n.mojito.service.drop.dropservice.importdrop_aroundbody6(dropservice.java:256)
	at com.box.l10n.mojito.service.drop.dropservice$ajcclosure7.run(dropservice.java:1)
	at org.aspectj.runtime.reflect.joinpointimpl.proceed(joinpointimpl.java:270)
	at com.box.l10n.mojito.service.pollabletask.pollablecallable.call(pollablecallable.java:50)
	at java.base/java.util.concurrent.futuretask.run(futuretask.java:317)
	at org.springframework.security.concurrent.delegatingsecuritycontextrunnable.run(delegatingsecuritycontextrunnable.java:94)
	at java.base/java.util.concurrent.executors$runnableadapter.call(executors.java:572)
	at java.base/java.util.concurrent.futuretask.run(futuretask.java:317)
	at java.base/java.util.concurrent.threadpoolexecutor.runworker(threadpoolexecutor.java:1144)
	at java.base/java.util.concurrent.threadpoolexecutor$worker.run(threadpoolexecutor.java:642)
	at java.base/java.lang.thread.run(thread.java:1583)
caused by: net.sf.okapi.common.exceptions.okapiioexception: com.ctc.wstx.exc.wstxeofexception: unexpected eof; was expecting a close tag for element <note>
 at [row,col,system-id]: [128,206,"/some/file/path/to/be/read/from/db"]
	at net.sf.okapi.filters.xliff.xlifffilter.processnote(xlifffilter.java:3671)
	at net.sf.okapi.filters.xliff.xlifffilter.processtransunit(xlifffilter.java:1688)
	at net.sf.okapi.filters.xliff.xlifffilter.read(xlifffilter.java:643)
	at net.sf.okapi.filters.xliff.xlifffilter.next(xlifffilter.java:360)
	at net.sf.okapi.steps.common.rawdocumenttofiltereventsstep.handleevent(rawdocumenttofiltereventsstep.java:166)
	at net.sf.okapi.common.pipeline.pipeline.execute(pipeline.java:117)
	at net.sf.okapi.common.pipeline.pipeline.process(pipeline.java:227)
	at net.sf.okapi.common.pipeline.pipeline.process(pipeline.java:199)
	at net.sf.okapi.common.pipelinedriver.pipelinedriver.processbatch(pipelinedriver.java:182)
	at com.box.l10n.mojito.service.tm.tmservice.updatetmwithxliff(tmservice.java:921)
	at com.box.l10n.mojito.service.tm.tmservice.updatetmwithtranslationkitxliff(tmservice.java:840)
	at com.box.l10n.mojito.service.drop.dropservice.updatetmwithlocalizedxliff_aroundbody10(dropservice.java:338)
	... 28 common frames omitted
caused by: com.ctc.wstx.exc.wstxeofexception: unexpected eof; was expecting a close tag for element <note>
 at [row,col,system-id]: [128,206,"/some/file/path/to/be/read/from/db"]
	at com.ctc.wstx.sr.streamscanner.throwunexpectedeof(streamscanner.java:701)
	at com.ctc.wstx.sr.basicstreamreader.throwunexpectedeof(basicstreamreader.java:5612)
	at com.ctc.wstx.sr.basicstreamreader.nextfromtree(basicstreamreader.java:2811)
	at com.ctc.wstx.sr.basicstreamreader.next(basicstreamreader.java:1122)
	at net.sf.okapi.filters.xliff.xlifffilter.processnote(xlifffilter.java:3642)
	... 39 common frames omitted

2026-01-29t07:42:26.610-08:00 debug 97 --- [ pollabletask-5] c.b.l.m.boxsdk.boxapiconnectionprovider  : getting box api connection
2026-01-29t07:42:27.110-08:00 debug 97 --- [ pollabletask-5] c.b.l.m.s.p.pollabletaskexceptionutils   : error happened during task execution

com.box.l10n.mojito.service.drop.importdropexception: number of files not imported: 1, check sub task for more information
	at com.box.l10n.mojito.service.drop.dropservice.importdrop_aroundbody6(dropservice.java:271)
	at com.box.l10n.mojito.service.drop.dropservice$ajcclosure7.run(dropservice.java:1)
	at org.aspectj.runtime.reflect.joinpointimpl.proceed(joinpointimpl.java:270)
	at com.box.l10n.mojito.service.pollabletask.pollablecallable.call(pollablecallable.java:50)
	at java.base/java.util.concurrent.futuretask.run(futuretask.java:317)
	at org.springframework.security.concurrent.delegatingsecuritycontextrunnable.run(delegatingsecuritycontextrunnable.java:94)
	at java.base/java.util.concurrent.executors$runnableadapter.call(executors.java:572)
	at java.base/java.util.concurrent.futuretask.run(futuretask.java:317)
	at java.base/java.util.concurrent.threadpoolexecutor.runworker(threadpoolexecutor.java:1144)
	at java.base/java.util.concurrent.threadpoolexecutor$worker.run(threadpoolexecutor.java:642)
	at java.base/java.lang.thread.run(thread.java:1583)
```

</details>

---

Note that the logged error position [128,206] was exacly 8192 characters. Additionally, this happens regardless of selected DropExporter (i.e. this is not caused by Box SDK failing to provide document content).

The root cause was one step in the Okapi pipeline (`IntegrityCheckStep`) advanding the underlying document stream to the end, while another step (`RawDocumentToFilterEventsStep` with `XLIFFFIlter`) was in the middle of parsing it. This issue was introduced in #731 which changed the method to retrieve content of the whole document from `RawDocument#getCharSequence` to `RawDocument#getReader`. According to the findings described in https://github.com/box/mojito/pull/1049#issuecomment-3854615251, it seems like it's only allowed to access the reader/stream within `BasePipelineStep#handleRawDocument`, not later (in any Filter Events handlers).

The fix is tested through new `DropServiceTest#forTranslationLargeXliffFile`.