### PR TITLE
Add --json flag to various CLI commands for use in AI translate scripts

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/Command.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/Command.java
@@ -5,9 +5,11 @@ import com.beust.jcommander.Parameters;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Base class for Commands, provides basic support for usage display.
+ * Base class for Commands, provides basic support for usage display and the shared {@code --json}
+ * machine-readable output convention.
  *
  * @author jaurambault
  */
@@ -16,6 +18,11 @@ public abstract class Command {
   static final String HELP_LONG = "--help";
   static final String HELP_SHORT = "-h";
   static final String HELP_DESCRIPTION = "Show help";
+
+  public static final String JSON_LONG = "--json";
+  public static final String JSON_DESCRIPTION =
+      "Emit a single machine-readable JSON result on stdout instead of human console output";
+
   public List<String> originalArgs;
 
   @Parameter(
@@ -23,6 +30,14 @@ public abstract class Command {
       help = true,
       description = HELP_DESCRIPTION)
   private boolean help;
+
+  @Parameter(
+      names = {JSON_LONG},
+      description = JSON_DESCRIPTION)
+  private boolean jsonOutput;
+
+  @Autowired(required = false)
+  JsonOutput jsonOutputWriter;
 
   /**
    * Method to be overridden to implement the business logic of this command
@@ -57,6 +72,39 @@ public abstract class Command {
    */
   public boolean shouldShowUsage() {
     return help;
+  }
+
+  /**
+   * Whether this invocation requested machine-readable JSON on stdout ({@code --json}). When true,
+   * commands should suppress human console progress and emit a JSON envelope via {@link
+   * #writeJsonSuccess(Object)} / {@link #writeJsonFailure(String)}.
+   */
+  public boolean isJsonOutput() {
+    return jsonOutput;
+  }
+
+  /** Write a successful JSON envelope (only when {@link #isJsonOutput()} is true). */
+  protected void writeJsonSuccess(Object data) {
+    if (!isJsonOutput()) {
+      return;
+    }
+    requireJsonOutputWriter().writeSuccess(getName(), data);
+  }
+
+  /** Write a failure JSON envelope (only when {@link #isJsonOutput()} is true). */
+  protected void writeJsonFailure(String error) {
+    if (!isJsonOutput()) {
+      return;
+    }
+    requireJsonOutputWriter().writeFailure(getName(), error);
+  }
+
+  private JsonOutput requireJsonOutputWriter() {
+    if (jsonOutputWriter == null) {
+      throw new IllegalStateException(
+          "JsonOutput bean is not available; --json requires Spring wiring");
+    }
+    return jsonOutputWriter;
   }
 
   /** Shows the command usage. */

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DropExportCommand.java
@@ -13,7 +13,9 @@ import com.box.l10n.mojito.rest.entity.RepositoryLocaleStatistic;
 import com.box.l10n.mojito.rest.entity.RepositoryStatistic;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.fusesource.jansi.Ansi.Color;
 import org.slf4j.Logger;
@@ -76,12 +78,14 @@ public class DropExportCommand extends Command {
   @Override
   public void execute() throws CommandException {
 
-    consoleWriter
-        .newLine()
-        .a("Export a Drop from repository: ")
-        .fg(Color.CYAN)
-        .a(repositoryParam)
-        .println(2);
+    if (!isJsonOutput()) {
+      consoleWriter
+          .newLine()
+          .a("Export a Drop from repository: ")
+          .fg(Color.CYAN)
+          .a(repositoryParam)
+          .println(2);
+    }
 
     Repository repository = commandHelper.findRepositoryByName(repositoryParam);
 
@@ -89,27 +93,53 @@ public class DropExportCommand extends Command {
       throw new CommandException("--use-inheritance can only be used with --type REVIEW");
     }
 
+    List<String> locales = getBcp47TagsForExport(repository);
+
     if (typeParam == ExportDropConfig.Type.REVIEW || shouldCreateDrop(repository)) {
       ExportDropConfig exportDropConfig = new ExportDropConfig();
       exportDropConfig.setRepositoryId(repository.getId());
       exportDropConfig.setType(typeParam);
-      exportDropConfig.setBcp47Tags(getBcp47TagsForExport(repository));
+      exportDropConfig.setBcp47Tags(locales);
       exportDropConfig.setUseInheritance(useInheritance);
 
       exportDropConfig = dropClient.exportDrop(exportDropConfig);
 
-      consoleWriter.a("Drop id: ").fg(Color.CYAN).a(exportDropConfig.getDropId()).print();
+      if (!isJsonOutput()) {
+        consoleWriter.a("Drop id: ").fg(Color.CYAN).a(exportDropConfig.getDropId()).print();
+      }
 
       PollableTask pollableTask = exportDropConfig.getPollableTask();
       commandHelper.waitForPollableTask(pollableTask.getId());
 
-      consoleWriter.newLine().fg(Color.GREEN).a("Finished").println(2);
+      if (isJsonOutput()) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("repository", repositoryParam);
+        data.put("created", true);
+        data.put("dropId", exportDropConfig.getDropId());
+        data.put("pollableTaskId", pollableTask.getId());
+        data.put("locales", locales);
+        if (typeParam != null) {
+          data.put("type", typeParam.name());
+        }
+        writeJsonSuccess(data);
+      } else {
+        consoleWriter.newLine().fg(Color.GREEN).a("Finished").println(2);
+      }
     } else {
-      consoleWriter
-          .newLine()
-          .fg(Color.GREEN)
-          .a("Repository is already fully translated")
-          .println(2);
+      if (isJsonOutput()) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("repository", repositoryParam);
+        data.put("created", false);
+        data.put("locales", locales);
+        data.put("reason", "Repository is already fully translated");
+        writeJsonSuccess(data);
+      } else {
+        consoleWriter
+            .newLine()
+            .fg(Color.GREEN)
+            .a("Repository is already fully translated")
+            .println(2);
+      }
     }
   }
 

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/DropImportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/DropImportCommand.java
@@ -3,10 +3,15 @@ package com.box.l10n.mojito.cli.command;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.rest.entity.Drop;
 import com.box.l10n.mojito.rest.entity.ImportDropConfig;
 import com.box.l10n.mojito.rest.entity.PollableTask;
 import com.box.l10n.mojito.rest.entity.Repository;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.fusesource.jansi.Ansi.Color;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +21,9 @@ import org.springframework.stereotype.Component;
 /**
  * Command to import a drop. Displays the list of drops available and ask the user the drop id to be
  * imported.
+ *
+ * <p>With {@code --json}: if neither {@code --drop-id} nor {@code --import-fetched} is set, lists
+ * available drops and exits (non-interactive). Otherwise imports and returns the imported drop ids.
  *
  * @author jaurambault
  */
@@ -47,27 +55,59 @@ public class DropImportCommand extends ProcessDropCommand {
 
     Repository repository = commandHelper.findRepositoryByName(repositoryParam);
 
+    boolean listOnly =
+        isJsonOutput() && importDropId == null && !Boolean.TRUE.equals(importFetchedParam);
+
+    if (listOnly) {
+      Map<Long, Drop> numberedAvailableDrops = fetchNumberedAvailableDrops();
+      List<Map<String, Object>> available = new ArrayList<>();
+      for (Drop drop : numberedAvailableDrops.values()) {
+        available.add(toDropJson(drop));
+      }
+      Map<String, Object> data = new LinkedHashMap<>();
+      data.put("repository", repositoryParam);
+      data.put("available", available);
+      writeJsonSuccess(data);
+      return;
+    }
+
     Collection<Long> dropIds = getDropIdsToProcess(importFetchedParam);
 
+    List<Map<String, Object>> imported = new ArrayList<>();
+
     for (Long dropId : dropIds) {
-      consoleWriter
-          .newLine()
-          .a("Import drop: ")
-          .fg(Color.CYAN)
-          .a(dropId)
-          .reset()
-          .a(" in repository: ")
-          .fg(Color.CYAN)
-          .a(repositoryParam)
-          .println(2);
+      if (!isJsonOutput()) {
+        consoleWriter
+            .newLine()
+            .a("Import drop: ")
+            .fg(Color.CYAN)
+            .a(dropId)
+            .reset()
+            .a(" in repository: ")
+            .fg(Color.CYAN)
+            .a(repositoryParam)
+            .println(2);
+      }
 
       ImportDropConfig importDropConfig =
           dropClient.importDrop(repository, dropId, importStatusParam);
       PollableTask pollableTask = importDropConfig.getPollableTask();
 
       commandHelper.waitForPollableTask(pollableTask.getId());
+
+      Map<String, Object> importedDrop = new LinkedHashMap<>();
+      importedDrop.put("id", dropId);
+      importedDrop.put("pollableTaskId", pollableTask.getId());
+      imported.add(importedDrop);
     }
 
-    consoleWriter.newLine().fg(Color.GREEN).a("Finished").println(2);
+    if (isJsonOutput()) {
+      Map<String, Object> data = new LinkedHashMap<>();
+      data.put("repository", repositoryParam);
+      data.put("imported", imported);
+      writeJsonSuccess(data);
+    } else {
+      consoleWriter.newLine().fg(Color.GREEN).a("Finished").println(2);
+    }
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/JsonOutput.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/JsonOutput.java
@@ -1,0 +1,60 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Shared helper for the CLI {@code --json} convention: emit a single machine-readable JSON document
+ * on stdout (no ANSI), suitable for scripts and Jenkins to parse.
+ *
+ * <p>Envelope shape:
+ *
+ * <pre>
+ * {
+ *   "successful": true|false,
+ *   "command": "&lt;command-name&gt;",
+ *   "data": { ... },      // present on success
+ *   "error": "..."        // present on failure
+ * }
+ * </pre>
+ *
+ * <p>When {@code --json} is set, commands should suppress human {@code ConsoleWriter} progress on
+ * stdout and call {@link #writeSuccess} / {@link #writeFailure} instead. Progress may still go to
+ * the logger / stderr.
+ */
+@Component
+public class JsonOutput {
+
+  @Autowired ObjectMapper objectMapper;
+
+  /** Write a successful result envelope for {@code command} with payload {@code data}. */
+  public void writeSuccess(String command, Object data) {
+    Map<String, Object> envelope = new LinkedHashMap<>();
+    envelope.put("successful", true);
+    envelope.put("command", command);
+    envelope.put("data", data);
+    write(envelope);
+  }
+
+  /** Write a failure result envelope for {@code command}. */
+  public void writeFailure(String command, String error) {
+    Map<String, Object> envelope = new LinkedHashMap<>();
+    envelope.put("successful", false);
+    envelope.put("command", command == null ? "" : command);
+    envelope.put("error", error == null ? "" : error);
+    write(envelope);
+  }
+
+  /** Serialize {@code value} as pretty-printed JSON to stdout. */
+  public void write(Object value) {
+    try {
+      System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize JSON output", e);
+    }
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/L10nJCommander.java
@@ -43,6 +43,8 @@ public class L10nJCommander {
 
   @Autowired AuthenticatedRestTemplate authenticatedRestTemplate;
 
+  @Autowired JsonOutput jsonOutput;
+
   static final String PROGRAM_NAME = "mojito";
 
   boolean systemExitEnabled = true;
@@ -105,15 +107,18 @@ public class L10nJCommander {
     }
 
     String parsedCommand = jCommander.getParsedCommand();
+    boolean jsonRequested = isJsonRequested(args, parsedCommand);
 
     if (parsingException != null) {
       logger.debug("Parsing failed, show help");
-      printErrorMessage(parsingException.getMessage());
+      printErrorMessage(parsingException.getMessage(), parsedCommand, jsonRequested);
 
-      if (parsedCommand == null) {
-        usage();
-      } else {
-        usage(parsedCommand);
+      if (!jsonRequested) {
+        if (parsedCommand == null) {
+          usage();
+        } else {
+          usage(parsedCommand);
+        }
       }
       exitWithError();
     } else {
@@ -125,19 +130,23 @@ public class L10nJCommander {
         command.run();
       } catch (SessionAuthenticationException ae) {
         logger.debug("Exit with Invalid username or password", ae);
-        printErrorMessage("Invalid username or password");
+        printErrorMessage(
+            "Invalid username or password", command.getName(), command.isJsonOutput());
         exitWithError();
       } catch (CommandWithExitStatusException cwese) {
         logger.error("Exit with error for command: " + command.getName(), cwese);
+        if (command.isJsonOutput()) {
+          printErrorMessage(cwese.getMessage(), command.getName(), true);
+        }
         exitWithError(cwese.getExitCode());
       } catch (CommandException ce) {
-        printErrorMessage(ce.getMessage());
+        printErrorMessage(ce.getMessage(), command.getName(), command.isJsonOutput());
         logger.error("Exit with error for command: " + command.getName(), ce);
         exitWithError();
       } catch (ResourceAccessException rae) {
         String msg =
             "Is a server running on: " + authenticatedRestTemplate.getURIForResource("") + "?";
-        printErrorMessage(msg);
+        printErrorMessage(msg, command.getName(), command.isJsonOutput());
         logger.error(msg, rae);
         exitWithError();
       } catch (HttpClientErrorException | HttpServerErrorException e) {
@@ -148,17 +157,31 @@ public class L10nJCommander {
                 + ExceptionUtils.getStackTrace(e)
                 + "\n"
                 + e.getResponseBodyAsString();
-        printErrorMessage(msg);
+        printErrorMessage(msg, command.getName(), command.isJsonOutput());
         logger.error("Unexpected error", e);
         logger.error(e.getResponseBodyAsString());
         exitWithError();
       } catch (Throwable t) {
         String msg = "Unexpected error: " + t.getMessage() + "\n" + ExceptionUtils.getStackTrace(t);
-        printErrorMessage(msg);
+        printErrorMessage(msg, command.getName(), command.isJsonOutput());
         logger.error("Unexpected error", t);
         exitWithError();
       }
     }
+  }
+
+  /**
+   * Whether this run should emit JSON errors. Prefer the parsed command's flag; fall back to
+   * scanning argv (e.g. parse failures before the command object is fully usable).
+   */
+  boolean isJsonRequested(String[] args, String parsedCommand) {
+    if (parsedCommand != null) {
+      Command command = getCommand(parsedCommand);
+      if (command != null && command.isJsonOutput()) {
+        return true;
+      }
+    }
+    return Arrays.asList(args).contains(Command.JSON_LONG);
   }
 
   /** Display the usage in the appLogger (instead of System.out). */
@@ -249,12 +272,19 @@ public class L10nJCommander {
   }
 
   /**
-   * Prints the error message with ANSI escape codee.
+   * Prints the error message. In {@code --json} mode, emits a failure envelope on stdout; otherwise
+   * prints a human ANSI error on the console.
    *
    * @param errorMsg the error message
+   * @param commandName the command name (may be null)
+   * @param json whether to emit JSON
    */
-  private void printErrorMessage(String errorMsg) {
-    consoleWriter.newLine().fg(Ansi.Color.RED).a(errorMsg).println(2);
+  private void printErrorMessage(String errorMsg, String commandName, boolean json) {
+    if (json) {
+      jsonOutput.writeFailure(commandName, errorMsg);
+    } else {
+      consoleWriter.newLine().fg(Ansi.Color.RED).a(errorMsg).println(2);
+    }
   }
 
   public boolean isSystemExitEnabled() {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/ProcessDropCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/ProcessDropCommand.java
@@ -68,17 +68,55 @@ public abstract class ProcessDropCommand extends Command {
 
     if (numberedAvailableDrops.isEmpty()) {
       // command should not error when no drops are available
-      consoleWriter.newLine().a("No drop available").println();
+      if (!isJsonOutput()) {
+        consoleWriter.newLine().a("No drop available").println();
+      }
       return Collections.emptyList();
     }
 
-    consoleWriter.newLine().a("Drops available").println();
-    displayAvailableDrops(numberedAvailableDrops);
+    if (!isJsonOutput()) {
+      consoleWriter.newLine().a("Drops available").println();
+      displayAvailableDrops(numberedAvailableDrops);
+    }
 
     if (Boolean.TRUE.equals(allFetched)) {
       return getAllFetchedDropIds(numberedAvailableDrops);
     }
+
+    // --json is non-interactive: listing only (caller uses --drop-id / --import-fetched to act)
+    if (isJsonOutput()) {
+      return Collections.emptyList();
+    }
+
     return getFromConsoleDropIds(numberedAvailableDrops);
+  }
+
+  /** Available drops for the repository, keyed by display number (1-based). */
+  protected Map<Long, Drop> fetchNumberedAvailableDrops() {
+    Repository repository = commandHelper.findRepositoryByName(repositoryParam);
+    return getNumberedAvailableDrops(repository.getId());
+  }
+
+  /** Machine-readable view of a drop for {@code --json} output. */
+  protected Map<String, Object> toDropJson(Drop drop) {
+    Map<String, Object> dropJson = new LinkedHashMap<>();
+    dropJson.put("id", drop.getId());
+    dropJson.put("name", drop.getName());
+    dropJson.put("status", dropStatus(drop));
+    if (drop.getLastImportedDate() != null) {
+      dropJson.put("lastImportedDate", drop.getLastImportedDate().toString());
+    }
+    return dropJson;
+  }
+
+  protected String dropStatus(Drop drop) {
+    if (Boolean.TRUE.equals(drop.getCanceled())) {
+      return "CANCELED";
+    }
+    if (drop.getLastImportedDate() == null) {
+      return "NEW";
+    }
+    return "IMPORTED";
   }
 
   protected void displayAvailableDrops(Map<Long, Drop> numberedAvailableDrops) {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoCreateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoCreateCommand.java
@@ -11,8 +11,12 @@ import com.box.l10n.mojito.rest.entity.IntegrityChecker;
 import com.box.l10n.mojito.rest.entity.Locale;
 import com.box.l10n.mojito.rest.entity.Repository;
 import com.box.l10n.mojito.rest.entity.RepositoryLocale;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.fusesource.jansi.Ansi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,13 +100,17 @@ public class RepoCreateCommand extends RepoCommand {
 
   @Override
   public void execute() throws CommandException {
-    consoleWriter.a("Create repository: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+    boolean printHuman = !isJsonOutput();
+
+    if (printHuman) {
+      consoleWriter.a("Create repository: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+    }
 
     try {
       Set<RepositoryLocale> repositoryLocales =
-          localeHelper.extractRepositoryLocalesFromInput(encodedBcp47Tags, true);
+          localeHelper.extractRepositoryLocalesFromInput(encodedBcp47Tags, printHuman);
       Set<IntegrityChecker> integrityCheckers =
-          extractIntegrityCheckersFromInput(integrityCheckParam, true);
+          extractIntegrityCheckersFromInput(integrityCheckParam, printHuman);
 
       Locale sourceLocale = null;
 
@@ -118,14 +126,36 @@ public class RepoCreateCommand extends RepoCommand {
               repositoryLocales,
               integrityCheckers,
               checkSLA);
-      consoleWriter
-          .newLine()
-          .a("created --> repository id: ")
-          .fg(Ansi.Color.MAGENTA)
-          .a(repository.getId())
-          .println();
+
+      if (isJsonOutput()) {
+        writeJsonSuccess(toJsonData(repository));
+      } else {
+        consoleWriter
+            .newLine()
+            .a("created --> repository id: ")
+            .fg(Ansi.Color.MAGENTA)
+            .a(repository.getId())
+            .println();
+      }
     } catch (ParameterException | ResourceNotCreatedException | LocaleNotFoundException ex) {
       throw new CommandException(ex.getMessage(), ex);
     }
+  }
+
+  /** Payload under the shared {@code data} key for {@code --json} output. */
+  Map<String, Object> toJsonData(Repository repository) {
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("repo", repository.getName());
+    data.put("description", repository.getDescription());
+    data.put("id", repository.getId());
+    data.put(
+        "locales",
+        repository.getRepositoryLocales() == null
+            ? List.of()
+            : repository.getRepositoryLocales().stream()
+                .map(rl -> rl.getLocale().getBcp47Tag())
+                .sorted(Comparator.naturalOrder())
+                .collect(Collectors.toList()));
+    return data;
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoViewCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoViewCommand.java
@@ -9,7 +9,9 @@ import com.box.l10n.mojito.rest.entity.Repository;
 import com.box.l10n.mojito.rest.entity.RepositoryLocale;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.fusesource.jansi.Ansi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,22 +42,75 @@ public class RepoViewCommand extends RepoCommand {
 
   @Override
   public void execute() throws CommandException {
-    consoleWriter.a("View repository: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+    if (!isJsonOutput()) {
+      consoleWriter.a("View repository: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+    }
 
     try {
       Repository repository = repositoryClient.getRepositoryByName(nameParam);
-      consoleWriter
-          .newLine()
-          .a("Repository id --> ")
-          .fg(Ansi.Color.MAGENTA)
-          .a(repository.getId())
-          .println();
-      printIntegrityChecker(repository);
-      printLocales(repository);
-      consoleWriter.println();
+      if (isJsonOutput()) {
+        writeJsonSuccess(toJsonData(repository));
+      } else {
+        consoleWriter
+            .newLine()
+            .a("Repository id --> ")
+            .fg(Ansi.Color.MAGENTA)
+            .a(repository.getId())
+            .println();
+        printIntegrityChecker(repository);
+        printLocales(repository);
+        consoleWriter.println();
+      }
     } catch (RepositoryNotFoundException ex) {
       throw new CommandException(ex.getMessage(), ex);
     }
+  }
+
+  /** Payload under the shared {@code data} key for {@code --json} output. */
+  Map<String, Object> toJsonData(Repository repository) {
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("repo", repository.getName());
+    data.put("description", repository.getDescription());
+    data.put("id", repository.getId());
+    data.put("integrityCheckers", toIntegrityCheckersJson(repository));
+    data.put("locales", toLocalesJson(repository));
+    return data;
+  }
+
+  private List<Map<String, Object>> toIntegrityCheckersJson(Repository repository) {
+    List<Map<String, Object>> result = new ArrayList<>();
+    if (repository.getIntegrityCheckers() == null || repository.getIntegrityCheckers().isEmpty()) {
+      return result;
+    }
+    List<IntegrityChecker> integrityCheckers = new ArrayList<>(repository.getIntegrityCheckers());
+    Collections.sort(integrityCheckers, IntegrityChecker.getComparator());
+    for (IntegrityChecker integrityChecker : integrityCheckers) {
+      Map<String, Object> entry = new LinkedHashMap<>();
+      entry.put("assetExtension", integrityChecker.getAssetExtension());
+      entry.put("integrityCheckerType", integrityChecker.getIntegrityCheckerType().toString());
+      result.add(entry);
+    }
+    return result;
+  }
+
+  private List<Map<String, Object>> toLocalesJson(Repository repository) {
+    List<Map<String, Object>> result = new ArrayList<>();
+    if (repository.getRepositoryLocales() == null || repository.getRepositoryLocales().isEmpty()) {
+      return result;
+    }
+    List<RepositoryLocale> repositoryLocales = new ArrayList<>(repository.getRepositoryLocales());
+    Collections.sort(repositoryLocales, RepositoryLocale.getComparator());
+    for (RepositoryLocale repositoryLocale : repositoryLocales) {
+      Map<String, Object> entry = new LinkedHashMap<>();
+      entry.put("bcp47Tag", repositoryLocale.getLocale().getBcp47Tag());
+      entry.put("toBeFullyTranslated", repositoryLocale.isToBeFullyTranslated());
+      RepositoryLocale parentRepositoryLocale = repositoryLocale.getParentLocale();
+      if (parentRepositoryLocale != null && parentRepositoryLocale.getLocale() != null) {
+        entry.put("parentLocale", parentRepositoryLocale.getLocale().getBcp47Tag());
+      }
+      result.add(entry);
+    }
+    return result;
   }
 
   private void printIntegrityChecker(Repository repository) {

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepositoryAiTranslationCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepositoryAiTranslationCommand.java
@@ -15,7 +15,9 @@ import com.box.l10n.mojito.rest.client.RepositoryAiTranslateClient.ProtoAiTransl
 import com.box.l10n.mojito.rest.client.exception.PollableTaskException;
 import com.box.l10n.mojito.rest.entity.PollableTask;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -219,15 +221,35 @@ public class RepositoryAiTranslationCommand extends Command {
   @Override
   public void execute() throws CommandException {
 
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("repository", repositoryParam);
+    result.put("locales", locales);
+    result.put("useBatch", useBatch);
+    result.put("sourceTextMaxCount", sourceTextMaxCount);
+    result.put("dryRun", dryRun);
+    if (useModel != null) {
+      result.put("useModel", useModel);
+    }
+
+    Long watchedPollableTaskId = null;
+    List<String> reportPaths = new ArrayList<>();
+    String action = "translate";
+
     if (importJobId != null) {
-      consoleWriter
-          .a("Importing task id: ")
-          .fg(Color.MAGENTA)
-          .a(importJobId)
-          .a(" (resume: ")
-          .a(resume)
-          .a(")")
-          .println();
+      action = "retry-import";
+      result.put("importJobId", importJobId);
+      result.put("resume", resume);
+
+      if (!isJsonOutput()) {
+        consoleWriter
+            .a("Importing task id: ")
+            .fg(Color.MAGENTA)
+            .a(importJobId)
+            .a(" (resume: ")
+            .a(resume)
+            .a(")")
+            .println();
+      }
 
       Optional<PollableTask> lastForReimport =
           pollableTaskClient.getPollableTask(importJobId).getSubTasks().stream()
@@ -235,17 +257,33 @@ public class RepositoryAiTranslationCommand extends Command {
               .max(Comparator.comparing(PollableTask::getCreatedDate));
 
       if (lastForReimport.isEmpty()) {
-        consoleWriter
-            .fg(Color.YELLOW)
-            .a("No subtask found for task id: ")
-            .fg(Color.MAGENTA)
-            .a(importJobId)
-            .println();
+        if (isJsonOutput()) {
+          result.put("action", action);
+          result.put("aborted", true);
+          result.put("reason", "No subtask found for task id: " + importJobId);
+          writeJsonSuccess(result);
+        } else {
+          consoleWriter
+              .fg(Color.YELLOW)
+              .a("No subtask found for task id: ")
+              .fg(Color.MAGENTA)
+              .a(importJobId)
+              .println();
+          consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
+        }
+        return;
+      }
 
-      } else {
-        PollableTask lastTask = lastForReimport.get();
+      PollableTask lastTask = lastForReimport.get();
 
-        if (!lastTask.isAllFinished()) {
+      if (!lastTask.isAllFinished()) {
+        if (isJsonOutput()) {
+          result.put("action", action);
+          result.put("aborted", true);
+          result.put("reason", "Last task " + lastTask.getId() + " is not finished");
+          result.put("lastTaskId", lastTask.getId());
+          writeJsonSuccess(result);
+        } else {
           consoleWriter
               .fg(Color.YELLOW)
               .a("Last task: ")
@@ -254,40 +292,52 @@ public class RepositoryAiTranslationCommand extends Command {
               .reset()
               .a(" is not finished. Aborting...")
               .println();
-        } else {
-          long pollableTaskId =
-              repositoryAiTranslateClient.retryImport(lastForReimport.get().getId(), resume);
-          consoleWriter
-              .a("New import task id: ")
-              .fg(Color.MAGENTA)
-              .a(pollableTaskId)
-              .reset()
-              .a(" to monitor progress, and eventually re-attach (--attach-job-id)")
-              .println();
-          waitForPollable(pollableTaskId);
+          consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
         }
+        return;
       }
+
+      long pollableTaskId =
+          repositoryAiTranslateClient.retryImport(lastForReimport.get().getId(), resume);
+      watchedPollableTaskId = pollableTaskId;
+      if (!isJsonOutput()) {
+        consoleWriter
+            .a("New import task id: ")
+            .fg(Color.MAGENTA)
+            .a(pollableTaskId)
+            .reset()
+            .a(" to monitor progress, and eventually re-attach (--attach-job-id)")
+            .println();
+      }
+      waitForPollable(pollableTaskId);
     } else if (attachJobId != null) {
-      consoleWriter.a("Attaching, task id: ").fg(Color.MAGENTA).a(attachJobId).println();
+      action = "attach";
+      watchedPollableTaskId = attachJobId;
+      result.put("attachJobId", attachJobId);
+      if (!isJsonOutput()) {
+        consoleWriter.a("Attaching, task id: ").fg(Color.MAGENTA).a(attachJobId).println();
+      }
       waitForPollable(attachJobId);
     } else {
-      consoleWriter
-          .newLine()
-          .a("Ai translate repository: ")
-          .fg(Color.CYAN)
-          .a(repositoryParam)
-          .reset()
-          .a(", model: ")
-          .fg(Color.CYAN)
-          .a(useModel)
-          .reset()
-          .a(" for locales: ")
-          .fg(Color.CYAN)
-          .a(
-              locales == null
-                  ? "<all>"
-                  : locales.stream().collect(Collectors.joining(", ", "[", "]")))
-          .println(2);
+      if (!isJsonOutput()) {
+        consoleWriter
+            .newLine()
+            .a("Ai translate repository: ")
+            .fg(Color.CYAN)
+            .a(repositoryParam)
+            .reset()
+            .a(", model: ")
+            .fg(Color.CYAN)
+            .a(useModel)
+            .reset()
+            .a(" for locales: ")
+            .fg(Color.CYAN)
+            .a(
+                locales == null
+                    ? "<all>"
+                    : locales.stream().collect(Collectors.joining(", ", "[", "]")))
+            .println(2);
+      }
 
       ProtoAiTranslateResponse protoAiTranslateResponse =
           repositoryAiTranslateClient.translateRepository(
@@ -315,8 +365,11 @@ public class RepositoryAiTranslationCommand extends Command {
                   timeoutSeconds));
 
       PollableTask pollableTask = protoAiTranslateResponse.pollableTask();
+      watchedPollableTaskId = pollableTask.getId();
       if (useBatch) {
-        consoleWriter.a("Running, task id: ").fg(Color.MAGENTA).a(pollableTask.getId()).println();
+        if (!isJsonOutput()) {
+          consoleWriter.a("Running, task id: ").fg(Color.MAGENTA).a(pollableTask.getId()).println();
+        }
         waitForPollable(pollableTask.getId());
       } else {
         commandHelper.waitForPollableTask(pollableTask.getId());
@@ -331,13 +384,49 @@ public class RepositoryAiTranslationCommand extends Command {
             Path path = Path.of(reportLocaleUrl + ".json");
             Files.createDirectories(path.getParent());
             Files.write(path, reportLocale.content());
-            consoleWriter.a("- ").a(path.toAbsolutePath().toString()).println();
+            reportPaths.add(path.toAbsolutePath().toString());
+            if (!isJsonOutput()) {
+              consoleWriter.a("- ").a(path.toAbsolutePath().toString()).println();
+            }
           }
         }
       }
     }
 
-    consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
+    if (isJsonOutput()) {
+      result.put("action", action);
+      result.put("aborted", false);
+      result.put("pollableTaskId", watchedPollableTaskId);
+      if (!reportPaths.isEmpty()) {
+        result.put("reportPaths", reportPaths);
+      }
+      if ("translate".equals(action) && watchedPollableTaskId != null) {
+        addHasMoreFromPollableOutput(result, watchedPollableTaskId);
+      }
+      writeJsonSuccess(result);
+    } else {
+      consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
+    }
+  }
+
+  /**
+   * Reads {@link RepositoryAiTranslateClient.AiTranslateOutput} written by the server-side AI
+   * translate job and adds {@code hasMore} / {@code hasMoreByLocale} to the JSON result.
+   */
+  void addHasMoreFromPollableOutput(Map<String, Object> result, Long pollableTaskId) {
+    try {
+      String outputJson = pollableTaskClient.getPollableTaskOutput(pollableTaskId);
+      RepositoryAiTranslateClient.AiTranslateOutput output =
+          objectMapper.readValueUnchecked(
+              outputJson, RepositoryAiTranslateClient.AiTranslateOutput.class);
+      result.put("hasMore", output.hasMore());
+      result.put("hasMoreByLocale", output.hasMoreByLocale());
+    } catch (Exception e) {
+      logger.warn(
+          "Could not read AI translate hasMore from pollable task {}: {}",
+          pollableTaskId,
+          e.getMessage());
+    }
   }
 
   void waitForPollable(Long pollableTaskId) {
@@ -348,6 +437,10 @@ public class RepositoryAiTranslationCommand extends Command {
           pollableTaskId,
           PollableTaskClient.NO_TIMEOUT,
           pollableTask -> {
+            if (isJsonOutput()) {
+              return;
+            }
+
             Optional<PollableTask> lastFinishedForOutput =
                 pollableTask.getSubTasks().stream()
                     .filter(t -> t.getCreatedDate() != null)

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/TMExportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/TMExportCommand.java
@@ -13,7 +13,10 @@ import com.box.l10n.mojito.rest.entity.XliffExportBody;
 import com.google.common.base.MoreObjects;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.fusesource.jansi.Ansi.Color;
 import org.slf4j.Logger;
@@ -76,12 +79,14 @@ public class TMExportCommand extends Command {
   @Override
   public void execute() throws CommandException {
 
-    consoleWriter
-        .newLine()
-        .a("Export TM for repository: ")
-        .fg(Color.CYAN)
-        .a(repositoryParam)
-        .println(2);
+    if (!isJsonOutput()) {
+      consoleWriter
+          .newLine()
+          .a("Export TM for repository: ")
+          .fg(Color.CYAN)
+          .a(repositoryParam)
+          .println(2);
+    }
 
     commandDirectories = new CommandDirectories(null, targetDirectoryParam);
 
@@ -95,18 +100,23 @@ public class TMExportCommand extends Command {
     Set<RepositoryLocale> repositoryLocales = repository.getRepositoryLocales();
 
     long assetNumber = 0;
+    List<Map<String, Object>> exported = new ArrayList<>();
 
     for (Asset asset : assets) {
       assetNumber++;
 
-      consoleWriter.newLine().a("Asset: ").fg(Color.CYAN).a(asset.getPath()).println();
+      if (!isJsonOutput()) {
+        consoleWriter.newLine().a("Asset: ").fg(Color.CYAN).a(asset.getPath()).println();
+      }
 
       for (RepositoryLocale repositoryLocale : repositoryLocales) {
 
         String bcp47Tag = repositoryLocale.getLocale().getBcp47Tag();
 
         if (bcp47tagsParam == null || bcp47tagsParam.contains(bcp47Tag)) {
-          consoleWriter.a("Exporting: ").fg(Color.CYAN).a(bcp47Tag).print();
+          if (!isJsonOutput()) {
+            consoleWriter.a("Exporting: ").fg(Color.CYAN).a(bcp47Tag).print();
+          }
 
           XliffExportBody xliffExport =
               assetClient.exportAssetAsXLIFFAsync(asset.getId(), bcp47Tag);
@@ -122,12 +132,29 @@ public class TMExportCommand extends Command {
           String export = assetClient.getExportedXLIFF(asset.getId(), xliffExport.getTmXliffId());
           commandHelper.writeFileContent(export, exportFile);
 
-          consoleWriter.a(" --> ").fg(Color.MAGENTA).a(exportFile.toString()).println();
+          Map<String, Object> exportedFile = new LinkedHashMap<>();
+          exportedFile.put("assetPath", asset.getPath());
+          exportedFile.put("locale", bcp47Tag);
+          exportedFile.put("file", exportFile.toAbsolutePath().toString());
+          exportedFile.put("pollableTaskId", pollableTaskId);
+          exported.add(exportedFile);
+
+          if (!isJsonOutput()) {
+            consoleWriter.a(" --> ").fg(Color.MAGENTA).a(exportFile.toString()).println();
+          }
         }
       }
     }
 
-    consoleWriter.fg(Color.GREEN).newLine().a("Finished").println(2);
+    if (isJsonOutput()) {
+      Map<String, Object> data = new LinkedHashMap<>();
+      data.put("repository", repositoryParam);
+      data.put("targetBasename", targetBasenameParam);
+      data.put("exported", exported);
+      writeJsonSuccess(data);
+    } else {
+      consoleWriter.fg(Color.GREEN).newLine().a("Finished").println(2);
+    }
   }
 
   /**

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/TMImportCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/TMImportCommand.java
@@ -12,7 +12,11 @@ import com.box.l10n.mojito.rest.client.RepositoryClient;
 import com.box.l10n.mojito.rest.client.exception.ResourceNotCreatedException;
 import com.box.l10n.mojito.rest.entity.Repository;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.fusesource.jansi.Ansi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,18 +83,23 @@ public class TMImportCommand extends Command {
 
   CommandDirectories commandDirectories;
 
+  List<Map<String, Object>> imported;
+
   @Override
   public void execute() throws CommandException {
 
-    consoleWriter
-        .newLine()
-        .a("Start importing for TM: ")
-        .fg(Ansi.Color.CYAN)
-        .a(repositoryParam)
-        .println(2);
+    if (!isJsonOutput()) {
+      consoleWriter
+          .newLine()
+          .a("Start importing for TM: ")
+          .fg(Ansi.Color.CYAN)
+          .a(repositoryParam)
+          .println(2);
+    }
 
     repository = commandHelper.findRepositoryByName(repositoryParam);
     commandDirectories = new CommandDirectories(sourceDirectoryParam);
+    imported = new ArrayList<>();
 
     FileType xliffFileType = new XliffFileType();
 
@@ -98,46 +107,65 @@ public class TMImportCommand extends Command {
       for (FileMatch sourceFileMatch :
           commandHelper.getSourceFileMatches(
               commandDirectories, Arrays.asList(xliffFileType), null, null, null, null)) {
-        doImportFileMatch(sourceFileMatch);
+        doImportFileMatch(sourceFileMatch, "source");
       }
     }
 
     for (FileMatch targetFileMatch :
         commandHelper.getTargetFileMatches(
             commandDirectories, Arrays.asList(xliffFileType), null, null, null, null)) {
-      doImportFileMatch(targetFileMatch);
+      doImportFileMatch(targetFileMatch, "target");
     }
 
-    consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
+    if (isJsonOutput()) {
+      Map<String, Object> data = new LinkedHashMap<>();
+      data.put("repository", repositoryParam);
+      data.put("updateTm", Boolean.TRUE.equals(updateTMParam));
+      data.put("skipSource", Boolean.TRUE.equals(skipSourceImportParam));
+      data.put("imported", imported);
+      writeJsonSuccess(data);
+    } else {
+      consoleWriter.fg(Ansi.Color.GREEN).newLine().a("Finished").println(2);
+    }
   }
 
   /**
    * @param fileMatch
+   * @param role source or target file role for JSON reporting
    * @throws CommandException
    */
-  protected void doImportFileMatch(FileMatch fileMatch) throws CommandException {
+  protected void doImportFileMatch(FileMatch fileMatch, String role) throws CommandException {
     try {
       Path relativeFilePath = commandDirectories.relativizeWithUserDirectory(fileMatch.getPath());
 
-      consoleWriter
-          .a(" - Importing file: ")
-          .fg(Ansi.Color.MAGENTA)
-          .a(relativeFilePath.toString())
-          .fg(Ansi.Color.YELLOW)
-          .a(" Running")
-          .println();
+      if (!isJsonOutput()) {
+        consoleWriter
+            .a(" - Importing file: ")
+            .fg(Ansi.Color.MAGENTA)
+            .a(relativeFilePath.toString())
+            .fg(Ansi.Color.YELLOW)
+            .a(" Running")
+            .println();
+      }
 
       repositoryClient.importRepository(
           repository.getId(), getFileContent(fileMatch), updateTMParam);
 
-      consoleWriter.erasePreviouslyPrintedLines();
-      consoleWriter
-          .a(" - Importing file: ")
-          .fg(Ansi.Color.MAGENTA)
-          .a(relativeFilePath.toString())
-          .fg(Ansi.Color.GREEN)
-          .a(" Done")
-          .println();
+      Map<String, Object> importedFile = new LinkedHashMap<>();
+      importedFile.put("file", relativeFilePath.toString());
+      importedFile.put("role", role);
+      imported.add(importedFile);
+
+      if (!isJsonOutput()) {
+        consoleWriter.erasePreviouslyPrintedLines();
+        consoleWriter
+            .a(" - Importing file: ")
+            .fg(Ansi.Color.MAGENTA)
+            .a(relativeFilePath.toString())
+            .fg(Ansi.Color.GREEN)
+            .a(" Done")
+            .println();
+      }
 
     } catch (ResourceNotCreatedException e) {
       throw new CommandException(

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/JsonOutputTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/JsonOutputTest.java
@@ -1,0 +1,68 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.box.l10n.mojito.json.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JsonOutputTest {
+
+  PrintStream originalOut;
+  ByteArrayOutputStream capturedOut;
+  JsonOutput jsonOutput;
+
+  @Before
+  public void setUp() {
+    originalOut = System.out;
+    capturedOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(capturedOut, true, StandardCharsets.UTF_8));
+
+    jsonOutput = new JsonOutput();
+    jsonOutput.objectMapper = new ObjectMapper();
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+  }
+
+  @Test
+  public void writeSuccessEmitsEnvelopeWithData() throws Exception {
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("repo", "MyNewRepo");
+    data.put("id", 42);
+    data.put("locales", List.of("bn-IN", "hi-IN"));
+
+    jsonOutput.writeSuccess("repo-create", data);
+
+    JsonNode root = new ObjectMapper().readTree(capturedOut.toString(StandardCharsets.UTF_8));
+    assertTrue(root.get("successful").asBoolean());
+    assertEquals("repo-create", root.get("command").asText());
+    assertEquals("MyNewRepo", root.get("data").get("repo").asText());
+    assertEquals(42, root.get("data").get("id").asInt());
+    assertEquals(2, root.get("data").get("locales").size());
+    assertFalse(root.has("error"));
+  }
+
+  @Test
+  public void writeFailureEmitsEnvelopeWithError() throws Exception {
+    jsonOutput.writeFailure("repo-create", "There is a conflict");
+
+    JsonNode root = new ObjectMapper().readTree(capturedOut.toString(StandardCharsets.UTF_8));
+    assertFalse(root.get("successful").asBoolean());
+    assertEquals("repo-create", root.get("command").asText());
+    assertEquals("There is a conflict", root.get("error").asText());
+    assertFalse(root.has("data"));
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoCreateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoCreateCommandTest.java
@@ -45,6 +45,40 @@ public class RepoCreateCommandTest extends CLITestBase {
     assertCreatedRepositoryHas6Locales(testRepoName, testDescription, false);
   }
 
+  @Test
+  public void testCreateTestRepoJsonOutput() throws Exception {
+    String testRepoName = testIdWatcher.getEntityName("repository-json");
+    String testDescription = testRepoName + " description";
+
+    List<String> args = new ArrayList<>();
+    args.add("repo-create");
+    args.add(Param.REPOSITORY_NAME_SHORT);
+    args.add(testRepoName);
+    args.add(Param.REPOSITORY_DESCRIPTION_SHORT);
+    args.add(testDescription);
+    args.add(Param.REPOSITORY_LOCALES_SHORT);
+    args.add("fr-FR");
+    args.add("hi-IN");
+    args.add(Command.JSON_LONG);
+
+    getL10nJCommander().run(args.toArray(new String[0]));
+
+    String output = outputCapture.toString();
+    assertTrue(
+        "Expected JSON successful=true in output:\n" + output,
+        output.contains("\"successful\" : true") || output.contains("\"successful\": true"));
+    assertTrue(output.contains("\"command\"") && output.contains("repo-create"));
+    assertTrue(output.contains(testRepoName));
+    assertTrue(output.contains("\"hi-IN\"") || output.contains("hi-IN"));
+    assertFalse(
+        "Human console message should be suppressed with --json",
+        output.contains("Create repository:"));
+
+    Repository repository = repositoryRepository.findByName(testRepoName);
+    assertNotNull(repository);
+    assertEquals(testDescription, repository.getDescription());
+  }
+
   protected void createTestRepoWith6Locales(
       String testRepoName, String testDescription, Boolean hasIntegrityChecker) throws Exception {
     logger.debug("Creating repo with name: {}", testRepoName);

--- a/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryAiTranslateClient.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/client/RepositoryAiTranslateClient.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.rest.client;
 
 import com.box.l10n.mojito.rest.entity.PollableTask;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -73,6 +74,12 @@ public class RepositoryAiTranslateClient extends BaseClient {
       Integer timeoutSeconds) {}
 
   public record ProtoAiTranslateResponse(PollableTask pollableTask) {}
+
+  /**
+   * Output stored on the AI translate pollable task. {@code hasMore} is true when selection hit the
+   * per-locale max for at least one locale.
+   */
+  public record AiTranslateOutput(boolean hasMore, Map<String, Boolean> hasMoreByLocale) {}
 
   public record ProtoAiTranslateRetryImportRequest(long childPollableTaskId, boolean resume) {}
 

--- a/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/AiTranslateWS.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/rest/textunit/AiTranslateWS.java
@@ -41,7 +41,7 @@ public class AiTranslateWS {
   public ProtoAiTranslateResponse aiTranslate(
       @RequestBody ProtoAiTranslateRequest protoAiTranslateRequest) {
 
-    PollableFuture<Void> pollableFuture =
+    PollableFuture<AiTranslateService.AiTranslateOutput> pollableFuture =
         aiTranslateService.aiTranslateAsync(
             new AiTranslateInput(
                 protoAiTranslateRequest.repositoryName(),

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateJob.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateJob.java
@@ -2,6 +2,7 @@ package com.box.l10n.mojito.service.oaitranslate;
 
 import com.box.l10n.mojito.quartz.QuartzPollableJob;
 import com.box.l10n.mojito.service.oaitranslate.AiTranslateService.AiTranslateInput;
+import com.box.l10n.mojito.service.oaitranslate.AiTranslateService.AiTranslateOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,15 +14,14 @@ import org.springframework.stereotype.Component;
  * @author garion
  */
 @Component
-public class AiTranslateJob extends QuartzPollableJob<AiTranslateInput, Void> {
+public class AiTranslateJob extends QuartzPollableJob<AiTranslateInput, AiTranslateOutput> {
 
   static Logger logger = LoggerFactory.getLogger(AiTranslateJob.class);
 
   @Autowired AiTranslateService aiTranslateService;
 
   @Override
-  public Void call(AiTranslateInput aiTranslateJobInput) throws Exception {
-    aiTranslateService.aiTranslate(aiTranslateJobInput, getCurrentPollableTask());
-    return null;
+  public AiTranslateOutput call(AiTranslateInput aiTranslateJobInput) throws Exception {
+    return aiTranslateService.aiTranslate(aiTranslateJobInput, getCurrentPollableTask());
   }
 }

--- a/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateService.java
+++ b/webapp/src/main/java/com/box/l10n/mojito/service/oaitranslate/AiTranslateService.java
@@ -202,9 +202,16 @@ public class AiTranslateService {
       boolean dryRun,
       Integer timeoutSeconds) {}
 
-  public PollableFuture<Void> aiTranslateAsync(AiTranslateInput aiTranslateInput) {
+  /**
+   * Result of an AI translate job. {@code hasMore} is true when at least one locale had more
+   * matching text units than {@link AiTranslateInput#sourceTextMaxCountPerLocale()} at selection
+   * time (so another run may still have work).
+   */
+  public record AiTranslateOutput(boolean hasMore, Map<String, Boolean> hasMoreByLocale) {}
 
-    QuartzJobInfo<AiTranslateInput, Void> quartzJobInfo =
+  public PollableFuture<AiTranslateOutput> aiTranslateAsync(AiTranslateInput aiTranslateInput) {
+
+    QuartzJobInfo<AiTranslateInput, AiTranslateOutput> quartzJobInfo =
         QuartzJobInfo.newBuilder(AiTranslateJob.class)
             .withInlineInput(false)
             .withInput(aiTranslateInput)
@@ -269,12 +276,12 @@ public class AiTranslateService {
     return groups;
   }
 
-  public void aiTranslate(AiTranslateInput aiTranslateInput, PollableTask currentTask)
+  public AiTranslateOutput aiTranslate(AiTranslateInput aiTranslateInput, PollableTask currentTask)
       throws AiTranslateException {
     if (aiTranslateInput.useBatch()) {
-      aiTranslateBatch(aiTranslateInput, currentTask);
+      return aiTranslateBatch(aiTranslateInput, currentTask);
     } else {
-      aiTranslateNoBatch(aiTranslateInput, currentTask);
+      return aiTranslateNoBatch(aiTranslateInput, currentTask);
     }
   }
 
@@ -293,7 +300,8 @@ public class AiTranslateService {
       TextUnitDTO textUnitDTO,
       CompletableFuture<ResponsesResponse> responsesResponseCompletableFuture) {}
 
-  public void aiTranslateNoBatch(AiTranslateInput aiTranslateInput, PollableTask currentTask) {
+  public AiTranslateOutput aiTranslateNoBatch(
+      AiTranslateInput aiTranslateInput, PollableTask currentTask) {
     Repository repository = getRepository(aiTranslateInput);
 
     logger.info("Start AI Translation (no batch) for repository: {}", repository.getName());
@@ -307,6 +315,7 @@ public class AiTranslateService {
 
     Stopwatch stopwatchForTotal = Stopwatch.createStarted();
 
+    Map<String, Boolean> hasMoreByLocale = new LinkedHashMap<>();
     List<String> reportFilenames = new ArrayList<>();
     for (RepositoryLocale repositoryLocale : filteredRepositoryLocales) {
       String bcp47Tag = repositoryLocale.getLocale().getBcp47Tag();
@@ -317,13 +326,16 @@ public class AiTranslateService {
 
       Stopwatch stopwatchForLocale = Stopwatch.createStarted();
 
-      List<TextUnitDTOWithVariantComments> textUnitDTOWithVariantCommentsList =
+      TextUnitDTOSelection textUnitDTOSelection =
           getTextUnitDTOS(
               repository,
               aiTranslateInput.sourceTextMaxCountPerLocale(),
               aiTranslateInput.tmTextUnitIds(),
               repositoryLocale,
               StatusFilter.valueOf(aiTranslateInput.statusFilter()));
+      hasMoreByLocale.put(bcp47Tag, textUnitDTOSelection.hasMore());
+      List<TextUnitDTOWithVariantComments> textUnitDTOWithVariantCommentsList =
+          textUnitDTOSelection.textUnits();
 
       if (textUnitDTOWithVariantCommentsList.isEmpty()) {
         logger.debug("Nothing to translate for locale: {}", bcp47Tag);
@@ -630,6 +642,9 @@ public class AiTranslateService {
         "Done with AI Translation (no batch) for repository: {}, total time: {}",
         repository.getName(),
         stopwatchForTotal);
+
+    boolean hasMore = hasMoreByLocale.values().stream().anyMatch(Boolean::booleanValue);
+    return new AiTranslateOutput(hasMore, hasMoreByLocale);
   }
 
   void putReportContent(PollableTask currentTask, List<String> reportFilenames) {
@@ -775,12 +790,14 @@ public class AiTranslateService {
     return cause instanceof IOException || cause instanceof TimeoutException;
   }
 
-  public void aiTranslateBatch(AiTranslateInput aiTranslateInput, PollableTask currentTask)
-      throws AiTranslateException {
+  public AiTranslateOutput aiTranslateBatch(
+      AiTranslateInput aiTranslateInput, PollableTask currentTask) throws AiTranslateException {
 
     Repository repository = getRepository(aiTranslateInput);
 
     logger.debug("Start AI Translation for repository: {}", repository.getName());
+
+    Map<String, Boolean> hasMoreByLocale = new LinkedHashMap<>();
 
     try {
 
@@ -798,8 +815,9 @@ public class AiTranslateService {
               RelatedStringsProvider.Type.fromString(aiTranslateInput.relatedStringsType()));
 
       for (RepositoryLocale repositoryLocale : repositoryLocalesWithoutRootLocale) {
+        String bcp47Tag = repositoryLocale.getLocale().getBcp47Tag();
         try {
-          CreateBatchResponse createBatchResponse =
+          CreateBatchResult createBatchResult =
               createBatchForRepositoryLocale(
                   repositoryLocale,
                   repository,
@@ -819,17 +837,19 @@ public class AiTranslateService {
                   aiTranslateInput.glossaryTermCaseSensitive(),
                   aiTranslateInput.glossaryOnlyMatchedTextUnits());
 
-          if (createBatchResponse != null) {
-            createdBatches.add(createBatchResponse);
+          hasMoreByLocale.put(bcp47Tag, createBatchResult.hasMore());
+
+          if (createBatchResult.createBatchResponse() != null) {
+            createdBatches.add(createBatchResult.createBatchResponse());
           } else {
-            skippedLocales.add(repositoryLocale.getLocale().getBcp47Tag());
+            skippedLocales.add(bcp47Tag);
           }
         } catch (Throwable t) {
           String errorMessage =
-              "Can't create batch for locale: %s. Error: %s"
-                  .formatted(repositoryLocale.getLocale().getBcp47Tag(), t.getMessage());
+              "Can't create batch for locale: %s. Error: %s".formatted(bcp47Tag, t.getMessage());
           logger.error(errorMessage, t);
           batchCreationErrors.add(errorMessage);
+          hasMoreByLocale.putIfAbsent(bcp47Tag, false);
         }
       }
 
@@ -857,6 +877,9 @@ public class AiTranslateService {
           openAIClientResponseException);
       throw new AiTranslateException(openAIClientResponseException);
     }
+
+    boolean hasMore = hasMoreByLocale.values().stream().anyMatch(Boolean::booleanValue);
+    return new AiTranslateOutput(hasMore, hasMoreByLocale);
   }
 
   private Set<RepositoryLocale> getFilteredRepositoryLocales(
@@ -1064,7 +1087,7 @@ public class AiTranslateService {
     return new PollableFutureTaskResult<>();
   }
 
-  CreateBatchResponse createBatchForRepositoryLocale(
+  CreateBatchResult createBatchForRepositoryLocale(
       RepositoryLocale repositoryLocale,
       Repository repository,
       int sourceTextMaxCountPerLocale,
@@ -1083,9 +1106,11 @@ public class AiTranslateService {
       boolean glossaryTermCaseSensitive,
       boolean glossaryOnlyMatchedTextUnits) {
 
-    List<TextUnitDTOWithVariantComments> textUnitDTOWithVariantCommentsList =
+    TextUnitDTOSelection textUnitDTOSelection =
         getTextUnitDTOS(
             repository, sourceTextMaxCountPerLocale, tmTextUnitIds, repositoryLocale, statusFilter);
+    List<TextUnitDTOWithVariantComments> textUnitDTOWithVariantCommentsList =
+        textUnitDTOSelection.textUnits();
 
     GlossaryTrie glossaryTrie =
         getGlossaryTrieForLocale(
@@ -1137,14 +1162,24 @@ public class AiTranslateService {
     }
 
     logger.info(
-        "Created batch for locale: {} with {} text units",
+        "Created batch for locale: {} with {} text units (hasMore={})",
         repositoryLocale.getLocale().getBcp47Tag(),
-        textUnitDTOWithVariantCommentsList.size());
+        textUnitDTOWithVariantCommentsList.size(),
+        textUnitDTOSelection.hasMore());
 
-    return createBatchResponse;
+    return new CreateBatchResult(createBatchResponse, textUnitDTOSelection.hasMore());
   }
 
-  private List<TextUnitDTOWithVariantComments> getTextUnitDTOS(
+  record CreateBatchResult(CreateBatchResponse createBatchResponse, boolean hasMore) {}
+
+  record TextUnitDTOSelection(List<TextUnitDTOWithVariantComments> textUnits, boolean hasMore) {}
+
+  /**
+   * Selects text units for AI translate. When {@code tmTextUnitIds} is unset, requests one more
+   * than {@code sourceTextMaxCountPerLocale} so {@link TextUnitDTOSelection#hasMore()} reflects
+   * whether another run may still have work for this locale.
+   */
+  private TextUnitDTOSelection getTextUnitDTOS(
       Repository repository,
       int sourceTextMaxCountPerLocale,
       List<Long> tmTextUnitIds,
@@ -1161,6 +1196,7 @@ public class AiTranslateService {
     textUnitSearcherParameters.setLocaleId(repositoryLocale.getLocale().getId());
     textUnitSearcherParameters.setUsedFilter(UsedFilter.USED);
 
+    boolean hasMore = false;
     if (tmTextUnitIds != null) {
       logger.debug(
           "Using tmTextUnitIds: {} for ai translate repository: {}",
@@ -1168,10 +1204,17 @@ public class AiTranslateService {
           repository.getName());
       textUnitSearcherParameters.setTmTextUnitIds(tmTextUnitIds);
     } else {
-      textUnitSearcherParameters.setLimit(sourceTextMaxCountPerLocale);
+      // Fetch one extra to detect truncation without a separate count query.
+      textUnitSearcherParameters.setLimit(sourceTextMaxCountPerLocale + 1);
     }
 
     List<TextUnitDTO> textUnitDTOS = textUnitSearcher.search(textUnitSearcherParameters);
+
+    if (tmTextUnitIds == null && textUnitDTOS.size() > sourceTextMaxCountPerLocale) {
+      hasMore = true;
+      textUnitDTOS = new ArrayList<>(textUnitDTOS.subList(0, sourceTextMaxCountPerLocale));
+    }
+
     List<Long> tmTextUnitVariantIds =
         textUnitDTOS.stream()
             .map(TextUnitDTO::getTmTextUnitVariantId)
@@ -1192,7 +1235,7 @@ public class AiTranslateService {
                         textUnitDTO, variantMap.get(textUnitDTO.getTmTextUnitVariantId())))
             .toList();
 
-    return textUnitDTOWithVariantComments;
+    return new TextUnitDTOSelection(textUnitDTOWithVariantComments, hasMore);
   }
 
   record TextUnitDTOWithVariantComments(


### PR DESCRIPTION
## Summary

Adds a shared CLI `--json` convention so automation (especially AI-translate Jenkins jobs) can consume a stable machine-readable result instead of scraping ANSI console output.

- Introduces a common JSON envelope on stdout: `{ successful, command, data, error? }`, with human console progress suppressed when `--json` is set
- Wires `--json` into: `repo-create`, `repo-view`, `drop-export`, `drop-import`, `tm-export`, `tm-import`, and `repository-ai-translate`
- For `repository-ai-translate`, the AI translate service now detects remaining work at selection time (fetch `sourceTextMaxCount + 1` per locale) and stores `hasMore` / `hasMoreByLocale` on the pollable job output; the CLI surfaces those fields in the `--json` result so schedulers can loop until a repo is drained

## Test plan

- [x] `mvn spotless:check`
- [x] Unit: `JsonOutputTest`, AI translate config/auto-fix integrity tests
- [x] CLI integration: `RepoCreateCommandTest` (incl. `--json`), `RepoViewCommandTest`, `DropExportCommandTest`, `DropImportCommandTest`, `TMExportCommandTest`, `TMImportCommandTest`
- [ ] Manually run `repository-ai-translate --json -r <repo> -l hi-IN bn-IN` against a repo with more than `--source-text-max-count` strings and confirm `hasMore: true`, then re-run until `hasMore: false`
- [ ] Confirm failure paths still exit non-zero and emit `{ successful: false, error: "..." }` with `--json`