### PR TITLE
Add FLUENT to restclient IntegrityCheckerType

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerType.java
@@ -7,6 +7,7 @@ package com.box.l10n.mojito.rest.entity;
  */
 public enum IntegrityCheckerType {
   MESSAGE_FORMAT,
+  FLUENT,
   MESSAGE_FORMAT_DOUBLE_BRACES,
   PRINTF_LIKE,
   PRINTF_LIKE_IGNORE_PERCENTAGE_AFTER_BRACKETS,

--- a/restclient/src/test/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerTypeTest.java
+++ b/restclient/src/test/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerTypeTest.java
@@ -1,0 +1,35 @@
+package com.box.l10n.mojito.rest.entity;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/**
+ * The restclient enum is deserialized from server JSON by name. A missing constant (historically
+ * {@code FLUENT}) makes {@code repo-view} / {@code repo-update} fail for that checker.
+ */
+public class IntegrityCheckerTypeTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void everyTypeDeserializesFromItsJsonName() throws Exception {
+    for (IntegrityCheckerType type : IntegrityCheckerType.values()) {
+      IntegrityCheckerType parsed =
+          objectMapper.readValue("\"" + type.name() + "\"", IntegrityCheckerType.class);
+      assertEquals(type.name(), type, parsed);
+    }
+  }
+
+  @Test
+  public void everyTypeDeserializesInACheckerPayload() throws Exception {
+    for (IntegrityCheckerType type : IntegrityCheckerType.values()) {
+      String json =
+          "{\"assetExtension\":\"ftl\",\"integrityCheckerType\":\"" + type.name() + "\"}";
+      IntegrityChecker checker = objectMapper.readValue(json, IntegrityChecker.class);
+      assertEquals(type.name(), "ftl", checker.getAssetExtension());
+      assertEquals(type.name(), type, checker.getIntegrityCheckerType());
+    }
+  }
+}

--- a/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerTypeTest.java
+++ b/webapp/src/test/java/com/box/l10n/mojito/service/assetintegritychecker/integritychecker/IntegrityCheckerTypeTest.java
@@ -1,0 +1,34 @@
+package com.box.l10n.mojito.service.assetintegritychecker.integritychecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Restclient {@code IntegrityCheckerType} is a name-only mirror of this server enum. Jackson
+ * deserializes by name, not ordinal — ordinals already diverge ({@code SIMPLE_PRINTF_LIKE}).
+ */
+public class IntegrityCheckerTypeTest {
+
+  @Test
+  public void restclientEnumHasTheSameNameSetAsTheServer() {
+    Set<String> serverNames =
+        Arrays.stream(IntegrityCheckerType.values()).map(Enum::name).collect(Collectors.toSet());
+    Set<String> restclientNames =
+        Arrays.stream(com.box.l10n.mojito.rest.entity.IntegrityCheckerType.values())
+            .map(Enum::name)
+            .collect(Collectors.toSet());
+
+    Set<String> onlyOnServer = new TreeSet<>(serverNames);
+    onlyOnServer.removeAll(restclientNames);
+    Set<String> onlyOnRestclient = new TreeSet<>(restclientNames);
+    onlyOnRestclient.removeAll(serverNames);
+
+    assertEquals(Set.of(), onlyOnServer, "on server but missing from restclient");
+    assertEquals(Set.of(), onlyOnRestclient, "on restclient but missing from server");
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes a client/server mismatch: the server `IntegrityCheckerType` enum includes `FLUENT` (Fluent integrity checker); the restclient copy did not.
- Jackson deserializes checkers **by name**, so `repo-view` / `repo-update` (and any other restclient path that reads `IntegrityChecker`) failed when a repository used a Fluent checker.
- Adds tests that every restclient enum name deserializes, and that the server and restclient enums have the same **name set** (not ordinals — those already diverge). A missing name is reported as “on server but missing from restclient” or the reverse.

Split out of https://github.com/box/mojito/pull/1076 per review.

## Test plan
- [ ] `mvn -pl restclient,webapp -am test -Dtest=IntegrityCheckerTypeTest -Dsurefire.failIfNoSpecifiedTests=false`
- [ ] Confirm `repo-view` / `repo-update` succeed for a repository that has a `FLUENT` integrity checker