### PR TITLE
Make TM import asynchronous

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/TMImportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/TMImportCommand.java
@@ -10,6 +10,7 @@ import com.box.l10n.mojito.cli.filefinder.file.XliffFileType;
 import com.box.l10n.mojito.rest.client.AssetClient;
 import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.client.exception.ResourceNotCreatedException;
+import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -123,23 +124,15 @@ public class TMImportCommand extends Command {
           .a(" - Importing file: ")
           .fg(Ansi.Color.MAGENTA)
           .a(relativeFilePath.toString())
-          .fg(Ansi.Color.YELLOW)
-          .a(" Running")
           .println();
 
-      repositoryClient.importRepository(
-          repository.getId(), getFileContent(fileMatch), updateTMParam);
+      PollableTask pollableTask =
+          repositoryClient.importRepository(
+              repository.getId(), getFileContent(fileMatch), updateTMParam);
 
-      consoleWriter.erasePreviouslyPrintedLines();
-      consoleWriter
-          .a(" - Importing file: ")
-          .fg(Ansi.Color.MAGENTA)
-          .a(relativeFilePath.toString())
-          .fg(Ansi.Color.GREEN)
-          .a(" Done")
-          .println();
+      commandHelper.waitForPollableTask(pollableTask.getId());
 
-    } catch (ResourceNotCreatedException e) {
+    } catch (ResourceNotCreatedException | CommandException e) {
       throw new CommandException(
           "Error importing ["
               + fileMatch.getPath().toString()

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryClient.java
@@ -140,10 +140,11 @@ public class RepositoryClient extends BaseClient {
    * @param exportedXliffContent
    * @param updateTM indicates if the TM should be updated or if the translation can be imported
    *     assuming that there is no translation yet.
-   * @return
+   * @return a {@link PollableTask} to track the import progress
    * @throws ResourceNotCreatedException
    */
-  public void importRepository(Long repositoryId, String exportedXliffContent, boolean updateTM)
+  public PollableTask importRepository(
+      Long repositoryId, String exportedXliffContent, boolean updateTM)
       throws ResourceNotCreatedException {
 
     String pathToImport = getBasePathForResource(repositoryId, "xliffImport");
@@ -153,8 +154,8 @@ public class RepositoryClient extends BaseClient {
     importRepositoryBody.setUpdateTM(updateTM);
 
     try {
-      authenticatedRestTemplate.postForEntity(pathToImport, importRepositoryBody, Void.class);
-
+      return authenticatedRestTemplate.postForObject(
+          pathToImport, importRepositoryBody, PollableTask.class);
     } catch (HttpClientErrorException exception) {
       if (exception.getStatusCode().equals(HttpStatus.CONFLICT)) {
         throw new ResourceNotCreatedException(

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/AuthenticatedRestTemplate.java
@@ -72,6 +72,11 @@ public class AuthenticatedRestTemplate {
     makeRestTemplateWithCustomObjectMapper(restTemplate);
     setErrorHandlerWithLogging(restTemplate);
 
+    if (resttemplateConfig.getReadTimeoutSeconds() != null) {
+      restTemplate.setCookieStoreAndUpdateRequestFactory(
+          restTemplate.getCookieStore(), resttemplateConfig.getReadTimeoutSeconds());
+    }
+
     ResttemplateConfig.AuthenticationMode mode = resttemplateConfig.getAuthenticationMode();
 
     switch (mode) {

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/CookieStoreRestTemplate.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/CookieStoreRestTemplate.java
@@ -1,9 +1,11 @@
 package com.box.l10n.mojito.rest.resttemplate;
 
 import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -26,17 +28,27 @@ public class CookieStoreRestTemplate extends RestTemplate {
   }
 
   public void setCookieStoreAndUpdateRequestFactory(CookieStore cookieStore) {
-    this.cookieStore = cookieStore;
-    HttpClient hc =
-        HttpClientBuilder.create()
-            .setDefaultCookieStore(cookieStore)
-            // we have to turn off auto redirect in the rest template because
-            // when session expires, it will return a 302 and resttemplate
-            // will automatically redirect to /login even before returning
-            // the ClientHttpResponse in the interceptor
-            .disableRedirectHandling()
-            .build();
+    setCookieStoreAndUpdateRequestFactory(cookieStore, null);
+  }
 
+  public void setCookieStoreAndUpdateRequestFactory(
+      CookieStore cookieStore, Integer readTimeoutSeconds) {
+    this.cookieStore = cookieStore;
+
+    // We have to turn off auto redirect in the rest template because
+    // when session expires, it will return a 302 and resttemplate
+    // will automatically redirect to /login even before returning
+    // the ClientHttpResponse in the interceptor
+    HttpClientBuilder builder =
+        HttpClientBuilder.create().setDefaultCookieStore(cookieStore).disableRedirectHandling();
+
+    if (readTimeoutSeconds != null && readTimeoutSeconds > 0) {
+      RequestConfig requestConfig =
+          RequestConfig.custom().setResponseTimeout(Timeout.ofSeconds(readTimeoutSeconds)).build();
+      builder.setDefaultRequestConfig(requestConfig);
+    }
+
+    HttpClient hc = builder.build();
     setRequestFactory(new HttpComponentsClientHttpRequestFactory(hc));
   }
 

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/ResttemplateConfig.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/resttemplate/ResttemplateConfig.java
@@ -20,6 +20,8 @@ public class ResttemplateConfig {
   String scheme = "http";
   String contextPath = "";
 
+  Integer readTimeoutSeconds;
+
   Authentication authentication = new Authentication();
 
   StatelessAuthentication stateless = new StatelessAuthentication();
@@ -224,5 +226,13 @@ public class ResttemplateConfig {
 
   public void setContextPath(String contextPath) {
     this.contextPath = contextPath;
+  }
+
+  public Integer getReadTimeoutSeconds() {
+    return readTimeoutSeconds;
+  }
+
+  public void setReadTimeoutSeconds(Integer readTimeoutSeconds) {
+    this.readTimeoutSeconds = readTimeoutSeconds;
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
@@ -159,10 +159,10 @@ public class RepositoryWS {
       throw new RepositoryWithIdNotFoundException(repositoryId);
     }
 
-    String normalizedContent =
-        NormalizationUtils.normalize(importRepositoryBody.getXliffContent());
+    String normalizedContent = NormalizationUtils.normalize(importRepositoryBody.getXliffContent());
     PollableFuture<Void> pollableFuture =
-        tmImportService.importXLIFF(repository, normalizedContent, importRepositoryBody.isUpdateTM());
+        tmImportService.importXLIFF(
+            repository, normalizedContent, importRepositoryBody.isUpdateTM());
 
     return pollableFuture.getPollableTask();
   }

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/repository/RepositoryWS.java
@@ -137,7 +137,8 @@ public class RepositoryWS {
   }
 
   /**
-   * Imports an entire {@link Repository} given an XLIFF
+   * Imports an entire {@link Repository} given an XLIFF. The import runs asynchronously and a
+   * {@link PollableTask} is returned to track progress.
    *
    * @param repositoryId
    * @param importRepositoryBody
@@ -146,25 +147,24 @@ public class RepositoryWS {
   @RequestMapping(
       value = "/api/repositories/{repositoryId}/xliffImport",
       method = RequestMethod.POST)
-  public ResponseEntity importRepository(
-      @PathVariable Long repositoryId, @RequestBody ImportRepositoryBody importRepositoryBody) {
+  public PollableTask importRepository(
+      @PathVariable Long repositoryId, @RequestBody ImportRepositoryBody importRepositoryBody)
+      throws RepositoryWithIdNotFoundException {
 
     logger.info("Importing for repo: [{}]", repositoryId);
 
-    try {
-      String normalizedContent =
-          NormalizationUtils.normalize(importRepositoryBody.getXliffContent());
-      tmImportService.importXLIFF(
-          repositoryRepository.getOne(repositoryId),
-          normalizedContent,
-          importRepositoryBody.isUpdateTM());
+    Repository repository = repositoryRepository.findById(repositoryId).orElse(null);
 
-      return new ResponseEntity(HttpStatus.CREATED);
-    } catch (RuntimeException exception) {
-      String msg = "Unable to import: " + exception.getMessage();
-      logger.debug(msg, exception);
-      return new ResponseEntity(msg, HttpStatus.CONFLICT);
+    if (repository == null) {
+      throw new RepositoryWithIdNotFoundException(repositoryId);
     }
+
+    String normalizedContent =
+        NormalizationUtils.normalize(importRepositoryBody.getXliffContent());
+    PollableFuture<Void> pollableFuture =
+        tmImportService.importXLIFF(repository, normalizedContent, importRepositoryBody.isUpdateTM());
+
+    return pollableFuture.getPollableTask();
   }
 
   /**

--- a/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMImportService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/tm/TMImportService.java
@@ -8,6 +8,9 @@ import com.box.l10n.mojito.okapi.RawDocument;
 import com.box.l10n.mojito.service.asset.AssetRepository;
 import com.box.l10n.mojito.service.asset.AssetService;
 import com.box.l10n.mojito.service.locale.LocaleService;
+import com.box.l10n.mojito.service.pollableTask.Pollable;
+import com.box.l10n.mojito.service.pollableTask.PollableFuture;
+import com.box.l10n.mojito.service.pollableTask.PollableFutureTaskResult;
 import net.sf.okapi.common.LocaleId;
 import net.sf.okapi.common.pipelinedriver.IPipelineDriver;
 import net.sf.okapi.common.pipelinedriver.PipelineDriver;
@@ -43,18 +46,22 @@ public class TMImportService {
   @Autowired ImportExportTextUnitUtils importExportTextUnitUtils;
 
   /**
-   * Import the exported XLIFF using Okapi driver into repository.
+   * Import the exported XLIFF using Okapi driver into repository asynchronously.
    *
    * @param repository
    * @param xliffContent
    * @param updateTM indicates if the TM should be updated or if the translation can be imported
    *     assuming that there is no translation yet.
+   * @return a {@link PollableFuture} to track the import progress
    */
-  public void importXLIFF(Repository repository, String xliffContent, boolean updateTM) {
+  @Pollable(async = true, message = "Importing XLIFF")
+  public PollableFuture<Void> importXLIFF(
+      Repository repository, String xliffContent, boolean updateTM) {
 
     ImportExportedXliffStep importExportedXliffStep =
         new ImportExportedXliffStep(repository, xliffContent, updateTM);
-    importXLIFF(importExportedXliffStep, xliffContent);
+    doImportXLIFF(importExportedXliffStep, xliffContent);
+    return new PollableFutureTaskResult<>();
   }
 
   /**
@@ -69,11 +76,11 @@ public class TMImportService {
     Asset asset = assetRepository.findById(assetId).orElse(null);
     ImportExportedXliffStep importExportedXliffStep =
         new ImportExportedXliffStep(asset, xliffContent, updateTM);
-    importXLIFF(importExportedXliffStep, xliffContent);
+    doImportXLIFF(importExportedXliffStep, xliffContent);
   }
 
   @Transactional
-  private void importXLIFF(ImportExportedXliffStep importExportedXliffStep, String xliffContent) {
+  private void doImportXLIFF(ImportExportedXliffStep importExportedXliffStep, String xliffContent) {
 
     IPipelineDriver driver = new PipelineDriver();
     XLIFFFilter xliffFilter = new XLIFFFilter();


### PR DESCRIPTION
TM import would time out for larger files due to connection timeout. Changed the TM import to a pollable task instead (consistent with TM export and other potentially long-running tasks).

Also added a CLI config prop `l10n.resttemplate.readTimeoutSeconds` to allow temporarily overriding default connection timeout if needed urgently.