### PR TITLE
Add CLI commands to create, update, delete, and view repo types

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeCreateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeCreateCommand.java
@@ -1,0 +1,69 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import com.box.l10n.mojito.rest.entity.RepoType;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+/** Creates a repo type with a name and optional description. */
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"repo-type-create"},
+    commandDescription = "Creates a repo type")
+public class RepoTypeCreateCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeCreateCommand.class);
+
+  @Autowired ConsoleWriter consoleWriter;
+
+  @Autowired RepoTypeClient repoTypeClient;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_NAME_LONG, Param.REPO_TYPE_NAME_SHORT},
+      arity = 1,
+      required = true,
+      description = Param.REPO_TYPE_NAME_DESCRIPTION)
+  String nameParam;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_DESCRIPTION_LONG, Param.REPO_TYPE_DESCRIPTION_SHORT},
+      arity = 1,
+      required = false,
+      description = Param.REPO_TYPE_DESCRIPTION_DESCRIPTION)
+  String descriptionParam;
+
+  @Override
+  protected void execute() throws CommandException {
+    consoleWriter.a("Create repo type: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+
+    try {
+      RepoType toCreate = new RepoType();
+      toCreate.setName(nameParam);
+      toCreate.setDescription(descriptionParam);
+
+      RepoType created = repoTypeClient.createRepoType(toCreate);
+      consoleWriter
+          .newLine()
+          .a("created --> repo type id: ")
+          .fg(Ansi.Color.MAGENTA)
+          .a(created.getId())
+          .println();
+    } catch (HttpClientErrorException ex) {
+      if (ex.getStatusCode().equals(HttpStatus.CONFLICT)) {
+        throw new CommandException("Repo type with name [" + nameParam + "] already exists", ex);
+      }
+      throw ex;
+    }
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeDeleteCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeDeleteCommand.java
@@ -1,0 +1,60 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import com.box.l10n.mojito.rest.entity.RepoType;
+import java.util.List;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/** Deletes an existing repo type by name. */
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"repo-type-delete"},
+    commandDescription = "Deletes a repo type")
+public class RepoTypeDeleteCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeDeleteCommand.class);
+
+  @Autowired ConsoleWriter consoleWriter;
+
+  @Autowired RepoTypeClient repoTypeClient;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_NAME_LONG, Param.REPO_TYPE_NAME_SHORT},
+      arity = 1,
+      required = true,
+      description = Param.REPO_TYPE_NAME_DESCRIPTION)
+  String nameParam;
+
+  @Override
+  protected void execute() throws CommandException {
+    consoleWriter.a("Delete repo type: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+
+    RepoType existing = getRepoTypeByName(nameParam);
+    repoTypeClient.deleteRepoType(existing.getId());
+
+    consoleWriter
+        .newLine()
+        .a("deleted --> repo type name: ")
+        .fg(Ansi.Color.MAGENTA)
+        .a(nameParam)
+        .println();
+  }
+
+  private RepoType getRepoTypeByName(String name) throws CommandException {
+    List<RepoType> repoTypes = repoTypeClient.getRepoTypes(name);
+    if (repoTypes.size() != 1) {
+      throw new CommandException("Repo type with name [" + name + "] is not found");
+    }
+    return repoTypes.get(0);
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeUpdateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeUpdateCommand.java
@@ -78,8 +78,7 @@ public class RepoTypeUpdateCommand extends Command {
           .println();
     } catch (HttpClientErrorException ex) {
       if (ex.getStatusCode().equals(HttpStatus.CONFLICT)) {
-        throw new CommandException(
-            "Repo type with name [" + newNameParam + "] already exists", ex);
+        throw new CommandException("Repo type with name [" + newNameParam + "] already exists", ex);
       }
       throw ex;
     }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeUpdateCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeUpdateCommand.java
@@ -1,0 +1,95 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import com.box.l10n.mojito.rest.entity.RepoType;
+import java.util.List;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+/** Updates name and/or description of an existing repo type. */
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"repo-type-update"},
+    commandDescription = "Updates a repo type")
+public class RepoTypeUpdateCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeUpdateCommand.class);
+
+  @Autowired ConsoleWriter consoleWriter;
+
+  @Autowired RepoTypeClient repoTypeClient;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_NAME_LONG, Param.REPO_TYPE_NAME_SHORT},
+      arity = 1,
+      required = true,
+      description = Param.REPO_TYPE_NAME_DESCRIPTION)
+  String nameParam;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_NEW_NAME_LONG, Param.REPO_TYPE_NEW_NAME_SHORT},
+      arity = 1,
+      required = false,
+      description = Param.REPO_TYPE_NEW_NAME_DESCRIPTION)
+  String newNameParam;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_DESCRIPTION_LONG, Param.REPO_TYPE_DESCRIPTION_SHORT},
+      arity = 1,
+      required = false,
+      description = Param.REPO_TYPE_DESCRIPTION_DESCRIPTION)
+  String descriptionParam;
+
+  @Override
+  protected void execute() throws CommandException {
+    consoleWriter.a("Update repo type: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+
+    if (newNameParam == null && descriptionParam == null) {
+      throw new CommandException(
+          "Must provide at least one of the following options: --new-name, --description");
+    }
+
+    RepoType existing = getRepoTypeByName(nameParam);
+
+    try {
+      RepoType toUpdate = new RepoType();
+      toUpdate.setName(newNameParam);
+      toUpdate.setDescription(descriptionParam);
+      // Leave integrity checkers unchanged (DTO defaults to empty set, which would clear them)
+      toUpdate.setIntegrityCheckers(null);
+
+      RepoType updated = repoTypeClient.updateRepoType(existing.getId(), toUpdate);
+      consoleWriter
+          .newLine()
+          .a("updated --> repo type id: ")
+          .fg(Ansi.Color.MAGENTA)
+          .a(updated.getId())
+          .println();
+    } catch (HttpClientErrorException ex) {
+      if (ex.getStatusCode().equals(HttpStatus.CONFLICT)) {
+        throw new CommandException(
+            "Repo type with name [" + newNameParam + "] already exists", ex);
+      }
+      throw ex;
+    }
+  }
+
+  private RepoType getRepoTypeByName(String name) throws CommandException {
+    List<RepoType> repoTypes = repoTypeClient.getRepoTypes(name);
+    if (repoTypes.size() != 1) {
+      throw new CommandException("Repo type with name [" + name + "] is not found");
+    }
+    return repoTypes.get(0);
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeViewCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeViewCommand.java
@@ -1,0 +1,63 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import com.box.l10n.mojito.rest.entity.RepoType;
+import java.util.List;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/** Views id, name, and description of an existing repo type. */
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"repo-type-view"},
+    commandDescription = "View a repo type")
+public class RepoTypeViewCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeViewCommand.class);
+
+  @Autowired ConsoleWriter consoleWriter;
+
+  @Autowired RepoTypeClient repoTypeClient;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_NAME_LONG, Param.REPO_TYPE_NAME_SHORT},
+      arity = 1,
+      required = true,
+      description = Param.REPO_TYPE_NAME_DESCRIPTION)
+  String nameParam;
+
+  @Override
+  protected void execute() throws CommandException {
+    consoleWriter.a("View repo type: ").fg(Ansi.Color.CYAN).a(nameParam).println();
+
+    RepoType repoType = getRepoTypeByName(nameParam);
+    String description = repoType.getDescription() != null ? repoType.getDescription() : "";
+
+    consoleWriter
+        .newLine()
+        .a("Repo type id --> ")
+        .fg(Ansi.Color.MAGENTA)
+        .a(repoType.getId())
+        .println();
+    consoleWriter.a("Name --> ").fg(Ansi.Color.MAGENTA).a(repoType.getName()).println();
+    consoleWriter.a("Description --> ").fg(Ansi.Color.MAGENTA).a(description).println();
+    consoleWriter.println();
+  }
+
+  private RepoType getRepoTypeByName(String name) throws CommandException {
+    List<RepoType> repoTypes = repoTypeClient.getRepoTypes(name);
+    if (repoTypes.size() != 1) {
+      throw new CommandException("Repo type with name [" + name + "] is not found");
+    }
+    return repoTypes.get(0);
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
@@ -67,6 +67,19 @@ public class Param {
   public static final String REPOSITORY_DESCRIPTION_DESCRIPTION =
       "Description of the repository to create or update";
 
+  public static final String REPO_TYPE_NAME_LONG = "--name";
+  public static final String REPO_TYPE_NAME_SHORT = "-n";
+  public static final String REPO_TYPE_NAME_DESCRIPTION = "Name of the repo type";
+
+  public static final String REPO_TYPE_NEW_NAME_LONG = "--new-name";
+  public static final String REPO_TYPE_NEW_NAME_SHORT = "-nn";
+  public static final String REPO_TYPE_NEW_NAME_DESCRIPTION = "New name for the repo type";
+
+  public static final String REPO_TYPE_DESCRIPTION_LONG = "--description";
+  public static final String REPO_TYPE_DESCRIPTION_SHORT = "-d";
+  public static final String REPO_TYPE_DESCRIPTION_DESCRIPTION =
+      "Description of the repo type to create or update";
+
   public static final String REPOSITORY_LOCALES_LONG = "--locales";
   public static final String REPOSITORY_LOCALES_SHORT = "-l";
   public static final String REPOSITORY_LOCALES_DESCRIPTION =

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeCreateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeCreateCommandTest.java
@@ -1,0 +1,68 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.entity.RepoType;
+import com.box.l10n.mojito.service.repotype.RepoTypeRepository;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RepoTypeCreateCommandTest extends CLITestBase {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeCreateCommandTest.class);
+
+  @Autowired RepoTypeRepository repoTypeRepository;
+
+  @Test
+  public void testCreateRepoType() throws Exception {
+    String name = testIdWatcher.getEntityName("React");
+    String description = "FormatJS / react-intl apps";
+
+    getL10nJCommander()
+        .run(
+            "repo-type-create",
+            Param.REPO_TYPE_NAME_SHORT,
+            name,
+            Param.REPO_TYPE_DESCRIPTION_SHORT,
+            description);
+
+    assertTrue(outputCapture.toString().contains("created --> repo type id: "));
+
+    RepoType created = repoTypeRepository.findByName(name);
+    assertNotNull(created);
+    assertEquals(name, created.getName());
+    assertEquals(description, created.getDescription());
+  }
+
+  @Test
+  public void testCreateRepoTypeWithoutDescription() throws Exception {
+    String name = testIdWatcher.getEntityName("NoDesc");
+
+    getL10nJCommander().run("repo-type-create", Param.REPO_TYPE_NAME_SHORT, name);
+
+    assertTrue(outputCapture.toString().contains("created --> repo type id: "));
+
+    RepoType created = repoTypeRepository.findByName(name);
+    assertNotNull(created);
+    assertEquals(name, created.getName());
+    assertNull(created.getDescription());
+  }
+
+  @Test
+  public void testCreateRepoTypeDuplicateName() throws Exception {
+    String name = testIdWatcher.getEntityName("Conflict");
+
+    getL10nJCommander().run("repo-type-create", Param.REPO_TYPE_NAME_SHORT, name);
+    getL10nJCommander().run("repo-type-create", Param.REPO_TYPE_NAME_SHORT, name);
+
+    assertTrue(
+        outputCapture.toString().contains("Repo type with name [" + name + "] already exists"));
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeDeleteCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeDeleteCommandTest.java
@@ -1,0 +1,47 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.service.repotype.RepoTypeRepository;
+import com.box.l10n.mojito.service.repotype.RepoTypeService;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RepoTypeDeleteCommandTest extends CLITestBase {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeDeleteCommandTest.class);
+
+  @Autowired RepoTypeService repoTypeService;
+
+  @Autowired RepoTypeRepository repoTypeRepository;
+
+  @Test
+  public void testDeleteRepoType() throws Exception {
+    String name = testIdWatcher.getEntityName("Android");
+
+    repoTypeService.createRepoType(name, "Android strings.xml apps", null, null);
+
+    getL10nJCommander().run("repo-type-delete", Param.REPO_TYPE_NAME_SHORT, name);
+
+    assertTrue(
+        "Repo type is not deleted successfully",
+        outputCapture.toString().contains("deleted --> repo type name: "));
+    assertNull("Repo type should be deleted", repoTypeRepository.findByName(name));
+  }
+
+  @Test
+  public void testDeleteNonExistingRepoType() throws Exception {
+    String name = testIdWatcher.getEntityName("missing");
+
+    getL10nJCommander().run("repo-type-delete", Param.REPO_TYPE_NAME_SHORT, name);
+
+    assertTrue(
+        "Expecting error from deleting non-existing repo type",
+        outputCapture.toString().contains("Repo type with name [" + name + "] is not found"));
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeUpdateCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeUpdateCommandTest.java
@@ -1,0 +1,137 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.entity.RepoType;
+import com.box.l10n.mojito.service.repotype.RepoTypeRepository;
+import com.box.l10n.mojito.service.repotype.RepoTypeService;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RepoTypeUpdateCommandTest extends CLITestBase {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeUpdateCommandTest.class);
+
+  @Autowired RepoTypeService repoTypeService;
+
+  @Autowired RepoTypeRepository repoTypeRepository;
+
+  @Test
+  public void testUpdateName() throws Exception {
+    String name = testIdWatcher.getEntityName("Android");
+    String newName = name + "_updated";
+    String description = "Android strings.xml apps";
+
+    RepoType created = repoTypeService.createRepoType(name, description, null, null);
+
+    getL10nJCommander()
+        .run(
+            "repo-type-update",
+            Param.REPO_TYPE_NAME_SHORT,
+            name,
+            Param.REPO_TYPE_NEW_NAME_SHORT,
+            newName);
+
+    assertTrue(
+        "Repo type is not updated successfully",
+        outputCapture.toString().contains("updated --> repo type id: "));
+
+    assertNull("Should not find repo type by old name", repoTypeRepository.findByName(name));
+
+    RepoType updated = repoTypeRepository.findByName(newName);
+    assertNotNull("Should find repo type by the new name", updated);
+    assertEquals(created.getId(), updated.getId());
+    assertEquals(description, updated.getDescription());
+  }
+
+  @Test
+  public void testUpdateDescription() throws Exception {
+    String name = testIdWatcher.getEntityName("iOS");
+    String oldDescription = "old description";
+    String newDescription = "Swift / Localizable.strings apps";
+
+    RepoType created = repoTypeService.createRepoType(name, oldDescription, null, null);
+
+    getL10nJCommander()
+        .run(
+            "repo-type-update",
+            Param.REPO_TYPE_NAME_SHORT,
+            name,
+            Param.REPO_TYPE_DESCRIPTION_SHORT,
+            newDescription);
+
+    assertTrue(
+        "Repo type is not updated successfully",
+        outputCapture.toString().contains("updated --> repo type id: "));
+
+    RepoType updated = repoTypeRepository.findByName(name);
+    assertNotNull(updated);
+    assertEquals(created.getId(), updated.getId());
+    assertEquals(newDescription, updated.getDescription());
+  }
+
+  @Test
+  public void testUpdateWithoutNewNameOrDescription() throws Exception {
+    String name = testIdWatcher.getEntityName("NoOptions");
+
+    repoTypeService.createRepoType(name, "original description", null, null);
+
+    getL10nJCommander().run("repo-type-update", Param.REPO_TYPE_NAME_SHORT, name);
+
+    assertTrue(
+        "Expecting error when neither --new-name nor --description is provided",
+        outputCapture
+            .toString()
+            .contains(
+                "Must provide at least one of the following options: --new-name, --description"));
+
+    RepoType unchanged = repoTypeRepository.findByName(name);
+    assertNotNull(unchanged);
+    assertEquals("original description", unchanged.getDescription());
+  }
+
+  @Test
+  public void testUpdateNonExistingRepoType() throws Exception {
+    String name = testIdWatcher.getEntityName("missing");
+
+    getL10nJCommander()
+        .run(
+            "repo-type-update",
+            Param.REPO_TYPE_NAME_SHORT,
+            name,
+            Param.REPO_TYPE_DESCRIPTION_SHORT,
+            "new description");
+
+    assertTrue(
+        "Expecting error from updating non-existing repo type",
+        outputCapture.toString().contains("Repo type with name [" + name + "] is not found"));
+  }
+
+  @Test
+  public void testUpdateDuplicateName() throws Exception {
+    String name1 = testIdWatcher.getEntityName("TypeA");
+    String name2 = testIdWatcher.getEntityName("TypeB");
+
+    repoTypeService.createRepoType(name1, null, null, null);
+    repoTypeService.createRepoType(name2, null, null, null);
+
+    getL10nJCommander()
+        .run(
+            "repo-type-update",
+            Param.REPO_TYPE_NAME_SHORT,
+            name1,
+            Param.REPO_TYPE_NEW_NAME_SHORT,
+            name2);
+
+    assertTrue(
+        "Expecting error from renaming to an existing repo type name",
+        outputCapture.toString().contains("Repo type with name [" + name2 + "] already exists"));
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeViewCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeViewCommandTest.java
@@ -1,0 +1,50 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertTrue;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.entity.RepoType;
+import com.box.l10n.mojito.service.repotype.RepoTypeService;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RepoTypeViewCommandTest extends CLITestBase {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeViewCommandTest.class);
+
+  @Autowired RepoTypeService repoTypeService;
+
+  @Test
+  public void testViewRepoType() throws Exception {
+    String name = testIdWatcher.getEntityName("Android");
+    String description = "Android strings.xml apps";
+
+    RepoType created = repoTypeService.createRepoType(name, description, null, null);
+
+    getL10nJCommander().run("repo-type-view", Param.REPO_TYPE_NAME_SHORT, name);
+
+    String output = outputCapture.toString();
+    assertTrue(
+        "Repo type id is missing or incorrect from output",
+        output.contains("Repo type id --> " + created.getId()));
+    assertTrue(
+        "Repo type name is missing or incorrect from output", output.contains("Name --> " + name));
+    assertTrue(
+        "Repo type description is missing or incorrect from output",
+        output.contains("Description --> " + description));
+  }
+
+  @Test
+  public void testViewNonExistingRepoType() throws Exception {
+    String name = testIdWatcher.getEntityName("missing");
+
+    getL10nJCommander().run("repo-type-view", Param.REPO_TYPE_NAME_SHORT, name);
+
+    assertTrue(
+        "Expecting error from viewing non-existing repo type",
+        outputCapture.toString().contains("Repo type with name [" + name + "] is not found"));
+  }
+}

--- a/docs/internal/Architecture.md
+++ b/docs/internal/Architecture.md
@@ -50,7 +50,7 @@ Many Mojito repositories share the same tech stack (React + FormatJS, Android `s
 | Concern | Notes |
 |--------|--------|
 | Assign / clear a type on a repository | Add optional FK from `repository` to `repo_type` |
-| CLI commands | See [CLI → Repo Types](#repo-types-1) |
+| CLI commands | Implemented; see [CLI → Repo Types](#repo-types-1) |
 | Prompt / integrity UI | See [Frontend → Repo Types](#repo-types-2) |
 | Layered prompt assembly (global → type → repo → request) | Prompt builder wiring type `aiPrompt` into AI runs |
 | Runtime superset of type + repo checkers on push/import | Union by `(assetExtension, integrityCheckerType)` |
@@ -285,7 +285,72 @@ JCommander commands that talk to a running Mojito server through `restclient`.
 
 #### Repo Types
 
-Not implemented yet. Follow-up work will add commands such as `repo-type-create`, `repo-type-update`, `repo-type-delete`, and `repo-type-view` that call `/api/repo-types` via `RepoTypeClient`. Until then, operators use the REST API (or tests use the client) directly.
+Name/description CLI for repo types. Commands are JCommander `Command` beans in `cli/.../command/`, same pattern as `repo-create` / `repo-update` / `repo-delete` / `repo-view`. They talk to the server only through `RepoTypeClient` (never through `RepoTypeService` in production code). Integration tests extend `CLITestBase` and then assert via `RepoTypeRepository` / `RepoTypeService`.
+
+**In scope**
+
+- `repo-type-create`, `repo-type-update`, `repo-type-delete`, `repo-type-view`
+- Setting **name** and **description** only
+
+**Out of scope (follow-up)**
+
+- CLI for `aiPrompt` and `integrityCheckers` (separate stories)
+- Listing all types (no `repo-type-list`; view is by exact name)
+
+##### Commands
+
+| Command | Role | Required flags | Optional flags |
+|---------|------|----------------|----------------|
+| `repo-type-create` | POST `/api/repo-types` | `--name` / `-n` | `--description` / `-d` |
+| `repo-type-update` | PATCH `/api/repo-types/{id}` | `--name` / `-n` (existing type) | `--new-name` / `-nn`, `--description` / `-d` |
+| `repo-type-delete` | DELETE `/api/repo-types/{id}` | `--name` / `-n` | — |
+| `repo-type-view` | GET list filtered by name | `--name` / `-n` | — |
+
+Flag constants live in `cli/.../command/param/Param.java` (`REPO_TYPE_*`). Help text comes from those descriptions.
+
+##### Lookup by name
+
+Update, delete, and view resolve the type with `RepoTypeClient.getRepoTypes(name)` (exact `?name=`). If the list size is not exactly `1`, the command fails with `Repo type with name [<name>] is not found` (`CommandException`). There is no dedicated get-by-name client method.
+
+##### Create
+
+- Body: `name` required; `description` may be omitted (`null`).
+- Does not send `aiPrompt` or `integrityCheckers` (server defaults: empty prompt, no checkers).
+- HTTP 409 → `Repo type with name [<name>] already exists`.
+- Success prints `created --> repo type id: <id>`.
+
+##### Update
+
+- At least one of `--new-name` or `--description` is required; otherwise `Must provide at least one of the following options: --new-name, --description`.
+- PATCH body sets only the fields the user passed; omitted flags stay `null` so the server leaves those columns unchanged (see [PATCH semantics](#5-patch-null-means-leave-unchanged)).
+- `integrityCheckers` is sent as `null` so checkers are not replaced. (A non-null empty set would clear them.)
+- HTTP 409 on rename conflict → `Repo type with name [<new-name>] already exists`.
+- Success prints `updated --> repo type id: <id>`.
+
+##### Delete
+
+- Resolves by name, then `deleteRepoType(id)`.
+- Success prints `deleted --> repo type name: <name>`.
+- Until repositories can reference a type, delete is an unconditional hard delete (same as the server).
+
+##### View
+
+Prints three fields for an existing type:
+
+- `Repo type id --> <id>`
+- `Name --> <name>`
+- `Description --> <description>` (`null` description prints as empty)
+
+##### Package layout (CLI)
+
+| File | Role |
+|------|------|
+| `cli/.../command/RepoTypeCreateCommand.java` | Create |
+| `cli/.../command/RepoTypeUpdateCommand.java` | Update |
+| `cli/.../command/RepoTypeDeleteCommand.java` | Delete |
+| `cli/.../command/RepoTypeViewCommand.java` | View |
+| `cli/.../command/param/Param.java` | `--name` / `--new-name` / `--description` constants |
+| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags) |
 
 ---
 
@@ -317,7 +382,7 @@ Web UI served from `webapp` (React / Flux-style JS under `webapp/src/main/resour
 
 #### Repo Types
 
-No UI yet. Follow-up work may add management screens for creating types, editing `aiPrompt`, and configuring `integrityCheckers`. Until then, configuration is API-only (and later CLI).
+No UI yet. Follow-up work may add management screens for creating types, editing `aiPrompt`, and configuring `integrityCheckers`. Until then, configuration is REST API and CLI (name/description only on the CLI).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Mojito CLI commands so engineers can manage repo type records without calling the REST API directly.

- New commands: `repo-type-create`, `repo-type-update`, `repo-type-delete`, and `repo-type-view`
- Commands talk to the existing `/api/repo-types` REST API via `RepoTypeClient` (same pattern as `repo-create` / `repo-update` / `repo-delete` / `repo-view`)
- `repo-type-view` prints id, name, and description
- Create and update set **name** and **description** only (`--name` / `-n`, `--description` / `-d`, and `--new-name` / `-nn` on update). Shared AI prompt and integrity checkers are out of scope for this change

Help text comes from JCommander parameter descriptions. Happy-path and error cases (duplicate name, unknown type, update with no optional flags) are covered by `CLITestBase` integration tests.

## Test plan

- [x] `mojito --help` lists all four `repo-type-*` commands
- [x] Create + view: name, description, and id
- [x] Update description; id unchanged
- [x] Rename with `--new-name`; old name not found
- [x] Delete; subsequent view not found
- [x] Duplicate create → already exists
- [x] Update / delete / view unknown name → not found
- [x] Update with neither `--new-name` nor `--description` → validation error

### Local CLI evidence (against localhost)

Help:

```
$ mojito-local --help | grep repo-type
    repo-type-create Creates a repo type
    repo-type-delete Deletes a repo type
    repo-type-update Updates a repo type
      repo-type-view View a repo type
```

Create and view:

```
$ mojito-local repo-type-create -n LocalReact -d "FormatJS / react-intl apps"
Create repo type: LocalReact

created --> repo type id: 1

$ mojito-local repo-type-view -n LocalReact
View repo type: LocalReact

Repo type id --> 1
Name --> LocalReact
Description --> FormatJS / react-intl apps
```

Update description:

```
$ mojito-local repo-type-update -n LocalReact -d "updated description"
Update repo type: LocalReact

updated --> repo type id: 1

$ mojito-local repo-type-view -n LocalReact
View repo type: LocalReact

Repo type id --> 1
Name --> LocalReact
Description --> updated description
```

Rename (id stays 1; old name is gone):

```
$ mojito-local repo-type-update -n LocalReact -nn LocalReactRenamed
Update repo type: LocalReact

updated --> repo type id: 1

$ mojito-local repo-type-view -n LocalReactRenamed
View repo type: LocalReactRenamed

Repo type id --> 1
Name --> LocalReactRenamed
Description --> updated description

$ mojito-local repo-type-view -n LocalReact
View repo type: LocalReact

Repo type with name [LocalReact] is not found
```

Delete:

```
$ mojito-local repo-type-delete -n LocalReactRenamed
Delete repo type: LocalReactRenamed

deleted --> repo type name: LocalReactRenamed

$ mojito-local repo-type-view -n LocalReactRenamed
View repo type: LocalReactRenamed

Repo type with name [LocalReactRenamed] is not found
```

Duplicate name:

```
$ mojito-local repo-type-create -n DupType
Create repo type: DupType

created --> repo type id: 2

$ mojito-local repo-type-create -n DupType
Create repo type: DupType

Repo type with name [DupType] already exists
```

Unknown type:

```
$ mojito-local repo-type-update -n DoesNotExist -d "x"
Update repo type: DoesNotExist

Repo type with name [DoesNotExist] is not found

$ mojito-local repo-type-delete -n DoesNotExist
Delete repo type: DoesNotExist

Repo type with name [DoesNotExist] is not found

$ mojito-local repo-type-view -n DoesNotExist
View repo type: DoesNotExist

Repo type with name [DoesNotExist] is not found
```

Update with no optional flags:

```
$ mojito-local repo-type-update -n DupType
Update repo type: DupType

Must provide at least one of the following options: --new-name, --description
```

Cleanup:

```
$ mojito-local repo-type-delete -n DupType
Delete repo type: DupType

deleted --> repo type name: DupType
```