### PR TITLE
Add support for proxy servers with OpenAI

### DIFF
--- a/common/src/main/java/com/box/l10n/mojito/openai/OpenAIClient.java
+++ b/common/src/main/java/com/box/l10n/mojito/openai/OpenAIClient.java
@@ -75,6 +75,8 @@ public class OpenAIClient {
 
     private Executor asyncExecutor;
 
+    private OpenAIProxyConfig proxyConfig;
+
     public Builder() {}
 
     public Builder apiKey(String apiKey) {
@@ -102,6 +104,11 @@ public class OpenAIClient {
       return this;
     }
 
+    public Builder proxyConfig(OpenAIProxyConfig proxyConfig) {
+      this.proxyConfig = proxyConfig;
+      return this;
+    }
+
     public OpenAIClient build() {
       if (apiKey == null) {
         throw new IllegalStateException("API key must be provided");
@@ -110,19 +117,15 @@ public class OpenAIClient {
       if (objectMapper == null) {
         objectMapper = createObjectMapper();
       }
-      if (httpClient == null) {
-        httpClient = createHttpClient();
-      }
 
       if (asyncExecutor == null) {
         asyncExecutor = ForkJoinPool.commonPool();
       }
+      if (httpClient == null) {
+        httpClient = OpenAIHttpClientFactory.createHttpClient(proxyConfig, asyncExecutor);
+      }
 
       return new OpenAIClient(apiKey, host, objectMapper, httpClient, asyncExecutor);
-    }
-
-    private HttpClient createHttpClient() {
-      return HttpClient.newBuilder().build();
     }
 
     private ObjectMapper createObjectMapper() {

--- a/common/src/main/java/com/box/l10n/mojito/openai/OpenAIClientPool.java
+++ b/common/src/main/java/com/box/l10n/mojito/openai/OpenAIClientPool.java
@@ -1,6 +1,5 @@
 package com.box.l10n.mojito.openai;
 
-import java.net.http.HttpClient;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -32,6 +31,15 @@ public class OpenAIClientPool {
       int numberOfParallelRequestPerClient,
       int sizeOfAsyncProcessors,
       String apiKey) {
+    this(numberOfClients, numberOfParallelRequestPerClient, sizeOfAsyncProcessors, apiKey, null);
+  }
+
+  public OpenAIClientPool(
+      int numberOfClients,
+      int numberOfParallelRequestPerClient,
+      int sizeOfAsyncProcessors,
+      String apiKey,
+      OpenAIProxyConfig proxyConfig) {
     ExecutorService asyncExecutor = Executors.newWorkStealingPool(sizeOfAsyncProcessors);
     this.numberOfClients = numberOfClients;
     this.openAIClientWithSemaphores = new OpenAIClientWithSemaphore[numberOfClients];
@@ -41,7 +49,7 @@ public class OpenAIClientPool {
               OpenAIClient.builder()
                   .apiKey(apiKey)
                   .asyncExecutor(asyncExecutor)
-                  .httpClient(HttpClient.newBuilder().executor(asyncExecutor).build())
+                  .httpClient(OpenAIHttpClientFactory.createHttpClient(proxyConfig, asyncExecutor))
                   .build(),
               new Semaphore(numberOfParallelRequestPerClient));
     }

--- a/common/src/main/java/com/box/l10n/mojito/openai/OpenAIHttpClientFactory.java
+++ b/common/src/main/java/com/box/l10n/mojito/openai/OpenAIHttpClientFactory.java
@@ -1,0 +1,58 @@
+package com.box.l10n.mojito.openai;
+
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.util.concurrent.Executor;
+
+public final class OpenAIHttpClientFactory {
+
+  private OpenAIHttpClientFactory() {}
+
+  public static HttpClient createHttpClient(OpenAIProxyConfig proxyConfig) {
+    return createHttpClient(proxyConfig, null);
+  }
+
+  public static HttpClient createHttpClient(OpenAIProxyConfig proxyConfig, Executor executor) {
+    HttpClient.Builder builder = HttpClient.newBuilder();
+    if (executor != null) {
+      builder.executor(executor);
+    }
+    configureProxy(builder, proxyConfig);
+    return builder.build();
+  }
+
+  static void configureProxy(HttpClient.Builder builder, OpenAIProxyConfig proxyConfig) {
+    if (proxyConfig != null && proxyConfig.isConfigured()) {
+      builder.proxy(createProxySelector(proxyConfig));
+      if (proxyConfig.user() != null && proxyConfig.password() != null) {
+        builder.authenticator(createProxyAuthenticator(proxyConfig));
+      }
+    }
+  }
+
+  static ProxySelector createProxySelector(OpenAIProxyConfig proxyConfig) {
+    return ProxySelector.of(new InetSocketAddress(proxyConfig.host(), proxyConfig.port()));
+  }
+
+  static Authenticator createProxyAuthenticator(OpenAIProxyConfig proxyConfig) {
+    return new Authenticator() {
+      @Override
+      protected PasswordAuthentication getPasswordAuthentication() {
+        return getProxyPasswordAuthentication(proxyConfig, getRequestorType());
+      }
+    };
+  }
+
+  static PasswordAuthentication getProxyPasswordAuthentication(
+      OpenAIProxyConfig proxyConfig, Authenticator.RequestorType requestorType) {
+    if (requestorType == Authenticator.RequestorType.PROXY
+        && proxyConfig.user() != null
+        && proxyConfig.password() != null) {
+      return new PasswordAuthentication(proxyConfig.user(), proxyConfig.password().toCharArray());
+    }
+    return null;
+  }
+}

--- a/common/src/main/java/com/box/l10n/mojito/openai/OpenAIProxyConfig.java
+++ b/common/src/main/java/com/box/l10n/mojito/openai/OpenAIProxyConfig.java
@@ -1,0 +1,12 @@
+package com.box.l10n.mojito.openai;
+
+public record OpenAIProxyConfig(String host, Integer port, String user, String password) {
+
+  public static OpenAIProxyConfig of(String host, Integer port, String user, String password) {
+    return new OpenAIProxyConfig(host, port, user, password);
+  }
+
+  public boolean isConfigured() {
+    return host != null && !host.isBlank() && port != null;
+  }
+}

--- a/common/src/main/java/com/box/l10n/mojito/openai/OpenAIProxyConfig.java
+++ b/common/src/main/java/com/box/l10n/mojito/openai/OpenAIProxyConfig.java
@@ -9,4 +9,17 @@ public record OpenAIProxyConfig(String host, Integer port, String user, String p
   public boolean isConfigured() {
     return host != null && !host.isBlank() && port != null;
   }
+
+  @Override
+  public String toString() {
+    return "OpenAIProxyConfig[host="
+        + host
+        + ", port="
+        + port
+        + ", user="
+        + (user == null ? "null" : "***")
+        + ", password="
+        + (password == null ? "null" : "***")
+        + "]";
+  }
 }

--- a/common/src/test/java/com/box/l10n/mojito/openai/OpenAIClientProxyConfigTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/openai/OpenAIClientProxyConfigTest.java
@@ -1,0 +1,45 @@
+package com.box.l10n.mojito.openai;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class OpenAIClientProxyConfigTest {
+
+  @Test
+  public void testOpenAIClientBuilderWithProxyConfig() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+
+    OpenAIClient openAIClient =
+        OpenAIClient.builder().apiKey("test-api-key").proxyConfig(proxyConfig).build();
+
+    assertNotNull(openAIClient.httpClient);
+  }
+
+  @Test
+  public void testOpenAIClientBuilderWithoutProxyConfig() {
+    OpenAIClient openAIClient = OpenAIClient.builder().apiKey("test-api-key").build();
+
+    assertNotNull(openAIClient.httpClient);
+  }
+
+  @Test
+  public void testOpenAIClientPoolWithoutProxyConfig() {
+    OpenAIClientPool openAIClientPool = new OpenAIClientPool(1, 1, 1, "test-api-key");
+
+    assertNotNull(openAIClientPool);
+    assertNotNull(openAIClientPool.openAIClientWithSemaphores[0].openAIClient().httpClient);
+  }
+
+  @Test
+  public void testOpenAIClientPoolWithProxyConfig() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+
+    OpenAIClientPool openAIClientPool = new OpenAIClientPool(1, 1, 1, "test-api-key", proxyConfig);
+
+    assertNotNull(openAIClientPool);
+    assertNotNull(openAIClientPool.openAIClientWithSemaphores[0].openAIClient().httpClient);
+  }
+}

--- a/common/src/test/java/com/box/l10n/mojito/openai/OpenAIHttpClientFactoryTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/openai/OpenAIHttpClientFactoryTest.java
@@ -26,6 +26,19 @@ public class OpenAIHttpClientFactoryTest {
   }
 
   @Test
+  public void testOpenAIProxyConfigToStringRedactsCredentials() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+
+    assertEquals(
+        "OpenAIProxyConfig[host=proxy.example.com, port=3128, user=***, password=***]",
+        proxyConfig.toString());
+    assertEquals(
+        "OpenAIProxyConfig[host=proxy.example.com, port=3128, user=null, password=null]",
+        OpenAIProxyConfig.of("proxy.example.com", 3128, null, null).toString());
+  }
+
+  @Test
   public void testCreateHttpClientWithoutProxy() {
     assertNotNull(OpenAIHttpClientFactory.createHttpClient(null));
     assertNotNull(

--- a/common/src/test/java/com/box/l10n/mojito/openai/OpenAIHttpClientFactoryTest.java
+++ b/common/src/test/java/com/box/l10n/mojito/openai/OpenAIHttpClientFactoryTest.java
@@ -1,0 +1,100 @@
+package com.box.l10n.mojito.openai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class OpenAIHttpClientFactoryTest {
+
+  @Test
+  public void testOpenAIProxyConfigIsConfigured() {
+    assertFalse(OpenAIProxyConfig.of(null, 3128, "user", "pass").isConfigured());
+    assertFalse(OpenAIProxyConfig.of("   ", 3128, "user", "pass").isConfigured());
+    assertFalse(OpenAIProxyConfig.of("proxy.example.com", null, "user", "pass").isConfigured());
+    assertTrue(OpenAIProxyConfig.of("proxy.example.com", 3128, "user", "pass").isConfigured());
+  }
+
+  @Test
+  public void testCreateHttpClientWithoutProxy() {
+    assertNotNull(OpenAIHttpClientFactory.createHttpClient(null));
+    assertNotNull(
+        OpenAIHttpClientFactory.createHttpClient(OpenAIProxyConfig.of(null, null, null, null)));
+  }
+
+  @Test
+  public void testCreateHttpClientWithProxy() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+    assertNotNull(OpenAIHttpClientFactory.createHttpClient(proxyConfig));
+  }
+
+  @Test
+  public void testCreateProxySelector() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+
+    ProxySelector proxySelector = OpenAIHttpClientFactory.createProxySelector(proxyConfig);
+    List<Proxy> proxies = proxySelector.select(URI.create("https://api.openai.com/v1/models"));
+
+    assertEquals(1, proxies.size());
+    assertEquals(Proxy.Type.HTTP, proxies.get(0).type());
+    InetSocketAddress address = (InetSocketAddress) proxies.get(0).address();
+    assertEquals("proxy.example.com", address.getHostString());
+    assertEquals(3128, address.getPort());
+  }
+
+  @Test
+  public void testGetProxyPasswordAuthenticationForProxyRequest() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+
+    PasswordAuthentication authentication =
+        OpenAIHttpClientFactory.getProxyPasswordAuthentication(
+            proxyConfig, Authenticator.RequestorType.PROXY);
+
+    assertNotNull(authentication);
+    assertEquals("proxy-user", authentication.getUserName());
+    assertEquals("proxy-password", new String(authentication.getPassword()));
+  }
+
+  @Test
+  public void testGetProxyPasswordAuthenticationReturnsNullForServerRequest() {
+    OpenAIProxyConfig proxyConfig =
+        OpenAIProxyConfig.of("proxy.example.com", 3128, "proxy-user", "proxy-password");
+
+    PasswordAuthentication authentication =
+        OpenAIHttpClientFactory.getProxyPasswordAuthentication(
+            proxyConfig, Authenticator.RequestorType.SERVER);
+
+    assertNull(authentication);
+  }
+
+  @Test
+  public void testConfigureProxySkipsIncompleteConfig() {
+    assertNotNull(
+        OpenAIHttpClientFactory.createHttpClient(
+            OpenAIProxyConfig.of("proxy.example.com", null, "proxy-user", "proxy-password")));
+  }
+
+  @Test
+  public void testCreateHttpClientWithProxyHostAndPortOnly() {
+    OpenAIProxyConfig proxyConfig = OpenAIProxyConfig.of("proxy.example.com", 3128, null, null);
+
+    ProxySelector proxySelector = OpenAIHttpClientFactory.createProxySelector(proxyConfig);
+    List<Proxy> proxies = proxySelector.select(URI.create("https://api.openai.com/v1/models"));
+
+    assertEquals(1, proxies.size());
+    assertNotNull(OpenAIHttpClientFactory.createHttpClient(proxyConfig));
+  }
+}

--- a/docs/_docs/refs/configurations_springboot2.md
+++ b/docs/_docs/refs/configurations_springboot2.md
@@ -237,3 +237,39 @@ You can also optionally use it in production by setting the following configurat
    Follow instructions [here](https://community.box.com/t5/For-Admins/How-Do-I-Share-Files-And-Folders-From-The-Admin-Console/ta-p/211) to share with collaborators.
 
    Tips: Access the Box Account as the Admin of the enterprise using the credentials for the Box Developer Account you created.
+
+## AI Translation and AI Review (OpenAI)
+
+AI translation and AI review use the OpenAI HTTP API. Configure an API token and, when required by your network, an optional HTTP proxy for outbound requests.
+
+### AI translation
+
+    # Required to enable AI translation features
+    l10n.ai-translate.openai-client-token=${OPENAI_API_KEY}
+
+    # Optional. Default: gpt-4o-2024-08-06
+    l10n.ai-translate.model-name=gpt-4o-2024-08-06
+
+    # Optional. HTTP proxy (host and port must both be set)
+    l10n.ai-translate.proxy-host=proxy.example.com
+    l10n.ai-translate.proxy-port=3128
+    l10n.ai-translate.proxy-user=proxy-user
+    l10n.ai-translate.proxy-password=${PROXY_PASSWORD}
+
+    # Optional. Use a dedicated Quartz scheduler for AI translation jobs
+    l10n.ai-translate.scheduler-name=ai-translate
+
+Keep secrets such as the API token and proxy password out of source control.
+
+### AI review
+
+AI review uses the same OpenAI client and proxy settings under the `l10n.ai-review.*` prefix:
+
+    l10n.ai-review.openai-client-token=${OPENAI_API_KEY}
+    l10n.ai-review.model-name=gpt-4o-2024-08-06
+    l10n.ai-review.proxy-host=proxy.example.com
+    l10n.ai-review.proxy-port=3128
+    l10n.ai-review.proxy-user=proxy-user
+    l10n.ai-review.proxy-password=${PROXY_PASSWORD}
+
+See also [Using AI Translations]({{ site.url }}/docs/guides/using-ai-translations/) for repository and CLI usage.

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaireview/AiReviewConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaireview/AiReviewConfig.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.service.oaireview;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.openai.OpenAIClient;
 import com.box.l10n.mojito.openai.OpenAIClientPool;
+import com.box.l10n.mojito.openai.OpenAIProxyConfig;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +25,10 @@ public class AiReviewConfig {
     if (openaiClientToken == null) {
       return null;
     }
-    return new OpenAIClient.Builder().apiKey(openaiClientToken).build();
+    return OpenAIClient.builder()
+        .apiKey(openaiClientToken)
+        .proxyConfig(getProxyConfig(aiReviewConfigurationProperties))
+        .build();
   }
 
   @Bean("openAIClientPoolReview")
@@ -33,7 +37,20 @@ public class AiReviewConfig {
     if (openaiClientToken == null) {
       return null;
     }
-    return new OpenAIClientPool(10, 10, 5, aiReviewConfigurationProperties.getOpenaiClientToken());
+    return new OpenAIClientPool(
+        10,
+        10,
+        5,
+        aiReviewConfigurationProperties.getOpenaiClientToken(),
+        getProxyConfig(aiReviewConfigurationProperties));
+  }
+
+  static OpenAIProxyConfig getProxyConfig(AiReviewConfigurationProperties properties) {
+    return OpenAIProxyConfig.of(
+        properties.getProxyHost(),
+        properties.getProxyPort(),
+        properties.getProxyUser(),
+        properties.getProxyPassword());
   }
 
   @Bean("objectMapperReview")

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaireview/AiReviewConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaireview/AiReviewConfigurationProperties.java
@@ -10,6 +10,10 @@ public class AiReviewConfigurationProperties {
   String openaiClientToken;
   String schedulerName = QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
   String modelName = "gpt-4o-2024-08-06";
+  String proxyHost;
+  Integer proxyPort;
+  String proxyUser;
+  String proxyPassword;
 
   public String getOpenaiClientToken() {
     return openaiClientToken;
@@ -33,5 +37,37 @@ public class AiReviewConfigurationProperties {
 
   public void setModelName(String modelName) {
     this.modelName = modelName;
+  }
+
+  public String getProxyHost() {
+    return proxyHost;
+  }
+
+  public void setProxyHost(String proxyHost) {
+    this.proxyHost = proxyHost;
+  }
+
+  public Integer getProxyPort() {
+    return proxyPort;
+  }
+
+  public void setProxyPort(Integer proxyPort) {
+    this.proxyPort = proxyPort;
+  }
+
+  public String getProxyUser() {
+    return proxyUser;
+  }
+
+  public void setProxyUser(String proxyUser) {
+    this.proxyUser = proxyUser;
+  }
+
+  public String getProxyPassword() {
+    return proxyPassword;
+  }
+
+  public void setProxyPassword(String proxyPassword) {
+    this.proxyPassword = proxyPassword;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaireview/AiReviewService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaireview/AiReviewService.java
@@ -187,13 +187,8 @@ public class AiReviewService {
 
     logger.info(objectMapper.writeValueAsStringUnchecked(chatCompletionsRequest));
 
-    OpenAIClient openAIClient =
-        OpenAIClient.builder()
-            .apiKey(aiReviewConfigurationProperties.getOpenaiClientToken())
-            .build();
-
     OpenAIClient.ChatCompletionsResponse chatCompletionsResponse =
-        openAIClient
+        getOpenAIClient()
             .getChatCompletions(chatCompletionsRequest, Duration.of(15, ChronoUnit.SECONDS))
             .join();
 

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfig.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfig.java
@@ -3,6 +3,7 @@ package com.box.l10n.mojito.service.oaitranslate;
 import com.box.l10n.mojito.json.ObjectMapper;
 import com.box.l10n.mojito.openai.OpenAIClient;
 import com.box.l10n.mojito.openai.OpenAIClientPool;
+import com.box.l10n.mojito.openai.OpenAIProxyConfig;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +27,10 @@ public class AiTranslateConfig {
     if (openaiClientToken == null) {
       return null;
     }
-    return new OpenAIClient.Builder().apiKey(openaiClientToken).build();
+    return OpenAIClient.builder()
+        .apiKey(openaiClientToken)
+        .proxyConfig(getProxyConfig(aiTranslateConfigurationProperties))
+        .build();
   }
 
   @Bean
@@ -37,7 +41,19 @@ public class AiTranslateConfig {
       return null;
     }
     return new OpenAIClientPool(
-        20, 100, 1, aiTranslateConfigurationProperties.getOpenaiClientToken());
+        20,
+        100,
+        1,
+        aiTranslateConfigurationProperties.getOpenaiClientToken(),
+        getProxyConfig(aiTranslateConfigurationProperties));
+  }
+
+  static OpenAIProxyConfig getProxyConfig(AiTranslateConfigurationProperties properties) {
+    return OpenAIProxyConfig.of(
+        properties.getProxyHost(),
+        properties.getProxyPort(),
+        properties.getProxyUser(),
+        properties.getProxyPassword());
   }
 
   @Bean

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfigurationProperties.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfigurationProperties.java
@@ -10,6 +10,10 @@ public class AiTranslateConfigurationProperties {
   String openaiClientToken;
   String schedulerName = QuartzSchedulerManager.DEFAULT_SCHEDULER_NAME;
   String modelName = "gpt-4o-2024-08-06";
+  String proxyHost;
+  Integer proxyPort;
+  String proxyUser;
+  String proxyPassword;
 
   public String getOpenaiClientToken() {
     return openaiClientToken;
@@ -33,5 +37,37 @@ public class AiTranslateConfigurationProperties {
 
   public void setModelName(String modelName) {
     this.modelName = modelName;
+  }
+
+  public String getProxyHost() {
+    return proxyHost;
+  }
+
+  public void setProxyHost(String proxyHost) {
+    this.proxyHost = proxyHost;
+  }
+
+  public Integer getProxyPort() {
+    return proxyPort;
+  }
+
+  public void setProxyPort(Integer proxyPort) {
+    this.proxyPort = proxyPort;
+  }
+
+  public String getProxyUser() {
+    return proxyUser;
+  }
+
+  public void setProxyUser(String proxyUser) {
+    this.proxyUser = proxyUser;
+  }
+
+  public String getProxyPassword() {
+    return proxyPassword;
+  }
+
+  public void setProxyPassword(String proxyPassword) {
+    this.proxyPassword = proxyPassword;
   }
 }

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -120,6 +120,24 @@ l10n.org.quartz.scheduler.skipUpdateCheck=true
 ### configure services as needed to use a different scheduler eg.
 
 #l10n.ai-translate.scheduler-name=ai-translate
+#
+# AI translation (OpenAI). When openai-client-token is set, Mojito can call the OpenAI API.
+# Optional HTTP proxy for environments that require outbound traffic through a proxy.
+# Both proxy-host and proxy-port must be set for proxy use.
+#l10n.ai-translate.openai-client-token=
+#l10n.ai-translate.model-name=gpt-4o-2024-08-06
+#l10n.ai-translate.proxy-host=
+#l10n.ai-translate.proxy-port=
+#l10n.ai-translate.proxy-user=
+#l10n.ai-translate.proxy-password=
+#
+# AI review (OpenAI). Same proxy properties apply when AI review is enabled.
+#l10n.ai-review.openai-client-token=
+#l10n.ai-review.model-name=gpt-4o-2024-08-06
+#l10n.ai-review.proxy-host=
+#l10n.ai-review.proxy-port=
+#l10n.ai-review.proxy-user=
+#l10n.ai-review.proxy-password=
 
 #l10n.assetWS.quartz.schedulerName=
 #l10n.assetService.quartz.schedulerName=

--- a/webapp/src/test/java/com/box/l10n/mojito/service/oaireview/AiReviewConfigTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/oaireview/AiReviewConfigTest.java
@@ -1,0 +1,67 @@
+package com.box.l10n.mojito.service.oaireview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.box.l10n.mojito.openai.OpenAIClient;
+import com.box.l10n.mojito.openai.OpenAIClientPool;
+import com.box.l10n.mojito.openai.OpenAIProxyConfig;
+import org.junit.Test;
+
+public class AiReviewConfigTest {
+
+  @Test
+  public void testOpenAiBeansAreNullWithoutToken() {
+    AiReviewConfigurationProperties properties = new AiReviewConfigurationProperties();
+    AiReviewConfig aiReviewConfig = new AiReviewConfig(properties);
+
+    assertNull(aiReviewConfig.openAIClient());
+    assertNull(aiReviewConfig.openAIClientPool());
+  }
+
+  @Test
+  public void testOpenAiBeansUseProxyConfiguration() {
+    AiReviewConfigurationProperties properties = new AiReviewConfigurationProperties();
+    properties.setOpenaiClientToken("test-token");
+    properties.setProxyHost("proxy.example.com");
+    properties.setProxyPort(3128);
+    properties.setProxyUser("proxy-user");
+    properties.setProxyPassword("proxy-password");
+
+    AiReviewConfig aiReviewConfig = new AiReviewConfig(properties);
+
+    OpenAIClient openAIClient = aiReviewConfig.openAIClient();
+    OpenAIClientPool openAIClientPool = aiReviewConfig.openAIClientPool();
+
+    assertNotNull(openAIClient);
+    assertNotNull(openAIClientPool);
+  }
+
+  @Test
+  public void testOpenAiBeansWithoutProxyConfiguration() {
+    AiReviewConfigurationProperties properties = new AiReviewConfigurationProperties();
+    properties.setOpenaiClientToken("test-token");
+
+    AiReviewConfig aiReviewConfig = new AiReviewConfig(properties);
+
+    assertNotNull(aiReviewConfig.openAIClient());
+    assertNotNull(aiReviewConfig.openAIClientPool());
+  }
+
+  @Test
+  public void testGetProxyConfigFromProperties() {
+    AiReviewConfigurationProperties properties = new AiReviewConfigurationProperties();
+    properties.setProxyHost("proxy.example.com");
+    properties.setProxyPort(3128);
+    properties.setProxyUser("proxy-user");
+    properties.setProxyPassword("proxy-password");
+
+    OpenAIProxyConfig proxyConfig = AiReviewConfig.getProxyConfig(properties);
+
+    assertEquals("proxy.example.com", proxyConfig.host());
+    assertEquals(Integer.valueOf(3128), proxyConfig.port());
+    assertEquals("proxy-user", proxyConfig.user());
+    assertEquals("proxy-password", proxyConfig.password());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/oaireview/AiReviewConfigurationPropertiesTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/oaireview/AiReviewConfigurationPropertiesTest.java
@@ -1,0 +1,48 @@
+package com.box.l10n.mojito.service.oaireview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    classes = {AiReviewConfigurationPropertiesTest.class},
+    properties = {
+      "l10n.ai-review.openai-client-token=test-token",
+      "l10n.ai-review.model-name=gpt-4o-test",
+      "l10n.ai-review.proxy-host=proxy.example.com",
+      "l10n.ai-review.proxy-port=3128",
+      "l10n.ai-review.proxy-user=proxy-user",
+      "l10n.ai-review.proxy-password=proxy-password"
+    })
+@EnableConfigurationProperties(AiReviewConfigurationProperties.class)
+public class AiReviewConfigurationPropertiesTest {
+
+  @Autowired AiReviewConfigurationProperties aiReviewConfigurationProperties;
+
+  @Test
+  public void testProxyPropertiesAreBound() {
+    assertEquals("test-token", aiReviewConfigurationProperties.getOpenaiClientToken());
+    assertEquals("gpt-4o-test", aiReviewConfigurationProperties.getModelName());
+    assertEquals("proxy.example.com", aiReviewConfigurationProperties.getProxyHost());
+    assertEquals(Integer.valueOf(3128), aiReviewConfigurationProperties.getProxyPort());
+    assertEquals("proxy-user", aiReviewConfigurationProperties.getProxyUser());
+    assertEquals("proxy-password", aiReviewConfigurationProperties.getProxyPassword());
+  }
+
+  @Test
+  public void testProxyPropertiesDefaultToNullWhenUnset() {
+    AiReviewConfigurationProperties properties = new AiReviewConfigurationProperties();
+
+    assertNull(properties.getProxyHost());
+    assertNull(properties.getProxyPort());
+    assertNull(properties.getProxyUser());
+    assertNull(properties.getProxyPassword());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfigTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfigTest.java
@@ -1,0 +1,67 @@
+package com.box.l10n.mojito.service.oaitranslate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.box.l10n.mojito.openai.OpenAIClient;
+import com.box.l10n.mojito.openai.OpenAIClientPool;
+import com.box.l10n.mojito.openai.OpenAIProxyConfig;
+import org.junit.Test;
+
+public class AiTranslateConfigTest {
+
+  @Test
+  public void testOpenAiBeansAreNullWithoutToken() {
+    AiTranslateConfigurationProperties properties = new AiTranslateConfigurationProperties();
+    AiTranslateConfig aiTranslateConfig = new AiTranslateConfig(properties);
+
+    assertNull(aiTranslateConfig.openAIClient());
+    assertNull(aiTranslateConfig.openAIClientPool());
+  }
+
+  @Test
+  public void testOpenAiBeansUseProxyConfiguration() {
+    AiTranslateConfigurationProperties properties = new AiTranslateConfigurationProperties();
+    properties.setOpenaiClientToken("test-token");
+    properties.setProxyHost("proxy.example.com");
+    properties.setProxyPort(3128);
+    properties.setProxyUser("proxy-user");
+    properties.setProxyPassword("proxy-password");
+
+    AiTranslateConfig aiTranslateConfig = new AiTranslateConfig(properties);
+
+    OpenAIClient openAIClient = aiTranslateConfig.openAIClient();
+    OpenAIClientPool openAIClientPool = aiTranslateConfig.openAIClientPool();
+
+    assertNotNull(openAIClient);
+    assertNotNull(openAIClientPool);
+  }
+
+  @Test
+  public void testOpenAiBeansWithoutProxyConfiguration() {
+    AiTranslateConfigurationProperties properties = new AiTranslateConfigurationProperties();
+    properties.setOpenaiClientToken("test-token");
+
+    AiTranslateConfig aiTranslateConfig = new AiTranslateConfig(properties);
+
+    assertNotNull(aiTranslateConfig.openAIClient());
+    assertNotNull(aiTranslateConfig.openAIClientPool());
+  }
+
+  @Test
+  public void testGetProxyConfigFromProperties() {
+    AiTranslateConfigurationProperties properties = new AiTranslateConfigurationProperties();
+    properties.setProxyHost("proxy.example.com");
+    properties.setProxyPort(3128);
+    properties.setProxyUser("proxy-user");
+    properties.setProxyPassword("proxy-password");
+
+    OpenAIProxyConfig proxyConfig = AiTranslateConfig.getProxyConfig(properties);
+
+    assertEquals("proxy.example.com", proxyConfig.host());
+    assertEquals(Integer.valueOf(3128), proxyConfig.port());
+    assertEquals("proxy-user", proxyConfig.user());
+    assertEquals("proxy-password", proxyConfig.password());
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfigurationPropertiesTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateConfigurationPropertiesTest.java
@@ -1,0 +1,48 @@
+package com.box.l10n.mojito.service.oaitranslate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(
+    classes = {AiTranslateConfigurationPropertiesTest.class},
+    properties = {
+      "l10n.ai-translate.openai-client-token=test-token",
+      "l10n.ai-translate.model-name=gpt-4o-test",
+      "l10n.ai-translate.proxy-host=proxy.example.com",
+      "l10n.ai-translate.proxy-port=3128",
+      "l10n.ai-translate.proxy-user=proxy-user",
+      "l10n.ai-translate.proxy-password=proxy-password"
+    })
+@EnableConfigurationProperties(AiTranslateConfigurationProperties.class)
+public class AiTranslateConfigurationPropertiesTest {
+
+  @Autowired AiTranslateConfigurationProperties aiTranslateConfigurationProperties;
+
+  @Test
+  public void testProxyPropertiesAreBound() {
+    assertEquals("test-token", aiTranslateConfigurationProperties.getOpenaiClientToken());
+    assertEquals("gpt-4o-test", aiTranslateConfigurationProperties.getModelName());
+    assertEquals("proxy.example.com", aiTranslateConfigurationProperties.getProxyHost());
+    assertEquals(Integer.valueOf(3128), aiTranslateConfigurationProperties.getProxyPort());
+    assertEquals("proxy-user", aiTranslateConfigurationProperties.getProxyUser());
+    assertEquals("proxy-password", aiTranslateConfigurationProperties.getProxyPassword());
+  }
+
+  @Test
+  public void testProxyPropertiesDefaultToNullWhenUnset() {
+    AiTranslateConfigurationProperties properties = new AiTranslateConfigurationProperties();
+
+    assertNull(properties.getProxyHost());
+    assertNull(properties.getProxyPort());
+    assertNull(properties.getProxyUser());
+    assertNull(properties.getProxyPassword());
+  }
+}


### PR DESCRIPTION
- modify OpenAIClient to handle proxy servers when talking to OpenAI
- add OpenAIProxyConfig to pick up the configuration for the proxy
    - proxy is allowed to be the same one as for talking to Box 3rd party API
- added same functionality for AI review
- added unit tests for the new functionality
- added documentation in the example configuration