### PR TITLE
Add open-source project roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ This project adheres to the [Box Open Code of Conduct](http://opensource.box.com
 
 ## How to contribute
 
-* **File an issue** - if you found a bug, want to request an enhancement, or want to implement something (bug fix or feature).
-* **Send a pull request** - if you want to contribute code. Please be sure to file an issue first.
+1. **Set up your environment** — follow the [Open Source Contributors](https://www.mojito.global/docs/guides/open-source-contributors/) guide.
+2. **Pick something to work on** — see the [project roadmap](docs/ROADMAP.md) for planned areas of future development, or file an issue for a bug or enhancement.
+3. **Send a pull request** — if you want to contribute code. Please be sure to file an issue first.
 
 ## Pull request best practices
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ For instruction to jump start
 ## [Full Documentation](http://opensource.box.com/mojito/docs/)
 For full documentation, examples, and other information.
 
+## [Roadmap](docs/ROADMAP.md)
+Planned areas of future development.
+
 ## Support
 
 Need to contact us directly? 
@@ -36,7 +39,7 @@ Need to contact us directly?
 
 ## Copyright and License
 
-Copyright 2016 Box, Inc. All rights reserved.
+Copyright 2016-2026 Box, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,52 @@
+---
+layout: page
+title: Roadmap
+permalink: /docs/roadmap/
+---
+
+Planned areas of future development in the Mojito open-source platform, grouped by topic. Existence of a feature on this list should be viewed as a proposal, not as a commitment to implement. If you would like to see particular features or lend support for particular features below, leave us a note in the [Mojito Discussions](https://github.com/box/mojito/discussions) forum.
+
+Items are ordered roughly by dependency where that applies; ordering within a topic is not a firm commitment.
+
+## AI Translations
+
+Core Mojito orchestration for AI-assisted translation (PRD-AI-Translations).
+
+1. Add Project Types
+2. Prompt Layer per Project Type
+3. Prompt Layer per Project
+4. Integrity checks per Project Type
+5. Glossary awareness in AI translation flows (approved terms in prompts)
+6. Derived-locale AI adaptation (parent → regional variant)
+7. Derived-locale prompt layers
+8. Fuzzy match support using Lucene search
+9. Translation memory support using fuzzy match (TM hits as AI reference context)
+10. Workbench free-text / TM search (filters by repo, locale, status)
+11. MQM-style quality measurement (segment-level scoring, batch scorecards, rollups)
+12. Automatic translation within Mojito (triggered on push / status changes), instead of kicking off translations externally via the CLI
+
+## Glossary Management
+
+First-class glossary product inside Mojito.
+
+1. Global glossary (installation-scoped; not a fake translation repository)
+2. Term workflow aligned with string statuses (New → Needs translation → Needs review → Accepted)
+3. CRUD UI and API without coupling to translation assets
+4. CSV import / export
+5. Roles (view / edit / approve)
+6. Glossary tab in the Mojito UI
+7. Glossary term management API (including Lucene-backed similar-term search)
+8. Do-not-translate (DNT) support
+
+## Screenshots & in-context review hooks
+
+1. Deduplicated screenshot upload / refresh for text units
+2. Screenshots as context in AI translation (and re-translate when a screenshot changes)
+3. Export screenshots with vendor drops for human/vendor locales
+4. APIs for in-context review to set status (Accepted vs Needs translation) and attach notes
+5. "Tagging" pseudo-locale: copy source strings and embed project name plus string id in hidden Unicode characters
+
+## UI Updates
+
+1. Update to modern React
+2. Update to modern Node.js

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ Core Mojito orchestration for AI-assisted translation.
 
 1. Add Repo Types
 2. Prompt Layer per Repo Type
-3. Prompt Layer per Project
+3. Prompt Layer per Repo
 4. Integrity checks per Repo Type
 5. Glossary awareness in AI translation flows (approved terms in prompts)
 6. Derived-locale AI adaptation (parent → regional variant)
@@ -24,6 +24,16 @@ Core Mojito orchestration for AI-assisted translation.
 10. Workbench free-text / TM search (filters by repo, locale, status)
 11. MQM-style quality measurement (segment-level scoring, batch scorecards, rollups)
 12. Automatic translation within Mojito (triggered on push / status changes), instead of kicking off translations externally via the CLI
+
+### A Few Definitions
+
+"Repo Types" are a classification of repos that allows you to create an AI prompt or a list of integrity checkers just once and then assign this type to new repos you create. The new repos then inherit the AI prompts and the integrity checks. It also allows you to modify the AI prompt or integrity checks for all repos of the same type at once.
+
+"Layered Prompts" refers to dynamic construction of AI prompts. The final prompt is constructed by taking the system prompt, adding the repo type prompt, then the repo prompt, and finally the per-request prompt from the CLI command-line. This offers more flexibiity to describe the strings being translated in a better way without putting all the possibly irrelevant info into every single prompt.
+
+"Derived Locales" are locales where the translations are mostly inherited from another parent locale. For example, French for Canada is derived from French for France. French for Canada only has small changes needed from France French, so it makes sense to translate once for France French and the derived the Canadian French from it. That increases the consistency and at the same time makes French for Canada be adapted properly for Canada. In the mojito CLI, this is usually denoted with the parentheses in locale lists:  `mojito-cli repo-create -n MyNewRepo -l fr-FR,(fr-CA)->fr-FR`
+
+"MQM means "Multidimensional Quality Metrics" which is an industry standard way of measuring translation quality. There is a rubric of 20 or so questions that you ask of each translation to score it, and then you combine the scores of individual translations together to create the overall score for a whole batch. See [The MQM](https://www.themqm.org/) for more details.
 
 ## Glossary Management
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,12 +10,12 @@ Items are ordered roughly by dependency where that applies; ordering within a to
 
 ## AI Translations
 
-Core Mojito orchestration for AI-assisted translation (PRD-AI-Translations).
+Core Mojito orchestration for AI-assisted translation.
 
-1. Add Project Types
-2. Prompt Layer per Project Type
+1. Add Repo Types
+2. Prompt Layer per Repo Type
 3. Prompt Layer per Project
-4. Integrity checks per Project Type
+4. Integrity checks per Repo Type
 5. Glossary awareness in AI translation flows (approved terms in prompts)
 6. Derived-locale AI adaptation (parent → regional variant)
 7. Derived-locale prompt layers

--- a/docs/_docs/guides/open-source-contributors.md
+++ b/docs/_docs/guides/open-source-contributors.md
@@ -5,6 +5,9 @@ date:   2016-02-17 15:25:25 -0800
 categories: guides
 permalink: /docs/guides/open-source-contributors/
 ---
+
+Looking for something to work on? See the [project roadmap]({{ site.url }}/docs/roadmap/) for planned areas of future development.
+
 ## Prerequisites
 
 The following requirements are needed to develop on {{ site.mojito_green }}: 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,6 +4,9 @@ title: Documentation
 permalink: /docs/
 ---
 
+<h3>Roadmap</h3>
+<a class="page-link" href="{{ site.url }}/docs/roadmap/">Roadmap</a>
+
 <h3>Guides</h3>
 {% assign docs=site.docs | sort: 'path' %}
 {% for my_page in docs %}


### PR DESCRIPTION
## Summary
- Add a public roadmap covering AI translations, glossary management, screenshot/in-context review hooks, and UI updates
- Link the roadmap from the docs index, README, CONTRIBUTING, and the Open Source Contributors guide

## Test plan
- [ ] Confirm links from README, CONTRIBUTING, and the Open Source Contributors guide resolve correctly
- [ ] Confirm `/docs/roadmap/` appears under Roadmap on the documentation index after docs publish


Made with [Cursor](https://cursor.com)