### PR TITLE
Add consistent pseudolocalization

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PseudoLocCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PseudoLocCommand.java
@@ -104,9 +104,10 @@ public class PseudoLocCommand extends Command {
       arity = 1,
       required = false,
       description =
-          "Character substitution mode: RANDOM picks a random diacritical replacement each time,"
-              + " CONSISTENT always maps to the same replacement")
-  String substituteType;
+          "Character substitution mode: RANDOM (default) picks a random diacritical replacement each time,"
+              + " CONSISTENT always maps to the same replacement within a given string.",
+      converter = SubstituteTypeConverter.class)
+  LocalizedAssetBody.SubstituteType substituteType = LocalizedAssetBody.SubstituteType.RANDOM;
 
   @Autowired AssetClient assetClient;
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/PseudoLocCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/PseudoLocCommand.java
@@ -99,6 +99,15 @@ public class PseudoLocCommand extends Command {
       description = Param.DIR_PATH_EXCLUDE_PATTERNS_DESCRIPTION)
   List<String> directoriesExcludePatterns = null;
 
+  @Parameter(
+      names = {"--substitute"},
+      arity = 1,
+      required = false,
+      description =
+          "Character substitution mode: RANDOM picks a random diacritical replacement each time,"
+              + " CONSISTENT always maps to the same replacement")
+  String substituteType;
+
   @Autowired AssetClient assetClient;
 
   @Autowired CommandHelper commandHelper;
@@ -192,7 +201,8 @@ public class PseudoLocCommand extends Command {
               assetByPathAndRepositoryId.getId(),
               assetContent,
               sourceFileMatch.getFileType().getFilterConfigIdOverride(),
-              filterOptions);
+              filterOptions,
+              substituteType);
 
       logger.trace("PseudoLocalizedAsset content = {}", pseudoLocalizedAsset.getContent());
       return pseudoLocalizedAsset;

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/SubstituteTypeConverter.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/SubstituteTypeConverter.java
@@ -1,0 +1,11 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.rest.entity.LocalizedAssetBody;
+
+public class SubstituteTypeConverter extends EnumConverter<LocalizedAssetBody.SubstituteType> {
+
+  @Override
+  protected Class<LocalizedAssetBody.SubstituteType> getGenericClass() {
+    return LocalizedAssetBody.SubstituteType.class;
+  }
+}

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
@@ -216,6 +216,16 @@ public class AssetClient extends BaseClient {
       String content,
       FilterConfigIdOverride filterConfigIdOverride,
       List<String> filterOptions) {
+    return getPseudoLocalizedAssetForContent(
+        assetId, content, filterConfigIdOverride, filterOptions, null);
+  }
+
+  public LocalizedAssetBody getPseudoLocalizedAssetForContent(
+      Long assetId,
+      String content,
+      FilterConfigIdOverride filterConfigIdOverride,
+      List<String> filterOptions,
+      String substituteType) {
 
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromPath(getBasePathForResource(assetId, "pseudo"));
@@ -225,6 +235,7 @@ public class AssetClient extends BaseClient {
     localizedAssetBody.setOutputBcp47tag(OUTPUT_BCP47_TAG);
     localizedAssetBody.setFilterConfigIdOverride(filterConfigIdOverride);
     localizedAssetBody.setFilterOptions(filterOptions);
+    localizedAssetBody.setSubstituteType(substituteType);
 
     return authenticatedRestTemplate.postForObject(
         uriBuilder.toUriString(), localizedAssetBody, LocalizedAssetBody.class);

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/AssetClient.java
@@ -209,23 +209,15 @@ public class AssetClient extends BaseClient {
    * @param filterConfigIdOverride Optional, can be null. Allows to specify a specific Okapi filter
    *     to use to process the asset
    * @param filterOptions
+   * @param substituteType Allows to choose
    * @return the pseudoloocalized asset content
    */
   public LocalizedAssetBody getPseudoLocalizedAssetForContent(
       Long assetId,
       String content,
       FilterConfigIdOverride filterConfigIdOverride,
-      List<String> filterOptions) {
-    return getPseudoLocalizedAssetForContent(
-        assetId, content, filterConfigIdOverride, filterOptions, null);
-  }
-
-  public LocalizedAssetBody getPseudoLocalizedAssetForContent(
-      Long assetId,
-      String content,
-      FilterConfigIdOverride filterConfigIdOverride,
       List<String> filterOptions,
-      String substituteType) {
+      LocalizedAssetBody.SubstituteType substituteType) {
 
     UriComponentsBuilder uriBuilder =
         UriComponentsBuilder.fromPath(getBasePathForResource(assetId, "pseudo"));

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/LocalizedAssetBody.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/LocalizedAssetBody.java
@@ -26,6 +26,17 @@ public class LocalizedAssetBody {
     ACCEPTED
   }
 
+  /**
+   * During pseudolocalization, specifies how accent/diacritics characters that replace ASCII
+   * letters are chosen.
+   */
+  public enum SubstituteType {
+    /** Replacement characters are picked at random. */
+    RANDOM,
+    /** Replacement characters are picked consistently for a given string. */
+    CONSISTENT
+  }
+
   /** Asset id */
   Long assetId;
 
@@ -66,7 +77,7 @@ public class LocalizedAssetBody {
 
   Status status = Status.ALL;
 
-  String substituteType;
+  SubstituteType substituteType;
 
   public Long getAssetId() {
     return assetId;
@@ -148,11 +159,11 @@ public class LocalizedAssetBody {
     this.pullRunName = pullRunName;
   }
 
-  public String getSubstituteType() {
+  public SubstituteType getSubstituteType() {
     return substituteType;
   }
 
-  public void setSubstituteType(String substituteType) {
+  public void setSubstituteType(SubstituteType substituteType) {
     this.substituteType = substituteType;
   }
 }

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/LocalizedAssetBody.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/LocalizedAssetBody.java
@@ -66,6 +66,8 @@ public class LocalizedAssetBody {
 
   Status status = Status.ALL;
 
+  String substituteType;
+
   public Long getAssetId() {
     return assetId;
   }
@@ -144,5 +146,13 @@ public class LocalizedAssetBody {
 
   public void setPullRunName(String pullRunName) {
     this.pullRunName = pullRunName;
+  }
+
+  public String getSubstituteType() {
+    return substituteType;
+  }
+
+  public void setSubstituteType(String substituteType) {
+    this.substituteType = substituteType;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/okapi/PseudoLocalizeStep.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/okapi/PseudoLocalizeStep.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.okapi;
 
 import com.box.l10n.mojito.entity.Asset;
 import com.box.l10n.mojito.pseudoloc.PseudoLocalization;
+import com.box.l10n.mojito.pseudoloc.PseudoLocalization.SubstituteType;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.IntegrityCheckerFactory;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.TextUnitIntegrityChecker;
 import com.box.l10n.mojito.service.tm.TMTextUnitRepository;
@@ -29,11 +30,17 @@ public class PseudoLocalizeStep extends BasePipelineStep {
   static Logger logger = LoggerFactory.getLogger(PseudoLocalizeStep.class);
 
   private Asset asset;
+  private SubstituteType substituteType;
   private LocaleId targetLocale;
   private Set<TextUnitIntegrityChecker> textUnitIntegrityCheckers = new HashSet<>();
 
   public PseudoLocalizeStep(Asset asset) {
+    this(asset, SubstituteType.RANDOM);
+  }
+
+  public PseudoLocalizeStep(Asset asset, SubstituteType substituteType) {
     this.asset = asset;
+    this.substituteType = substituteType;
   }
 
   @Autowired IntegrityCheckerFactory integrityCheckerFactory;
@@ -81,7 +88,8 @@ public class PseudoLocalizeStep extends BasePipelineStep {
     if (textUnit.isTranslatable()) {
       String source = textUnitUtils.getSourceAsString(textUnit);
       String pseudoTranslation =
-          pseudoLocalization.convertStringToPseudoLoc(source, textUnitIntegrityCheckers);
+          pseudoLocalization.convertStringToPseudoLoc(
+              source, textUnitIntegrityCheckers, substituteType);
       textUnit.setTarget(targetLocale, new TextContainer(pseudoTranslation));
     }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/pseudoloc/PseudoLocalization.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pseudoloc/PseudoLocalization.java
@@ -17,6 +17,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class PseudoLocalization {
 
+  public enum SubstituteType {
+    RANDOM,
+    CONSISTENT
+  }
+
   /** Logger */
   static Logger logger = LoggerFactory.getLogger(PseudoLocalization.class);
 
@@ -87,15 +92,21 @@ public class PseudoLocalization {
    * @return pseudo localized string
    */
   public String convertStringToPseudoLoc(String string, Set<TextUnitIntegrityChecker> checkers) {
+    return convertStringToPseudoLoc(string, checkers, SubstituteType.RANDOM);
+  }
+
+  public String convertStringToPseudoLoc(
+      String string, Set<TextUnitIntegrityChecker> checkers, SubstituteType substituteType) {
     TextUnitIntegrityChecker checker = getIntegrityCheckerForPlaceholderProcessing(checkers);
 
     if (checker == null) {
       logger.debug("There is no checker for pseudolocalization placeholder processing.");
-      return convertStringToPseudoLoc(string);
+      return convertStringToPseudoLoc(string, substituteType);
     } else {
       logger.debug("Found checker for pseudolocalization placeholder processing.");
       LocalizableString localizableString = checker.extractNonLocalizableParts(string);
-      String pseudolocalized = convertStringToPseudoLoc(localizableString.getLocalizableString());
+      String pseudolocalized =
+          convertStringToPseudoLoc(localizableString.getLocalizableString(), substituteType);
       localizableString.setLocalizableString(pseudolocalized);
       return checker.restoreNonLocalizableParts(localizableString);
     }
@@ -108,10 +119,14 @@ public class PseudoLocalization {
    * @return pseudo localized string
    */
   public String convertStringToPseudoLoc(String string) {
+    return convertStringToPseudoLoc(string, SubstituteType.RANDOM);
+  }
+
+  public String convertStringToPseudoLoc(String string, SubstituteType substituteType) {
     StringBuilder sb = new StringBuilder();
 
     if (!Strings.isNullOrEmpty(string)) {
-      String str = convertAsciiToDiacritics(string);
+      String str = convertAsciiToDiacritics(string, substituteType);
       sb.append(expand(str));
       sb.insert(0, '⟦');
       sb.append('⟧');
@@ -159,36 +174,68 @@ public class PseudoLocalization {
    * @return
    */
   public String convertAsciiToDiacritics(String string) {
-    int stringLength = string.length();
+    return convertAsciiToDiacritics(string, SubstituteType.RANDOM);
+  }
 
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < stringLength; i++) {
-      char character = string.charAt(i);
-      sb.append(getMappingCharFromMap(character));
-    }
-
-    return sb.toString();
+  public String convertAsciiToDiacritics(String string, SubstituteType substituteType) {
+    return switch (substituteType) {
+      case RANDOM -> convertAsciiToDiacriticsRandom(string);
+      case CONSISTENT -> convertAsciiToDiacriticsConsistent(string);
+    };
   }
 
   /**
-   * Get a non ASCII character mapping to provided character or the character itself if there is no
-   * mapping
-   *
-   * @param character ASCII character to be mapped
-   * @return Non ASCII character or character itself
+   * Converts ASCII letters in the whole string into equivalent characters with accent/diacritics,
+   * selecting mapped characters consistently. This will always return the same mapped string for a
+   * given input.
    */
-  private char getMappingCharFromMap(char character) {
-    char mappedChar = character;
+  private String convertAsciiToDiacriticsConsistent(String string) {
+    StringBuilder builder = new StringBuilder();
 
-    String mappingCharsForChar = pseudoLocMap.get(mappedChar);
+    // keeps track of which mapped char we used last time
+    Map<Character, Integer> lastMappedIdx = new HashMap<>();
 
-    if (mappingCharsForChar != null) {
-      int maxIndex = mappingCharsForChar.length() - 1;
-      int randomIndex = (int) (Math.random() * maxIndex);
-      mappedChar = mappingCharsForChar.charAt(randomIndex);
+    for (char character : string.toCharArray()) {
+      String mappingsForChar = pseudoLocMap.get(character);
+
+      if (mappingsForChar == null) {
+        // don't replace if no mapping available
+        builder.append(character);
+        continue;
+      }
+
+      // pick next mapped char (or go back to the beginning if used all of them)
+      int mappedIdx = (1 + lastMappedIdx.getOrDefault(character, -1)) % mappingsForChar.length();
+      lastMappedIdx.put(character, mappedIdx);
+      char mappedCharacter = mappingsForChar.charAt(mappedIdx);
+
+      builder.append(mappedCharacter);
     }
+    return builder.toString();
+  }
 
-    return mappedChar;
+  /**
+   * Converts ASCII letters in the whole string into equivalent characters with accent/diacritics,
+   * selecting mapped characters at random. This will return different string every time, even if
+   * input does not change.
+   */
+  private String convertAsciiToDiacriticsRandom(String string) {
+    int stringLength = string.length();
+    StringBuilder sb = new StringBuilder();
+
+    for (int i = 0; i < stringLength; i++) {
+      char character = string.charAt(i);
+      String mappingCharsForChar = pseudoLocMap.get(character);
+
+      if (mappingCharsForChar != null) {
+        int maxIndex = mappingCharsForChar.length() - 1;
+        int randomIndex = (int) (Math.random() * maxIndex);
+        character = mappingCharsForChar.charAt(randomIndex);
+      }
+
+      sb.append(character);
+    }
+    return sb.toString();
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/pseudoloc/PseudoLocalization.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/pseudoloc/PseudoLocalization.java
@@ -17,8 +17,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class PseudoLocalization {
 
+  /** Specifies how accent/diacritics characters that replace ASCII letters are chosen */
   public enum SubstituteType {
+    /** Replacement characters are picked at random. */
     RANDOM,
+    /** Replacement characters are picked consistently for a given string. */
     CONSISTENT
   }
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/AssetWS.java
@@ -11,6 +11,7 @@ import com.box.l10n.mojito.entity.RepositoryLocale;
 import com.box.l10n.mojito.entity.TMXliff;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.okapi.asset.UnsupportedAssetFilterTypeException;
+import com.box.l10n.mojito.pseudoloc.PseudoLocalization;
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.rest.View;
@@ -306,9 +307,17 @@ public class AssetWS {
     Asset asset = assetRepository.getOne(assetId);
     String normalizedContent = NormalizationUtils.normalize(localizedAssetBody.getContent());
 
+    PseudoLocalization.SubstituteType substituteType =
+        localizedAssetBody.getSubstituteType() != null
+            ? localizedAssetBody.getSubstituteType()
+            : PseudoLocalization.SubstituteType.RANDOM;
+
     String generateLocalized =
         tmService.generatePseudoLocalized(
-            asset, normalizedContent, localizedAssetBody.getFilterConfigIdOverride());
+            asset,
+            normalizedContent,
+            localizedAssetBody.getFilterConfigIdOverride(),
+            substituteType);
 
     localizedAssetBody.setContent(generateLocalized);
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/asset/LocalizedAssetBody.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/asset/LocalizedAssetBody.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.rest.asset;
 import com.box.l10n.mojito.okapi.FilterConfigIdOverride;
 import com.box.l10n.mojito.okapi.InheritanceMode;
 import com.box.l10n.mojito.okapi.Status;
+import com.box.l10n.mojito.pseudoloc.PseudoLocalization;
 import java.util.List;
 
 /**
@@ -49,6 +50,8 @@ public class LocalizedAssetBody {
   InheritanceMode inheritanceMode = InheritanceMode.USE_PARENT;
 
   Status status = Status.ALL;
+
+  PseudoLocalization.SubstituteType substituteType;
 
   public LocalizedAssetBody() {}
 
@@ -135,5 +138,13 @@ public class LocalizedAssetBody {
 
   public void setPullRunName(String pullRunName) {
     this.pullRunName = pullRunName;
+  }
+
+  public PseudoLocalization.SubstituteType getSubstituteType() {
+    return substituteType;
+  }
+
+  public void setSubstituteType(PseudoLocalization.SubstituteType substituteType) {
+    this.substituteType = substituteType;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMService.java
@@ -41,6 +41,7 @@ import com.box.l10n.mojito.okapi.qualitycheck.Parameters;
 import com.box.l10n.mojito.okapi.qualitycheck.QualityCheckStep;
 import com.box.l10n.mojito.okapi.steps.CheckForDoNotTranslateStep;
 import com.box.l10n.mojito.okapi.steps.FilterEventsToInMemoryRawDocumentStep;
+import com.box.l10n.mojito.pseudoloc.PseudoLocalization;
 import com.box.l10n.mojito.quartz.QuartzJobInfo;
 import com.box.l10n.mojito.quartz.QuartzPollableTaskScheduler;
 import com.box.l10n.mojito.retry.DataIntegrityViolationExceptionRetryTemplate;
@@ -1098,10 +1099,21 @@ public class TMService {
   public String generatePseudoLocalized(
       Asset asset, String content, FilterConfigIdOverride filterConfigIdOverride)
       throws UnsupportedAssetFilterTypeException {
+    return generatePseudoLocalized(
+        asset, content, filterConfigIdOverride, PseudoLocalization.SubstituteType.RANDOM);
+  }
+
+  public String generatePseudoLocalized(
+      Asset asset,
+      String content,
+      FilterConfigIdOverride filterConfigIdOverride,
+      PseudoLocalization.SubstituteType substituteType)
+      throws UnsupportedAssetFilterTypeException {
 
     String bcp47tag = "en-x-psaccent";
 
-    BasePipelineStep pseudoLocalizedStep = (BasePipelineStep) new PseudoLocalizeStep(asset);
+    BasePipelineStep pseudoLocalizedStep =
+        (BasePipelineStep) new PseudoLocalizeStep(asset, substituteType);
     return generateLocalizedBase(
         asset, content, filterConfigIdOverride, null, pseudoLocalizedStep, bcp47tag);
   }

--- a/webapp/src/test/java/com/box/l10n/mojito/pseudoloc/PseudoLocalizationTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/pseudoloc/PseudoLocalizationTest.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.pseudoloc;
 
 import static org.junit.Assert.*;
 
+import com.box.l10n.mojito.pseudoloc.PseudoLocalization.SubstituteType;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.MessageFormatIntegrityChecker;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.TextUnitIntegrityChecker;
 import com.box.l10n.mojito.service.assetintegritychecker.integritychecker.WhitespaceIntegrityChecker;
@@ -148,5 +149,51 @@ public class PseudoLocalizationTest {
     assertFalse(
         "The plural text variation should be pseudolocalized while the placeholder should not",
         pseudoLocalized.contains("{# Comments or Tasks}"));
+  }
+
+  @Test
+  public void testConsistentSubstitutionIsDeterministic() {
+    PseudoLocalization ps = new PseudoLocalization();
+    String first = ps.convertAsciiToDiacritics("Hello World", SubstituteType.CONSISTENT);
+    String second = ps.convertAsciiToDiacritics("Hello World", SubstituteType.CONSISTENT);
+    assertEquals("Consistent substitution should produce identical results", first, second);
+  }
+
+  @Test
+  public void testConsistentSubstitutionProducesDiacritics() {
+    PseudoLocalization ps = new PseudoLocalization();
+    String result = ps.convertAsciiToDiacritics("Hello", SubstituteType.CONSISTENT);
+    assertNotEquals("Consistent substitution should still transform the string", "Hello", result);
+  }
+
+  @Test
+  public void testConsistentConvertStringToPseudoLoc() {
+    PseudoLocalization ps = new PseudoLocalization();
+    String first = ps.convertStringToPseudoLoc("English Sentence", SubstituteType.CONSISTENT);
+    String second = ps.convertStringToPseudoLoc("English Sentence", SubstituteType.CONSISTENT);
+    assertEquals(
+        "Consistent pseudolocalization should be deterministic across calls", first, second);
+  }
+
+  @Test
+  public void testConsistentConvertStringToPseudoLocWithCheckers() {
+    PseudoLocalization ps = new PseudoLocalization();
+    Set<TextUnitIntegrityChecker> checkers = new HashSet<>();
+    checkers.add(new MessageFormatIntegrityChecker());
+    String first =
+        ps.convertStringToPseudoLoc("Hello {name}, welcome!", checkers, SubstituteType.CONSISTENT);
+    String second =
+        ps.convertStringToPseudoLoc("Hello {name}, welcome!", checkers, SubstituteType.CONSISTENT);
+    assertEquals("Consistent substitution with checkers should be deterministic", first, second);
+    assertTrue(
+        "Placeholders should be preserved with consistent substitution", first.contains("{name}"));
+  }
+
+  @Test
+  public void testConsistentDoesNotConvertUnmappedChars() {
+    PseudoLocalization ps = new PseudoLocalization();
+    String result = ps.convertAsciiToDiacritics("qQV", SubstituteType.CONSISTENT);
+    assertEquals(
+        "Unmapped chars should remain unchanged with consistent substitution", "qQV", result);
   }
 }

--- a/webapp/src/test/java/com/box/l10n/mojito/pseudoloc/PseudoLocalizationTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/pseudoloc/PseudoLocalizationTest.java
@@ -29,6 +29,15 @@ public class PseudoLocalizationTest {
   }
 
   @Test
+  public void testStringIsConvertedToDiacriticsRandom() {
+    PseudoLocalization ps = new PseudoLocalization();
+    String first = ps.convertAsciiToDiacritics("English Sentence");
+    String second = ps.convertAsciiToDiacritics("English Sentence");
+    assertNotEquals(
+        "Default substitution should randomly select diacritics across calls", first, second);
+  }
+
+  @Test
   public void testStringIsNotConvertedToDiacritics() {
     // The chars q, Q, and V are not converted so they should not be converted
     // when we call the convert function
@@ -42,6 +51,15 @@ public class PseudoLocalizationTest {
     PseudoLocalization ps = new PseudoLocalization();
     String pseudoLocalized = ps.convertStringToPseudoLoc("English Sentence");
     assertNotEquals("The string should be pseudolocalized", "English Sentence", pseudoLocalized);
+  }
+
+  @Test
+  public void testconvertStringToPseudoLocRandom() {
+    PseudoLocalization ps = new PseudoLocalization();
+    String first = ps.convertStringToPseudoLoc("English Sentence");
+    String second = ps.convertStringToPseudoLoc("English Sentence");
+    assertNotEquals(
+        "Default pseudolocalization should substitute diacritics randomly", first, second);
   }
 
   @Test


### PR DESCRIPTION
This PR adds ability to produce pseudolocalized strings consistently instead of picking replacement characters at random.

In some cases, it's not desirable to get a completely different pseudolocalized string after each run of the `pseudo` command. To avoid it, this PR adds a CLI option `--substitute` which allows to select whether replacement characters are picked at random (`--substitute=RANDOM`), or consistently (`--substitute=CONSISTENT`).

Consistent pseudo means that for a given input string, pseudolocalized output will be invariant. Note that generally there will still be different diacritic characters inserted across the whole content (e.g. a `G` can still be one of `ĜĞĠĢ`) - the choice in consistent mode is based on the amount of previous occurrences of that character inside a given input string.

To preserve original behaviour, default value for this option is `RANDOM`.