### PR TITLE
Implement Google Cloud Storage-based blob storage

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -193,6 +193,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <version>2.38.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <scope>runtime</scope>

--- a/webapp/src/main/java/com/box/l10n/mojito/gcs/GCSConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/gcs/GCSConfiguration.java
@@ -9,9 +9,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Configuration for the Google Cloud Storage client.
  *
- * <p>Creates a {@link Storage} client using Application Default Credentials (ADC) when {@code
- * l10n.gcs.enabled=true}. Set {@code l10n.blob-storage.type=gcs} to use GCS as the blob storage
- * implementation.
+ * <p>Creates a {@link Storage} client using Application Default Credentials (ADC).
  */
 @Configuration
 @ConditionalOnProperty("l10n.gcs.enabled")

--- a/webapp/src/main/java/com/box/l10n/mojito/gcs/GCSConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/gcs/GCSConfiguration.java
@@ -1,0 +1,24 @@
+package com.box.l10n.mojito.gcs;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for the Google Cloud Storage client.
+ *
+ * <p>Creates a {@link Storage} client using Application Default Credentials (ADC) when {@code
+ * l10n.gcs.enabled=true}. Set {@code l10n.blob-storage.type=gcs} to use GCS as the blob storage
+ * implementation.
+ */
+@Configuration
+@ConditionalOnProperty("l10n.gcs.enabled")
+public class GCSConfiguration {
+
+  @Bean
+  public Storage gcsStorage() {
+    return StorageOptions.getDefaultInstance().getService();
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/BlobStorageConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/BlobStorageConfiguration.java
@@ -6,8 +6,11 @@ import com.box.l10n.mojito.service.blobstorage.database.DatabaseBlobStorage;
 import com.box.l10n.mojito.service.blobstorage.database.DatabaseBlobStorageCleanupJob;
 import com.box.l10n.mojito.service.blobstorage.database.DatabaseBlobStorageConfigurationProperties;
 import com.box.l10n.mojito.service.blobstorage.database.MBlobRepository;
+import com.box.l10n.mojito.service.blobstorage.gcs.GCSBlobStorage;
+import com.box.l10n.mojito.service.blobstorage.gcs.GCSBlobStorageConfigurationProperties;
 import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorage;
 import com.box.l10n.mojito.service.blobstorage.s3.S3BlobStorageConfigurationProperties;
+import com.google.cloud.storage.Storage;
 import java.time.Duration;
 import org.quartz.JobDetail;
 import org.quartz.SimpleTrigger;
@@ -15,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,7 +33,12 @@ import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
  * testing or deployments with limited load.
  *
  * <p>Consider using {@link S3BlobStorage} for larger deployment. An {@link AmazonS3} client must be
- * configured first, and then the storage enabled with the `l10n.blob-storage.type=s3` property
+ * configured first, and then the storage enabled with the `l10n.blob-storage.type=s3` property.
+ *
+ * <p>Alternatively use {@link GCSBlobStorage} with Google Cloud Storage. Enable the GCS client with
+ * `l10n.gcs.enabled=true`, set `l10n.blob-storage.type=gcs`, and configure
+ * `l10n.blob-storage.gcs.bucket` (and optionally `l10n.blob-storage.gcs.prefix`). Authentication
+ * uses Application Default Credentials (ADC).
  */
 @Configuration
 public class BlobStorageConfiguration {
@@ -48,6 +57,20 @@ public class BlobStorageConfiguration {
     public S3BlobStorage s3BlobStorage() {
       logger.info("Configure S3BlobStorage");
       return new S3BlobStorage(amazonS3, s3BlobStorageConfigurationProperties);
+    }
+  }
+
+  @ConditionalOnProperty(value = "l10n.blob-storage.type", havingValue = "gcs")
+  @ConditionalOnBean(Storage.class)
+  @Configuration
+  static class GCSBlobStorageConfiguration {
+
+    @Autowired GCSBlobStorageConfigurationProperties gcsBlobStorageConfigurationProperties;
+
+    @Bean
+    public GCSBlobStorage gcsBlobStorage(Storage gcsStorage) {
+      logger.info("Configure GCSBlobStorage (using Application Default Credentials)");
+      return new GCSBlobStorage(gcsStorage, gcsBlobStorageConfigurationProperties);
     }
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/BlobStorageConfiguration.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/BlobStorageConfiguration.java
@@ -32,13 +32,14 @@ import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
  * <p>{@link DatabaseBlobStorage} is the default implementation but it should be use only for
  * testing or deployments with limited load.
  *
- * <p>Consider using {@link S3BlobStorage} for larger deployment. An {@link AmazonS3} client must be
- * configured first, and then the storage enabled with the `l10n.blob-storage.type=s3` property.
+ * <p>Consider using one of the following alternatives for larger deployment:
  *
- * <p>Alternatively use {@link GCSBlobStorage} with Google Cloud Storage. Enable the GCS client with
- * `l10n.gcs.enabled=true`, set `l10n.blob-storage.type=gcs`, and configure
- * `l10n.blob-storage.gcs.bucket` (and optionally `l10n.blob-storage.gcs.prefix`). Authentication
- * uses Application Default Credentials (ADC).
+ * <ul>
+ *   <li>{@link S3BlobStorage} with {@link AmazonS3} client
+ *   <li>{@link GCSBlobStorage} with Google Cloud {@link Storage} client
+ * </ul>
+ *
+ * <p>The `l10n.blob-storage.type` property can be set switch between the desired implementation.
  */
 @Configuration
 public class BlobStorageConfiguration {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
@@ -8,6 +8,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.common.base.Preconditions;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -17,18 +18,27 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation that uses Google Cloud Storage to store blobs.
  *
- * <p>Uses Application Default Credentials (ADC) for authentication. ADC is automatically used when
- * you run on Google Cloud (GCE, GKE, Cloud Run) or when {@code GOOGLE_APPLICATION_CREDENTIALS} is
- * set to a service account key file, or after {@code gcloud auth application-default login}.
+ * <p>Rely on S3 lifecyle rules to clean up expired blobs. This must be set up on the bucket,
+ * otherwise no cleanup will happen.
  *
- * <p>Rely on GCS lifecycle rules to cleanup expired blobs. This must be setup manually in the
- * bucket; otherwise no cleanup will happen.
+ * <p>Objects will have a <a
+ * href="https://docs.cloud.google.com/storage/docs/metadata#custom-time">Custom-Time</a> metadata
+ * field set to the end of the desired retention period (except {@link Retention#PERMANENT} where
+ * this is not set).
  *
- * <p>Objects will have a "retention" custom metadata field, see values in {@link Retention}. You
- * can configure lifecycle rules to delete objects with retention=ephemeral (or equivalent) after a
- * given age.
+ * <p>On the bucket, configure a single lifecycle rule:
  *
- * <p>See https://cloud.google.com/storage/docs/lifecycle for details.
+ * <ul>
+ *   <li>action: Delete
+ *   <li>condition: {@code daysSinceCustomTime: 0}
+ * </ul>
+ *
+ * That will delete objects once the current time is past their Custom-Time (end of retention). Note
+ * that objects without Custom-Time set (i.e. {@link Retention#PERMANENT}) are never deleted by this
+ * rule.
+ *
+ * <p>See <a href="https://docs.cloud.google.com/storage/docs/lifecycle#dayssincecustomtime">Object
+ * Lifecycle Management</a> for reference.
  */
 public class GCSBlobStorage implements BlobStorage {
 
@@ -86,7 +96,6 @@ public class GCSBlobStorage implements BlobStorage {
 
   void put(String name, byte[] content, Retention retention, String contentType) {
     Map<String, String> metadata = new HashMap<>();
-    metadata.put("retention", retention.toString());
     put(name, content, retention, contentType, metadata);
   }
 
@@ -97,20 +106,26 @@ public class GCSBlobStorage implements BlobStorage {
       String contentType,
       Map<String, String> metadata) {
     Map<String, String> fullMetadata = new HashMap<>(metadata != null ? metadata : Map.of());
-    fullMetadata.put("retention", retention.toString());
-
-    BlobInfo blobInfo =
+    BlobInfo.Builder builder =
         BlobInfo.newBuilder(BlobId.of(configurationProperties.getBucket(), getFullName(name)))
             .setContentType(contentType)
-            .setMetadata(fullMetadata)
-            .build();
+            .setMetadata(fullMetadata);
 
-    storage.create(blobInfo, content);
+    customTimeAtEndOfRetention(retention).ifPresent(builder::setCustomTimeOffsetDateTime);
+
+    storage.create(builder.build(), content);
   }
 
-  /** Returns the GCS URI for the given blob name (e.g. gs://bucket/prefix/name). */
-  public String getGcsUri(String name) {
-    return String.format("gs://%s/%s", configurationProperties.getBucket(), getFullName(name));
+  /**
+   * GCS Custom-Time at end of retention for lifecycle (daysSinceCustomTime: 0). Empty means no
+   * Custom-Time (object never expires). Exhaustive on {@link Retention} so new enum values require
+   * an explicit case here.
+   */
+  private static Optional<OffsetDateTime> customTimeAtEndOfRetention(Retention retention) {
+    return switch (retention) {
+      case PERMANENT -> Optional.empty();
+      case MIN_1_DAY -> Optional.of(OffsetDateTime.now().plusDays(1));
+    };
   }
 
   String getFullName(String name) {

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
@@ -1,0 +1,119 @@
+package com.box.l10n.mojito.service.blobstorage.gcs;
+
+import com.box.l10n.mojito.service.blobstorage.BlobStorage;
+import com.box.l10n.mojito.service.blobstorage.Retention;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.common.base.Preconditions;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation that uses Google Cloud Storage to store blobs.
+ *
+ * <p>Uses Application Default Credentials (ADC) for authentication. ADC is automatically used when
+ * you run on Google Cloud (GCE, GKE, Cloud Run) or when {@code GOOGLE_APPLICATION_CREDENTIALS} is
+ * set to a service account key file, or after {@code gcloud auth application-default login}.
+ *
+ * <p>Rely on GCS lifecycle rules to cleanup expired blobs. This must be setup manually in the
+ * bucket; otherwise no cleanup will happen.
+ *
+ * <p>Objects will have a "retention" custom metadata field, see values in {@link Retention}. You
+ * can configure lifecycle rules to delete objects with retention=ephemeral (or equivalent) after a
+ * given age.
+ *
+ * <p>See https://cloud.google.com/storage/docs/lifecycle for details.
+ */
+public class GCSBlobStorage implements BlobStorage {
+
+  static final Logger logger = LoggerFactory.getLogger(GCSBlobStorage.class);
+
+  private final Storage storage;
+  private final GCSBlobStorageConfigurationProperties configurationProperties;
+
+  public GCSBlobStorage(
+      Storage storage, GCSBlobStorageConfigurationProperties configurationProperties) {
+    Preconditions.checkNotNull(storage);
+    Preconditions.checkNotNull(configurationProperties);
+    this.storage = storage;
+    this.configurationProperties = configurationProperties;
+  }
+
+  @Override
+  public Optional<byte[]> getBytes(String name) {
+    Blob blob = storage.get(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
+    if (blob == null) {
+      return Optional.empty();
+    }
+    return Optional.of(blob.getContent());
+  }
+
+  @Override
+  public Optional<String> getString(String name) {
+    return getBytes(name).map(bytes -> new String(bytes, StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public void put(String name, byte[] content, Retention retention) {
+    put(name, content, retention, "application/octet-stream");
+  }
+
+  @Override
+  public void delete(String name) {
+    storage.delete(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
+  }
+
+  @Override
+  public boolean exists(String name) {
+    Blob blob = storage.get(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
+    return blob != null;
+  }
+
+  @Override
+  public void put(String name, String content, Retention retention) {
+    byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("Content-Type", "text/plain");
+    metadata.put("Content-Encoding", StandardCharsets.UTF_8.toString());
+    put(name, bytes, retention, "text/plain", metadata);
+  }
+
+  void put(String name, byte[] content, Retention retention, String contentType) {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("retention", retention.toString());
+    put(name, content, retention, contentType, metadata);
+  }
+
+  void put(
+      String name,
+      byte[] content,
+      Retention retention,
+      String contentType,
+      Map<String, String> metadata) {
+    Map<String, String> fullMetadata = new HashMap<>(metadata != null ? metadata : Map.of());
+    fullMetadata.put("retention", retention.toString());
+
+    BlobInfo blobInfo =
+        BlobInfo.newBuilder(BlobId.of(configurationProperties.getBucket(), getFullName(name)))
+            .setContentType(contentType)
+            .setMetadata(fullMetadata)
+            .build();
+
+    storage.create(blobInfo, content);
+  }
+
+  /** Returns the GCS URI for the given blob name (e.g. gs://bucket/prefix/name). */
+  public String getGcsUri(String name) {
+    return String.format("gs://%s/%s", configurationProperties.getBucket(), getFullName(name));
+  }
+
+  String getFullName(String name) {
+    return configurationProperties.getPrefix() + "/" + name;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
@@ -15,7 +15,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation that uses Google Cloud Storage to store blobs.
  *
- * <p>Rely on S3 lifecyle rules to clean up expired blobs. This must be set up on the bucket,
+ * <p>To use it, first enable the client through {@link com.box.l10n.mojito.gcs.GCSConfiguration}.
+ *
+ * <p>Rely on GCS lifecyle rules to clean up expired blobs. This must be set up on the bucket,
  * otherwise no cleanup will happen.
  *
  * <p>Objects will have a <a

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorage.java
@@ -7,10 +7,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.common.base.Preconditions;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +44,8 @@ public class GCSBlobStorage implements BlobStorage {
   private final Storage storage;
   private final GCSBlobStorageConfigurationProperties configurationProperties;
 
+  private static final String byteContentType = "application/octet-stream";
+
   public GCSBlobStorage(
       Storage storage, GCSBlobStorageConfigurationProperties configurationProperties) {
     Preconditions.checkNotNull(storage);
@@ -55,7 +54,6 @@ public class GCSBlobStorage implements BlobStorage {
     this.configurationProperties = configurationProperties;
   }
 
-  @Override
   public Optional<byte[]> getBytes(String name) {
     Blob blob = storage.get(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
     if (blob == null) {
@@ -64,56 +62,23 @@ public class GCSBlobStorage implements BlobStorage {
     return Optional.of(blob.getContent());
   }
 
-  @Override
-  public Optional<String> getString(String name) {
-    return getBytes(name).map(bytes -> new String(bytes, StandardCharsets.UTF_8));
-  }
-
-  @Override
   public void put(String name, byte[] content, Retention retention) {
-    put(name, content, retention, "application/octet-stream");
-  }
-
-  @Override
-  public void delete(String name) {
-    storage.delete(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
-  }
-
-  @Override
-  public boolean exists(String name) {
-    Blob blob = storage.get(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
-    return blob != null;
-  }
-
-  @Override
-  public void put(String name, String content, Retention retention) {
-    byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-    Map<String, String> metadata = new HashMap<>();
-    metadata.put("Content-Type", "text/plain");
-    metadata.put("Content-Encoding", StandardCharsets.UTF_8.toString());
-    put(name, bytes, retention, "text/plain", metadata);
-  }
-
-  void put(String name, byte[] content, Retention retention, String contentType) {
-    Map<String, String> metadata = new HashMap<>();
-    put(name, content, retention, contentType, metadata);
-  }
-
-  void put(
-      String name,
-      byte[] content,
-      Retention retention,
-      String contentType,
-      Map<String, String> metadata) {
-    Map<String, String> fullMetadata = new HashMap<>(metadata != null ? metadata : Map.of());
     BlobInfo.Builder builder =
         BlobInfo.newBuilder(BlobId.of(configurationProperties.getBucket(), getFullName(name)))
-            .setContentType(contentType)
-            .setMetadata(fullMetadata);
+            .setContentType(byteContentType);
 
     customTimeAtEndOfRetention(retention).ifPresent(builder::setCustomTimeOffsetDateTime);
 
     storage.create(builder.build(), content);
+  }
+
+  public void delete(String name) {
+    storage.delete(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
+  }
+
+  public boolean exists(String name) {
+    Blob blob = storage.get(BlobId.of(configurationProperties.getBucket(), getFullName(name)));
+    return blob != null;
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorageConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorageConfigurationProperties.java
@@ -1,0 +1,28 @@
+package com.box.l10n.mojito.service.blobstorage.gcs;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("l10n.blob-storage.gcs")
+public class GCSBlobStorageConfigurationProperties {
+
+  String bucket = "mojito";
+  String prefix = "mojito";
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public void setBucket(String bucket) {
+    this.bucket = bucket;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public void setPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+}

--- a/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/s3/S3BlobStorage.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/blobstorage/s3/S3BlobStorage.java
@@ -25,6 +25,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation that uses S3 to store blobs.
  *
+ * <p>To use it, first enable and configure the client through {@link
+ * com.box.l10n.mojito.aws.s3.AmazonS3Configuration}.
+ *
  * <p>Rely on S3 lifecyle rules to cleanup expired blobs. This must be setup manually else no clean
  * up will happen.
  *

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -296,4 +296,10 @@ spring.session.jdbc.cleanup-cron=-
 #l10n.blob-storage.s3.bucket=mojito
 #l10n.blob-storage.s3.prefix=mojito
 
+# GCS implementation (uses Application Default Credentials)
+#l10n.gcs.enabled=true
+#l10n.blob-storage.type=gcs
+#l10n.blob-storage.gcs.bucket=mojito
+#l10n.blob-storage.gcs.prefix=mojito
+
 

--- a/webapp/src/test/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorageTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/blobstorage/gcs/GCSBlobStorageTest.java
@@ -1,0 +1,115 @@
+package com.box.l10n.mojito.service.blobstorage.gcs;
+
+import com.box.l10n.mojito.gcs.GCSConfiguration;
+import com.box.l10n.mojito.service.blobstorage.BlobStorage;
+import com.box.l10n.mojito.service.blobstorage.BlobStorageTestShared;
+import com.google.cloud.storage.Storage;
+import java.util.UUID;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    classes = {
+      GCSBlobStorageTest.class,
+      GCSConfiguration.class,
+      GCSBlobStorageConfigurationProperties.class,
+      GCSBlobStorageTest.TestConfig.class,
+    })
+@EnableConfigurationProperties
+@TestPropertySource(properties = {"l10n.gcs.enabled=true", "l10n.blob-storage.type=gcs"})
+public class GCSBlobStorageTest implements BlobStorageTestShared {
+
+  @Autowired(required = false)
+  GCSBlobStorage gcsBlobStorage;
+
+  @Override
+  public BlobStorage getBlobStorage() {
+    return gcsBlobStorage;
+  }
+
+  @Before
+  @Override
+  public void bbefore() {
+    BlobStorageTestShared.super.bbefore();
+    // Skip tests when GCS ADC or bucket is not configured
+    try {
+      getBlobStorage().exists("probe-" + UUID.randomUUID());
+    } catch (Exception e) {
+      Assume.assumeNoException("GCS credentials/ADC not available", e);
+    }
+  }
+
+  @Test
+  @Override
+  public void testNoMatchString() {
+    BlobStorageTestShared.super.testNoMatchString();
+  }
+
+  @Test
+  @Override
+  public void testNoMatchBytes() {
+    BlobStorageTestShared.super.testNoMatchBytes();
+  }
+
+  @Test
+  @Override
+  public void testMatchString() {
+    BlobStorageTestShared.super.testMatchString();
+  }
+
+  @Test
+  @Override
+  public void testMatchBytes() {
+    BlobStorageTestShared.super.testMatchBytes();
+  }
+
+  @Test
+  @Override
+  public void testMatchMin1DayRetentionString() {
+    BlobStorageTestShared.super.testMatchMin1DayRetentionString();
+  }
+
+  @Test
+  @Override
+  public void testMatchMin1DayRetentionBytes() {
+    BlobStorageTestShared.super.testMatchMin1DayRetentionBytes();
+  }
+
+  @Test
+  @Override
+  public void testUpdatesWithPut() {
+    BlobStorageTestShared.super.testUpdatesWithPut();
+  }
+
+  @Test
+  @Override
+  public void testExsits() {
+    BlobStorageTestShared.super.testExsits();
+  }
+
+  @Test
+  @Override
+  public void testDelete() {
+    BlobStorageTestShared.super.testDelete();
+  }
+
+  @Configuration
+  static class TestConfig {
+
+    @Bean
+    public GCSBlobStorage gcsBlobStorage(
+        Storage gcsStorage, GCSBlobStorageConfigurationProperties configurationProperties) {
+      return new GCSBlobStorage(gcsStorage, configurationProperties);
+    }
+  }
+}


### PR DESCRIPTION
This PR implements a GCS-backed blob storage backend.

To enable it, specify the following properties:
```properties
# Enable GCS client
l10n.gcs.enabled=true

# Use GCS as Blob Storage backend
l10n.blob-storage.type=gcs

# Specify bucket name and object name prefix (i.e. directory)
l10n.blob-storage.gcs.bucket=mojito
l10n.blob-storage.gcs.prefix=mojito
```

Configuration of the client auth should happen through [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/provide-credentials-adc).