### PR TITLE
Refactor workaround for Okapi in-memory document handling

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/okapi/RawDocument.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/RawDocument.java
@@ -1,14 +1,8 @@
 package com.box.l10n.mojito.okapi;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.lang.reflect.Field;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 import net.sf.okapi.common.LocaleId;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * When creating {@link RawDocument} from a string the URI is not set and setter is not available.
@@ -29,25 +23,5 @@ public class RawDocument extends net.sf.okapi.common.resource.RawDocument {
         StandardCharsets.UTF_8.name().toLowerCase(),
         sourceLocale,
         targetLocale);
-
-    Field inputURIField = ReflectionUtils.findField(RawDocument.class, "inputURI");
-    ReflectionUtils.makeAccessible(inputURIField);
-
-    try {
-      URI fakeUri = new URI("/some/file/path/to/be/read/from/db");
-      ReflectionUtils.setField(inputURIField, this, fakeUri);
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * Returns a fake output URI to be used where the Okapi class were modify to work with streams
-   * instead of files.
-   *
-   * @return a fake output URI form streams
-   */
-  public static URI getFakeOutputURIForStream() {
-    return new File("fakeOuputURIForStream-" + UUID.randomUUID()).toURI();
   }
 }

--- a/common/src/main/java/com/box/l10n/mojito/okapi/RawDocument.java
+++ b/common/src/main/java/com/box/l10n/mojito/okapi/RawDocument.java
@@ -11,7 +11,7 @@ import net.sf.okapi.common.LocaleId;
  */
 public class RawDocument extends net.sf.okapi.common.resource.RawDocument {
 
-  public static String EMPTY = "";
+  private static final String EMPTY = "";
 
   public RawDocument(CharSequence inputCharSequence, LocaleId sourceLocale) {
     this(inputCharSequence, sourceLocale, LocaleId.EMPTY);
@@ -23,5 +23,15 @@ public class RawDocument extends net.sf.okapi.common.resource.RawDocument {
         StandardCharsets.UTF_8.name().toLowerCase(),
         sourceLocale,
         targetLocale);
+  }
+
+  /**
+   * Creates new instance of an empty in-memory RawDocument that can be fed to the {@link
+   * net.sf.okapi.common.pipelinedriver.PipelineDriver#addBatchItem} when using an {@link
+   * net.sf.okapi.common.filters.IFilter} that generates pipeline events from non-document locations
+   * (e.g. {@link com.box.l10n.mojito.service.tm.TMExportFilter}
+   */
+  public static RawDocument createFakeDocument(LocaleId sourceLocale, LocaleId targetLocale) {
+    return new RawDocument(EMPTY, sourceLocale, targetLocale);
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/qualitycheck/QualityCheckStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/qualitycheck/QualityCheckStep.java
@@ -7,11 +7,13 @@ import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.TMText
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.TMTextUnitVariantCommentAnnotations;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.UUID;
 import net.sf.okapi.common.Event;
 import net.sf.okapi.common.LocaleId;
 import net.sf.okapi.common.pipeline.annotations.StepParameterMapping;
 import net.sf.okapi.common.pipeline.annotations.StepParameterType;
 import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.StartDocument;
 import net.sf.okapi.common.resource.TextContainer;
 import net.sf.okapi.lib.verification.Issue;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -48,6 +50,59 @@ public class QualityCheckStep extends net.sf.okapi.steps.qualitycheck.QualityChe
     } catch (IllegalAccessException e) {
       logger.error("Cannot replace the QualityCheckSession with Reflection");
     }
+  }
+
+  /**
+   * This is a workaround to allow using in-memory files with current Okapi implementation of the
+   * QualityCheckStep.
+   *
+   * <p>In order for the {@link net.sf.okapi.steps.qualitycheck.QualityCheckStep} to work in a
+   * non-interactive mode, it needs to be supplied with Filter Events. These come from {@link
+   * net.sf.okapi.steps.common.RawDocumentToFilterEventsStep}, which accepts {@link
+   * net.sf.okapi.common.resource.RawDocument} representation of a file to parse. Per the
+   * RawDocument documentation, it can be constructed from either of:
+   *
+   * <ul>
+   *   <li>URI
+   *   <li>CharSequence (String)
+   *   <li>InputStream
+   * </ul>
+   *
+   * but it can only be one of those things at once.
+   *
+   * <p>QualityCheckStep through its {@link QualityCheckSession} eventually calls {@link
+   * net.sf.okapi.lib.verification.QualityChecker#processStartDocument}. In the current version of
+   * Okapi, this seems to expect the {@link StartDocument#getName} to be non-null, otherwise the
+   * following line throws an NPE:
+   *
+   * <pre>
+   *     (new File(sd.getName())).toURI()
+   * </pre>
+   *
+   * Yet, for in-memory RawDocuments (created from CharSequence or Stream) the URI must be null.
+   * Therefore, this workaround injects a fake document name instead of null into the {@link
+   * StartDocument} resource by calling its public method {@link StartDocument#setName}.
+   *
+   * @param event event to handle
+   */
+  @Override
+  protected Event handleStartDocument(Event event) {
+    StartDocument sd = (StartDocument) event.getResource();
+    String name = sd.getName();
+    if (name == null) {
+      sd.setName(createFakeDocumentName());
+    }
+    return super.handleStartDocument(event);
+  }
+
+  /**
+   * Returns a fake document name to be used where the Okapi classes can't work with streams instead
+   * of files.
+   *
+   * @return a fake output document name from stream
+   */
+  private static String createFakeDocumentName() {
+    return "inMemoryDocument-" + UUID.randomUUID();
   }
 
   @Override

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -981,13 +981,12 @@ public class TMService {
     driver.addStep(new RawDocumentToFilterEventsStep(new TMExportFilter(assetId)));
     driver.addStep(filterEventsWriterStep);
 
-    logger.trace("Add single document with fake output URI to be processed with an outputStream");
+    logger.trace("Add fake document to be processed");
     Locale locale = localeService.findByBcp47Tag(bcp47Tag);
-    RawDocument rawDocument =
-        new RawDocument(
-            RawDocument.EMPTY, LocaleId.ENGLISH, LocaleId.fromBCP47(locale.getBcp47Tag()));
+    RawDocument fakeDocument =
+        RawDocument.createFakeDocument(LocaleId.ENGLISH, LocaleId.fromBCP47(locale.getBcp47Tag()));
 
-    driver.addBatchItem(rawDocument);
+    driver.addBatchItem(fakeDocument);
 
     logger.debug("Start processing batch");
     driver.processBatch();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -915,7 +915,7 @@ public class TMService {
         targetLanguage != null ? LocaleId.fromBCP47(targetLanguage) : LocaleId.EMPTY;
     RawDocument rawDocument = new RawDocument(xliffContent, LocaleId.ENGLISH, targetLocaleId);
 
-    driver.addBatchItem(rawDocument, RawDocument.getFakeOutputURIForStream(), null);
+    driver.addBatchItem(rawDocument);
 
     logger.debug("Start processing batch");
     driver.processBatch();
@@ -987,7 +987,7 @@ public class TMService {
         new RawDocument(
             RawDocument.EMPTY, LocaleId.ENGLISH, LocaleId.fromBCP47(locale.getBcp47Tag()));
 
-    driver.addBatchItem(rawDocument, RawDocument.getFakeOutputURIForStream(), null);
+    driver.addBatchItem(rawDocument);
 
     logger.debug("Start processing batch");
     driver.processBatch();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
@@ -116,7 +116,7 @@ public class TranslationKitService {
         new RawDocument(
             RawDocument.EMPTY, LocaleId.ENGLISH, LocaleId.fromBCP47(locale.getBcp47Tag()));
 
-    driver.addBatchItem(rawDocument, RawDocument.getFakeOutputURIForStream(), null);
+    driver.addBatchItem(rawDocument);
 
     logger.debug("Start processing batch");
     driver.processBatch();

--- a/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/translationkit/TranslationKitService.java
@@ -110,13 +110,12 @@ public class TranslationKitService {
     driver.addStep(tksStep);
     driver.addStep(filterEventsWriterStep);
 
-    logger.trace("Add single document with fake output URI to be processed with an outputStream");
+    logger.trace("Add fake document to be processed");
     Locale locale = localeService.findById(localeId);
-    RawDocument rawDocument =
-        new RawDocument(
-            RawDocument.EMPTY, LocaleId.ENGLISH, LocaleId.fromBCP47(locale.getBcp47Tag()));
+    RawDocument fakeDocument =
+        RawDocument.createFakeDocument(LocaleId.ENGLISH, LocaleId.fromBCP47(locale.getBcp47Tag()));
 
-    driver.addBatchItem(rawDocument);
+    driver.addBatchItem(fakeDocument);
 
     logger.debug("Start processing batch");
     driver.processBatch();


### PR DESCRIPTION
Split off from #1049

This PR removes the URI injection using reflection on RawDocument which is potentially fragile. Instead, it replaces it with an override on `QualityCheckStep` `START_DOCUMENT` event handler that injects the expected value directly into the `StartDocument` resource through its public method `StartDocument#setName`.

Additionally, it slightly refactors the empty `RawDocument` approach to make it more explicit that the _content_ of this document is not relevant - it's only used to "drive" the Okapi pipeline and provide Locale configuration.

---

Rationale for the URI refactor:

Force setting URI on a `RawDocument` backed by InputStream or a CharSequence breaks its contract as specified [here](https://gitlab.com/okapiframework/Okapi/-/blob/v1.45.0/okapi/core/src/main/java/net/sf/okapi/common/resource/RawDocument.java#L52-L53):

> The RawDocument object has one (and only one) of three input objects: a CharSequence, a URI, or an InputStream.

Even the private runtime of RawDocument itself depends on whether the URI field is set (e.g. [here](https://gitlab.com/okapiframework/Okapi/-/blob/v1.45.0/okapi/core/src/main/java/net/sf/okapi/common/resource/RawDocument.java#L324)), meaning this workaround might introduce unexpected behaviour and is potentially fragile.

After removal of the URI injection from Mojito code, the only thing that breaks seems to be `QualityCheckStep` - specifically, it throws a NullPointerException on the following [line](https://gitlab.com/okapiframework/Okapi/-/blob/v1.45.0/okapi/libraries/lib-verification/src/main/java/net/sf/okapi/lib/verification/QualityChecker.java#L114):

```java
@Override
public void processStartDocument (StartDocument sd,
	List<String> sigList)
{
	currentDocId = (new File(sd.getName())).toURI();
// ...
```

This can be avoided by setting an override on our existing `QualityCheckStep` subclass which will set this name if it's null. This way, the workaround is localized only to the class that actually needs it, rather than affecting all steps of Okapi pipelines that would rely on `RawDocument`.