### PR TITLE
Add mojito-mcp: CLI-backed MCP server for Cursor and Claude Code

### DIFF
--- a/mojito-mcp/.gitignore
+++ b/mojito-mcp/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.tsbuildinfo
+coverage/
+.env
+.env.local
+tests-integration/integration-config.json

--- a/mojito-mcp/.prettierrc.json
+++ b/mojito-mcp/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "printWidth": 100
+}

--- a/mojito-mcp/Architecture.md
+++ b/mojito-mcp/Architecture.md
@@ -1,4 +1,4 @@
-# mojito-mcp design: CLI-backed MCP server
+# mojito-mcp architecture: CLI-backed MCP server
 
 ## Goal
 

--- a/mojito-mcp/Architecture.md
+++ b/mojito-mcp/Architecture.md
@@ -82,7 +82,7 @@ Skill guidance: prefer **mojito-dev** while building features; use **mojito-prod
 | Variable               | Required | Default       | Meaning |
 |------------------------|----------|---------------|---------|
 | `MOJITO_CLI`           | No       | `mojito-prod` | Executable name or path of the Mojito CLI script |
-| `MOJITO_CLI_TIMEOUT_MS`| No       | `600000` (10m)| Hard kill timeout for each CLI invocation |
+| `MOJITO_CLI_TIMEOUT_MS`| No       | `600000` (10m)| Hard kill timeout for each CLI invocation (positive whole milliseconds; invalid values use the default) |
 
 Removed relative to the stub design: `MOJITO_BASE_URL`, `MOJITO_AUTH_TOKEN` (auth/host are CLI concerns).
 

--- a/mojito-mcp/DESIGN.md
+++ b/mojito-mcp/DESIGN.md
@@ -1,0 +1,292 @@
+# mojito-mcp design: CLI-backed MCP server
+
+## Goal
+
+Expose curated Mojito REST capabilities to AI agents (Cursor MCP) by shelling out to the **Mojito CLI `api` command**, not by reimplementing HTTP or auth in Node.
+
+If `mojito-prod api …` (or `mojito-dev api …`) works in a developer’s shell, the MCP tools for that environment work the same way.
+
+## Non-goals
+
+- Reimplementing Mojito authentication, cookies, MSAL, or host configuration in the MCP process.
+- Exposing a generic “raw API” tool or `mojito api --spec` as an MCP tool (`--spec` remains a human/dev aid when authoring tools and skills).
+- Auto-waiting on pollable tasks for the initial tool set (see [Wait / timeout](#wait--timeout)).
+
+## Architecture
+
+```
+Cursor (MCP host)
+  └─ mojito-mcp (stdio transport)
+       └─ MojitoCliClient
+            └─ spawn(MOJITO_CLI, ["api", …])  // stdout/stderr captured
+                 └─ Mojito CLI (AuthenticatedRestTemplate + local CLI config)
+                      └─ Mojito REST (/api/…)
+```
+
+Tool registration (`register-tools.ts`) stays as the MCP surface. Handlers call a CLI-backed client instead of a stub HTTP client.
+
+### Why the CLI
+
+- Auth and instance URL live in the engineer’s existing CLI setup (e.g. Spring config under `~/.l10n/…`).
+- No `MOJITO_AUTH_TOKEN` or base URL secrets in Cursor MCP env.
+- Pagination, JSON field encoding, and pollable-task helpers already exist on `mojito api`.
+- Prod vs dev is the same dual-script pattern developers already use.
+
+## Prod vs dev (dual script + dual MCP server)
+
+Developers maintain two CLI entry points on `PATH`:
+
+| Script        | Typical use                          |
+|---------------|--------------------------------------|
+| `mojito-prod` | Real data (linguistic bugs, prod)    |
+| `mojito-dev`  | Feature development / experimentation |
+
+The MCP process does **not** know about “prod” or “dev” as first-class concepts. It only runs whatever binary `MOJITO_CLI` names.
+
+**Defaults**
+
+| Variable / concept | Default        |
+|--------------------|----------------|
+| `MOJITO_CLI`       | `mojito-prod`  |
+| Dev script name    | `mojito-dev` (documented; set explicitly in Cursor) |
+
+**Cursor configuration:** two MCP server entries, same Node package, different `MOJITO_CLI`:
+
+```json
+{
+  "mcpServers": {
+    "mojito-prod": {
+      "command": "node",
+      "args": ["/absolute/path/to/mojito/mojito-mcp/dist/index.js"],
+      "env": {
+        "MOJITO_CLI": "mojito-prod",
+        "MOJITO_CLI_TIMEOUT_MS": "600000"
+      }
+    },
+    "mojito-dev": {
+      "command": "node",
+      "args": ["/absolute/path/to/mojito/mojito-mcp/dist/index.js"],
+      "env": {
+        "MOJITO_CLI": "mojito-dev",
+        "MOJITO_CLI_TIMEOUT_MS": "600000"
+      }
+    }
+  }
+}
+```
+
+Skill guidance: prefer **mojito-dev** while building features; use **mojito-prod** for real-data / linguistic work. Treat write tools on prod with care.
+
+## Configuration
+
+| Variable               | Required | Default       | Meaning |
+|------------------------|----------|---------------|---------|
+| `MOJITO_CLI`           | No       | `mojito-prod` | Executable name or path of the Mojito CLI script |
+| `MOJITO_CLI_TIMEOUT_MS`| No       | `600000` (10m)| Hard kill timeout for each CLI invocation |
+
+Removed relative to the stub design: `MOJITO_BASE_URL`, `MOJITO_AUTH_TOKEN` (auth/host are CLI concerns).
+
+### Startup probe
+
+On process start:
+
+1. Resolve `MOJITO_CLI` (default `mojito-prod`).
+2. Run `{MOJITO_CLI} --help` with captured stdout/stderr and a short timeout.
+3. If the process cannot be spawned or exits non-zero, exit the MCP server with a clear stderr message (CLI missing or broken). Do **not** call the network / `api` during startup.
+
+## CLI runner contract
+
+Module responsibility (e.g. `cli-runner.ts`):
+
+- `execFile` / `spawn` with an argv array (no shell), program = `MOJITO_CLI`.
+- **Always capture** child stdout and stderr (never inherit stdout onto the MCP stdio transport).
+- Enforce `MOJITO_CLI_TIMEOUT_MS`; on timeout, kill the child and fail the tool call.
+- Return `{ exitCode, stdout, stderr }` to the client layer.
+
+MCP stdio uses the server’s stdin/stdout for the protocol. Child stdout must not be mixed into that stream. Child stderr is captured and only surfaced via tool error payloads / MCP logging—not streamed live into the protocol.
+
+## `mojito api` usage conventions
+
+Follow the CLI output contract:
+
+| Channel   | Content |
+|-----------|---------|
+| stdout    | Response body only (JSON when applicable) |
+| stderr    | Diagnostics (`mojito: …`), including HTTP error summaries |
+| exit code | Non-zero on HTTP ≥ 400 (and CLI validation failures) |
+
+Client behavior:
+
+1. Build `api` argv for the tool.
+2. Run via the CLI runner.
+3. If `exitCode !== 0` (or timeout): treat as tool failure. Prefer stderr text for the AI-visible error; include stdout body when present (often JSON error details).
+4. If success: `JSON.parse(stdout)` (or handle empty body) and return as MCP tool text content (pretty-printed JSON is fine for readability).
+
+### Pagination
+
+For list/search-style tools that can return multiple pages, always pass:
+
+- `--paginate`
+- `--slurp`
+- `--max-pages` `0` (no limit; avoid the CLI default of 10)
+
+Pass caller `limit` / `offset` / page-size fields through as `-f`/`-F` when the tool schema includes them; they influence page size / starting position per CLI semantics. Do not rely on the AI to loop pages manually for v1.
+
+### Wait / timeout
+
+**v1 tools:** do **not** pass `-w` / `--wait`. None of them need to block on pollable tasks.
+
+`MOJITO_CLI_TIMEOUT_MS` still applies to every spawn (network hangs, slow searches). Default **10 minutes** so future tools that *do* use `--wait` (e.g. drop export/import, which can take ~5+ minutes per project) work without a too-aggressive default. Operators raise the env var for larger jobs.
+
+When adding long-running tools later: pass `--wait` and document raising `MOJITO_CLI_TIMEOUT_MS` as needed. Keep `mojito_pollabletask_get` as a non-waiting status GET.
+
+### `--spec`
+
+Not registered as an MCP tool. Developers may run `mojito-prod api --spec` (or dev) locally when designing new tools or skills.
+
+## Tool naming
+
+All tools use **`mojito_<object>_<action>`**, where `<object>` is the resource the action applies to.
+
+| Object | Actions (v1) |
+|--------|----------------|
+| `repo` | `list`, `view`, `create`, `delete` |
+| `textunit` | `search`, `info`, `history`, `translation_add` |
+| `review` | `update` |
+| `pollabletask` | `get` |
+
+Later (not v1): `mojito_textunit_translation_update` and related translation tools.
+
+## Tool → CLI mapping (v1)
+
+### Repository
+
+| MCP tool | CLI shape |
+|----------|-----------|
+| `mojito_repo_list` | `api /api/repositories --paginate --slurp --max-pages 0` optional `-f name=…` |
+| `mojito_repo_view` | `api /api/repositories/{repositoryId}` |
+| `mojito_repo_create` | `api /api/repositories -X POST` + body fields (`name`, optional `description`, `sourceLocale`, `checkSLA`, `repositoryLocales`, `assetIntegrityCheckers`) |
+| `mojito_repo_delete` | `api /api/repositories/{repositoryId} -X DELETE` |
+
+`mojito_repo_create` body mirrors `POST /api/repositories` (`Repository` JSON). Prefer `--input` with JSON when nested `repositoryLocales` / integrity checkers are present; simple creates can use `-F`/`-f`.
+
+### Text units
+
+| MCP tool | CLI shape |
+|----------|-----------|
+| `mojito_textunit_search` | `api /api/textunits/search -X POST --paginate --slurp --max-pages 0` + search body (see below) |
+| `mojito_textunit_info` | `api /api/textunits/search -X POST` with `tmTextUnitIds[]=…` (and optional `localeTags`) — returns `TextUnitDTO` rows (created date, status, used, target, asset path, etc.). There is no dedicated GET-by-id endpoint. |
+| `mojito_textunit_history` | `api /api/textunits/{tmTextUnitId}/history` + required `-f bcp47Tag=…` (API requires BCP-47 tag, e.g. `fr-FR`) |
+| `mojito_textunit_translation_add` | `api /api/textunits -X POST` with `tmTextUnitId`, `localeId`, `target`, optional `targetComment`, `status`, `includedInLocalizedFile` |
+
+#### `mojito_textunit_search` parameters
+
+Map the workbench / `TextUnitSearchBody` surface so agents can filter the same way the UI does:
+
+| Parameter | Type | Notes |
+|-----------|------|--------|
+| `repositoryIds` | `number[]` | If set, restrict to these repos; **omit for all repos** |
+| `repositoryNames` | `string[]` | Same scoping as ids (alternate); omit for all |
+| `tmTextUnitIds` | `number[]` | Pin to specific TM text units (repo lists not required) |
+| `localeTags` | `string[]` | If set, restrict to these BCP-47 tags; **omit for all locales** |
+| `name` | `string` | Match string **id** / name |
+| `source` | `string` | Match **source** text |
+| `target` | `string` | Match **target** (translation) text |
+| `assetPath` | `string` | Asset path filter |
+| `pluralFormOther` | `string` | Plural “other” form filter |
+| `searchType` | enum | How `name` / `source` / `target` match: `EXACT`, `CONTAINS`, `ILIKE` (default API: `EXACT`) |
+| `statusFilter` | enum | Workbench status bucket — see below |
+| `usedFilter` | enum | `USED` \| `UNUSED` (omit = both) |
+| `doNotTranslateFilter` | `boolean` | DNT filter |
+| `tmTextUnitCreatedAfter` | datetime string | Date range start (ISO-8601) |
+| `tmTextUnitCreatedBefore` | datetime string | Date range end (ISO-8601) |
+| `branchId` | `number` | Branch scope |
+| `pluralFormFiltered` | `boolean` | Default true on API |
+| `pluralFormExcluded` | `boolean` | Default false on API |
+| `limit` / `offset` | `number` | Page size / start; still use CLI `--paginate --slurp --max-pages 0` to collect all pages |
+
+**`statusFilter` values** (from `StatusFilter`): `ALL`, `TRANSLATED`, `UNTRANSLATED`, `TRANSLATED_AND_NOT_REJECTED`, `APPROVED_OR_NEEDS_REVIEW_AND_NOT_REJECTED`, `APPROVED_AND_NOT_REJECTED`, `FOR_TRANSLATION`, `REVIEW_NEEDED`, `REVIEW_NEEDED_OR_REJECTED`, `REVIEW_NOT_NEEDED`, `TRANSLATION_NEEDED`, `REJECTED`, `NOT_REJECTED`.
+
+Search matches **source**, **name (id)**, and/or **target** independently: set any combination of those string fields plus `searchType`.
+
+#### All repos / all locales (omit = all)
+
+No extra flags. Presence of a list **restricts**; absence means **all**.
+
+| Intent | Tool input | Client behavior |
+|--------|------------|-----------------|
+| All locales | Omit `localeTags` | Do not send `localeTags` (API already means all locales) |
+| All repositories | Omit `repositoryIds` and `repositoryNames` | Mojito’s search API still requires a repo (or `tmTextUnitIds`) scope. Client expands “all” by listing repos (`mojito_repo_list` path), then POSTs search with every repository `id`. Transparent to the AI. |
+| Specific repos | Non-empty `repositoryIds` and/or `repositoryNames` | Pass through |
+| Specific text units | Non-empty `tmTextUnitIds` | Pass through; no repo expansion |
+
+Skill note: prefer scoping by repo when possible; all-repo search can be large even with `--paginate --slurp`.
+
+### Review
+
+| MCP tool | CLI shape |
+|----------|-----------|
+| `mojito_review_update` | `api /api/textunits -X POST` — same endpoint as `mojito_textunit_translation_add`; sets review outcome like the workbench modal |
+
+Workbench actions → fields (same as UI `TextUnitStore.onReviewTextUnits`):
+
+| Action (tool param) | `status` | `includedInLocalizedFile` |
+|---------------------|----------|---------------------------|
+| `accept` | `APPROVED` | `true` |
+| `review` | `REVIEW_NEEDED` | `true` |
+| `translate` | `TRANSLATION_NEEDED` | `true` |
+| `reject` | `TRANSLATION_NEEDED` | `false` |
+
+Required inputs: `tmTextUnitId`, `localeId`, `target` (current translation text; API requires it), `action` (or explicit `status` + `includedInLocalizedFile`), optional `targetComment`.
+
+### Pollable tasks
+
+| MCP tool | CLI shape |
+|----------|-----------|
+| `mojito_pollabletask_get` | `api /api/pollableTasks/{pollableTaskId}` |
+
+### Field encoding helpers
+
+- Prefer `-F` for typed values (`true`/`false`/`null`/integers) and `-f` when the value must stay a string.
+- Arrays: repeated `name[]=value` (CLI convention).
+- Nested create payloads: `--input` + `-X POST`.
+- Always require explicit `-X` for methods other than GET (CLI safety rule).
+
+Tool ids and zod schemas in `register-tools.ts` / `tool-metadata.ts` must match this table (rename away from the stub names).
+
+## Module plan
+
+| Path | Change |
+|------|--------|
+| `src/config.ts` | `cliBinary` (`MOJITO_CLI`), `timeoutMs` (`MOJITO_CLI_TIMEOUT_MS`); drop base URL / auth token |
+| `src/cli-runner.ts` | **New** — spawn, capture, timeout |
+| `src/mojito-client.ts` | CLI-backed methods for every tool above |
+| `src/tool-metadata.ts` | Canonical renamed tool id list |
+| `src/register-tools.ts` | Register renamed tools + full search / review schemas |
+| `src/index.ts` | Load config, startup `--help` probe, construct client |
+| `README.md` / `SKILL.md` | Dual MCP servers, naming, CLI auth, search filter guidance |
+| `tests/` | Mock runner; argv + error mapping; tool-id parity |
+
+## Testing strategy
+
+1. **Unit tests** with a fake CLI runner: each client method builds the expected argv (`api`, path, `--paginate`, `--slurp`, `--max-pages`, `0`, `-X`, fields).
+2. **Error paths:** non-zero exit + stderr → thrown/returned error message suitable for MCP tool errors; timeout → distinct message.
+3. **Startup:** `--help` failure fails process boot (test with injectable runner if practical).
+4. **Optional integration** (manual or gated env): real `mojito-dev` / `mojito-prod` on the developer machine—not required for CI if Java CLI isn’t available.
+
+## Implementation order
+
+1. Config + CLI runner + unit tests.
+2. Startup `--help` probe in `index.ts`.
+3. Rename tool surface; implement repo + textunit + review + pollabletask client methods (paginate/slurp/max-pages where applicable; no `--wait`).
+4. Expand `mojito_textunit_search` schema to full `TextUnitSearchBody` filters.
+5. Update README and SKILL (dual-server, naming, search/review workflows).
+6. Manual smoke: Cursor → `mojito-dev` `mojito_repo_list` → `mojito-prod` `mojito_textunit_search` (read-only).
+
+## Future extensions (out of scope for v1)
+
+- Drop export/import tools with `--wait` and documented long timeouts.
+- Optional `--paginate` toggles only if unbounded slurps become a problem (not expected).
+- Escape-hatch raw `api` tool (deliberately deferred; curated tools are safer for agents).
+- Using `api --spec` offline when authoring new mappings.
+- `mojito_repo_update` (`PATCH /api/repositories/{id}`) if needed later.

--- a/mojito-mcp/LICENSE
+++ b/mojito-mcp/LICENSE
@@ -1,0 +1,166 @@
+                             Apache License
+                       Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/mojito-mcp/README.md
+++ b/mojito-mcp/README.md
@@ -255,7 +255,7 @@ Optional second add with `MOJITO_CLI=mojito-dev` if you have a local/non-prod Mo
 | Variable | Required | Default | Meaning |
 |----------|----------|---------|---------|
 | `MOJITO_CLI` | No | `mojito-prod` | Mojito CLI executable name or path on `PATH` |
-| `MOJITO_CLI_TIMEOUT_MS` | No | `600000` (10 minutes) | Hard timeout per CLI invocation |
+| `MOJITO_CLI_TIMEOUT_MS` | No | `600000` (10 minutes) | Hard timeout per CLI invocation, as a positive whole number of milliseconds. Invalid values (including fractions) use the default. |
 
 There is **no** `MOJITO_BASE_URL` or auth token in the MCP env. Host and credentials live in the CLI configuration only.
 

--- a/mojito-mcp/README.md
+++ b/mojito-mcp/README.md
@@ -2,11 +2,15 @@
 
 MCP (Model Context Protocol) server that lets Cursor and other AI hosts work with [Mojito](https://github.com/box/mojito) — search strings, inspect repositories, add translations, update review status, and more.
 
-**Authentication and server URL are not configured in this package.** The server shells out to your existing Mojito CLI (`mojito api …`). If the CLI can reach Mojito, the MCP tools can too.
-
 This directory is a **standalone npm package** (not a Maven module). You need **Node 18+** and a working Mojito CLI on your `PATH`.
 
 Internal design notes for implementers: see [Architecture.md](./Architecture.md).
+
+## Why it shells out to the Mojito CLI
+
+Mojito’s REST APIs sit behind the same Java authentication the CLI already implements (form login, MSAL, Cloudflare Access headers, cookies, and per-instance Spring config). Reproducing that in Node for MCP would be fragile and would duplicate host/credential setup.
+
+So this server does **not** talk to Mojito over HTTP itself and does **not** take `MOJITO_AUTH_TOKEN` or a base URL. It runs your existing CLI (`mojito api …`). If the CLI can reach Mojito, the MCP tools can too. Auth and instance URL stay in the CLI config you already maintain.
 
 ## Prerequisites: Mojito CLI
 

--- a/mojito-mcp/README.md
+++ b/mojito-mcp/README.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server that lets Cursor and other AI hosts work wit
 
 This directory is a **standalone npm package** (not a Maven module). You need **Node 18+** and a working Mojito CLI on your `PATH`.
 
-Internal design notes for implementers: see [DESIGN.md](./DESIGN.md).
+Internal design notes for implementers: see [Architecture.md](./Architecture.md).
 
 ## Prerequisites: Mojito CLI
 
@@ -28,34 +28,182 @@ Typical pieces:
 
 The MCP server does **not** replace that setup. It only invokes the script you point it at.
 
-### Prod and dev (dual scripts)
+### Prod and optional dev
 
-Many teams run two Mojito servers (for example **prod** with real linguistic data and **dev** for feature work). Use **two CLI entry points**, each with its own config (host + auth), both on your `PATH`:
+Most people only need **one** CLI wrapper, pointed at the Mojito they actually use (typically prod). That is enough for MCP.
 
-| Script (convention) | Use for |
-|---------------------|---------|
-| `mojito-prod` | Real data — linguistic bugs, production lookups |
-| `mojito-dev` | Developing against a non-prod Mojito |
+**`mojito-dev` is optional.** Add it only if you run a **local or non-prod Mojito** (for example a laptop server or a shared dev instance) and want a second MCP server for experiments. If you do not have a dev server, skip the `mojito-dev` jar, wrapper, properties, and MCP entry.
+
+| Script (convention) | Required? | Use for |
+|---------------------|-----------|---------|
+| `mojito-prod` | Yes (or any single name you set as `MOJITO_CLI`) | Real data — linguistic bugs, production lookups |
+| `mojito-dev` | No — only with a local/non-prod Mojito | Feature work against that instance |
 
 Name the scripts whatever you like; the MCP server only cares about the value of `MOJITO_CLI`. The conventions above match the defaults and docs in this package.
 
-Verify each script independently:
+### Download `mojito-cli.jar` from your Mojito instance
+
+Use the CLI jar **served by the Mojito webapp you will talk to**. Each instance publishes it at:
+
+`https://<your-mojito-host>/cli/mojito-cli.jar`
+
+Download the jar from **that** instance so the CLI version matches the server. Homebrew or a locally built `cli/target/mojito-cli-*-exec.jar` are alternatives; the instance URL is the usual path.
+
+```bash
+mkdir -p "$HOME/bin/mojito-files/prod"
+
+# Replace the host with your Mojito origin (same host you set in l10n.resttemplate.host).
+curl -fL -o "$HOME/bin/mojito-files/prod/mojito-cli.jar" \
+  "https://mojito.example.com/cli/mojito-cli.jar"
+```
+
+**Optional — only if you have a local or non-prod Mojito:**
+
+```bash
+mkdir -p "$HOME/bin/mojito-files/dev"
+
+curl -fL -o "$HOME/bin/mojito-files/dev/mojito-cli.jar" \
+  "https://mojito-dev.example.com/cli/mojito-cli.jar"
+```
+
+Re-run the same `curl` commands to pick up a new CLI after the server is upgraded. If the instance is behind Cloudflare Access, pass the CF Access client id/secret headers (see [Installation and Setup](https://www.mojito.global/docs/guides/install-springboot3/) for `install.sh` with `authMode=CF_SERVICE_TOKEN`). The webapp also serves `/cli/install.sh` if you prefer the official installer over a raw jar.
+
+### Example wrappers
+
+Each script is a thin `java -jar` launcher: a **CLI jar**, a **Spring config directory**, and a **profile** that selects host + auth. Put the scripts on your `PATH` (for example `~/bin`) and `chmod +x` them.
+
+`~/bin/mojito-prod`:
+
+```bash
+#!/bin/sh
+exec java -jar "$HOME/bin/mojito-files/prod/mojito-cli.jar" "$@" \
+  --spring.config.additional-location="file://${HOME}/.l10n/config/cli/" \
+  --spring.profiles.active=cli,formlogincredentialprovider
+```
+
+**Optional `~/bin/mojito-dev`** (only if you have a local/non-prod Mojito). Use a **different jar and/or Spring profile** so it cannot share the prod host:
+
+```bash
+#!/bin/sh
+exec java -jar "$HOME/bin/mojito-files/dev/mojito-cli.jar" "$@" \
+  --spring.config.additional-location="file://${HOME}/.l10n/config/cli/" \
+  --spring.profiles.active=dev,formlogincredentialprovider
+```
+
+`"$@"` must be passed through so `api` and other CLI args reach the jar. `formlogincredentialprovider` matches username/password in the properties files; other auth modes (MSAL, header/CF Access, console prompt) use different profiles — see [Configurations](https://www.mojito.global/docs/refs/configurations/).
+
+Host and credentials live next to the CLI, not in MCP. With `--spring.profiles.active=cli,…` Spring loads `application-cli.properties`; `dev` loads `application-dev.properties`. Example (placeholders only):
+
+`~/.l10n/config/cli/application-cli.properties` (prod):
+
+```properties
+l10n.resttemplate.host=mojito.example.com
+l10n.resttemplate.port=443
+l10n.resttemplate.scheme=https
+l10n.resttemplate.authentication.credentialProvider=CONFIG
+l10n.resttemplate.authentication.username=your-user
+l10n.resttemplate.authentication.password=your-password
+```
+
+`~/.l10n/config/cli/application-dev.properties` (**optional**, local/non-prod Mojito): same keys, **dev host** and credentials.
+
+Cursor’s GUI `PATH` may not include `~/bin`; if MCP startup cannot find the wrapper, set `MOJITO_CLI` to the script’s **absolute path**.
+
+Verify the prod wrapper:
 
 ```bash
 mojito-prod --help
 mojito-prod api /api/repositories
-
-mojito-dev --help
-mojito-dev api /api/repositories
 ```
 
-Then register **two MCP servers** in Cursor (same package, different `MOJITO_CLI`) — see [Configure Cursor](#configure-cursor).
+If you set up **mojito-dev**, verify it the same way (`mojito-dev --help` and `mojito-dev api /api/repositories`).
 
-**Default:** if `MOJITO_CLI` is unset, the MCP server uses `mojito-prod`. Prefer `mojito-dev` while building features; use prod when you need real data. Be careful with write tools (`mojito_repo_create`, `mojito_repo_delete`, `mojito_textunit_translation_add`, `mojito_review_update`) on prod.
+Then register **one MCP server** for prod (and a second only if you have `mojito-dev`) — see [Install from npm](#install-from-npm-recommended) or [Install from a local checkout](#install-from-a-local-checkout).
 
-## Install
+**Default:** if `MOJITO_CLI` is unset, the MCP server uses `mojito-prod`. If you have a local/non-prod instance, prefer **mojito-dev** while building features and **mojito-prod** for real data. Be careful with write tools (`mojito_repo_create`, `mojito_repo_delete`, `mojito_textunit_translation_add`, `mojito_review_update`) on prod.
 
-From this directory (development / local checkout):
+## Install from npm (recommended)
+
+Install the published package **once, globally**. Cursor and Claude Code then spawn that binary on stdio. Do **not** use `npx` in a long-lived MCP config: every host start can hit the registry again.
+
+```bash
+npm install -g mojito-mcp
+```
+
+If the published name is scoped (for example `@box/mojito-mcp`), use that name in `npm install -g` and in the snippets below. You still need **Node 18+** and a working `mojito-prod` (or whatever you set as `MOJITO_CLI`). Add `mojito-dev` only if you have a local/non-prod Mojito. This package does not install the Mojito CLI.
+
+Resolve the installed binary and use that **absolute path** in host config. GUI apps (Cursor) often do not inherit your shell `PATH` (nvm, fnm, asdf), so `"command": "mojito-mcp"` can fail even when the same name works in a terminal.
+
+```bash
+which mojito-mcp
+# example: /Users/you/.nvm/versions/node/v22.14.0/bin/mojito-mcp
+```
+
+Upgrade later with `npm install -g mojito-mcp@<version>` (or the same command without a version for latest). After upgrading, `which mojito-mcp` should still be the same path unless you changed Node versions.
+
+If you only use prod (typical), register a **single** MCP server with `MOJITO_CLI` set to `mojito-prod` (or omit it — that is the default). The `mojito-dev` blocks below are optional.
+
+### Cursor
+
+In **Cursor → Settings → MCP**, or in `~/.cursor/mcp.json` (all projects) / `.cursor/mcp.json` (this repo), add a **mojito-prod** entry. Merge into an existing `mcpServers` object; do not replace other servers. Replace the `command` path with your `which mojito-mcp` output. Add **mojito-dev** only if you have a local/non-prod Mojito.
+
+```json
+{
+  "mcpServers": {
+    "mojito-prod": {
+      "command": "/absolute/path/to/mojito-mcp",
+      "env": {
+        "MOJITO_CLI": "mojito-prod",
+        "MOJITO_CLI_TIMEOUT_MS": "600000"
+      }
+    }
+  }
+}
+```
+
+Optional second entry (local/non-prod Mojito only):
+
+```json
+"mojito-dev": {
+  "command": "/absolute/path/to/mojito-mcp",
+  "env": {
+    "MOJITO_CLI": "mojito-dev",
+    "MOJITO_CLI_TIMEOUT_MS": "600000"
+  }
+}
+```
+
+Reload MCP (or restart Cursor) and confirm the server(s) show as connected.
+
+### Claude Code
+
+Claude Code’s installer is `claude mcp add`. Everything after `--` is the process it spawns. Prefer the absolute path from `which mojito-mcp`. `--scope user` registers the server for all of your projects; use `--scope project` and a committed `.mcp.json` if the team should share the same launch command (no secrets belong there — auth stays in the Mojito CLI).
+
+```bash
+MCP_BIN="$(which mojito-mcp)"
+
+claude mcp add --scope user mojito-prod \
+  --env MOJITO_CLI=mojito-prod \
+  --env MOJITO_CLI_TIMEOUT_MS=600000 \
+  -- "$MCP_BIN"
+```
+
+Optional — only if you have a local/non-prod Mojito:
+
+```bash
+claude mcp add --scope user mojito-dev \
+  --env MOJITO_CLI=mojito-dev \
+  --env MOJITO_CLI_TIMEOUT_MS=600000 \
+  -- "$MCP_BIN"
+```
+
+Check with `claude mcp list`, or `/mcp` inside a Claude Code session.
+
+There is no `setup.sh` for this on purpose. Cursor wants a JSON merge into a file you already have; Claude Code already has a first-class add command. Copy the snippets above, or run `claude mcp add`.
+
+## Install from a local checkout
+
+For developing this package, or before it is published:
 
 ```bash
 cd mojito-mcp
@@ -64,13 +212,11 @@ npm test
 npm run build
 ```
 
-The compiled entrypoint is `dist/index.js`. Cursor should run that file with Node (stdio transport). Do not pipe JSON to stdin yourself; the MCP host owns the protocol.
+The compiled entrypoint is `dist/index.js`. Point the host at that file with Node (stdio). Do not pipe JSON to stdin yourself; the MCP host owns the protocol.
 
-After an internal publish you can switch to your registry’s `npx` / package install pattern; configuration below stays the same.
+### Cursor (local `dist/`)
 
-## Configure Cursor
-
-In **Cursor → Settings → MCP**, or in `~/.cursor/mcp.json`, add one entry per Mojito environment. Use **absolute paths** to `dist/index.js`.
+Same as the npm install: **mojito-prod** is enough. Add **mojito-dev** only if you have a local/non-prod Mojito.
 
 ```json
 {
@@ -82,20 +228,23 @@ In **Cursor → Settings → MCP**, or in `~/.cursor/mcp.json`, add one entry pe
         "MOJITO_CLI": "mojito-prod",
         "MOJITO_CLI_TIMEOUT_MS": "600000"
       }
-    },
-    "mojito-dev": {
-      "command": "node",
-      "args": ["/absolute/path/to/mojito/mojito-mcp/dist/index.js"],
-      "env": {
-        "MOJITO_CLI": "mojito-dev",
-        "MOJITO_CLI_TIMEOUT_MS": "600000"
-      }
     }
   }
 }
 ```
 
-If you only use one environment, a single server entry is enough. Set `MOJITO_CLI` to that script’s name (or omit it to default to `mojito-prod`).
+### Claude Code (local `dist/`)
+
+```bash
+claude mcp add --scope user mojito-prod \
+  --env MOJITO_CLI=mojito-prod \
+  --env MOJITO_CLI_TIMEOUT_MS=600000 \
+  -- node /absolute/path/to/mojito/mojito-mcp/dist/index.js
+```
+
+Optional second add with `MOJITO_CLI=mojito-dev` if you have a local/non-prod Mojito.
+
+## Configuration
 
 ### Environment variables
 
@@ -167,7 +316,7 @@ npm run test:watch
 npm run build
 ```
 
-Unit tests use Jest + `ts-jest` (ESM) under `tests/`. Implementation should follow [DESIGN.md](./DESIGN.md).
+Unit tests use Jest + `ts-jest` (ESM) under `tests/`. Implementation should follow [Architecture.md](./Architecture.md).
 
 ### Integration tests (real Mojito CLI / dev server)
 
@@ -183,4 +332,4 @@ See [tests-integration/README.md](./tests-integration/README.md).
 
 ## License
 
-Apache-2.0, consistent with Mojito.
+[Apache License 2.0](./LICENSE), consistent with Mojito.

--- a/mojito-mcp/README.md
+++ b/mojito-mcp/README.md
@@ -1,0 +1,186 @@
+# mojito-mcp
+
+MCP (Model Context Protocol) server that lets Cursor and other AI hosts work with [Mojito](https://github.com/box/mojito) — search strings, inspect repositories, add translations, update review status, and more.
+
+**Authentication and server URL are not configured in this package.** The server shells out to your existing Mojito CLI (`mojito api …`). If the CLI can reach Mojito, the MCP tools can too.
+
+This directory is a **standalone npm package** (not a Maven module). You need **Node 18+** and a working Mojito CLI on your `PATH`.
+
+Internal design notes for implementers: see [DESIGN.md](./DESIGN.md).
+
+## Prerequisites: Mojito CLI
+
+Before installing the MCP server, install and configure the Mojito CLI so it authenticates to your Mojito instance(s).
+
+### Official Mojito documentation
+
+| Topic | Doc |
+|-------|-----|
+| Install the CLI (jar, Homebrew, install script from the server) | [Installation and Setup](https://www.mojito.global/docs/guides/install-springboot3/) |
+| CLI host, credentials, and auth modes (`l10n.resttemplate.*`) | [Configurations](https://www.mojito.global/docs/refs/configurations/) |
+| Contributor / local alias examples | [Open source contributors](https://www.mojito.global/docs/guides/open-source-contributors/) |
+
+Typical pieces:
+
+1. A CLI wrapper on your `PATH` (install script from the Mojito server, Homebrew `mojito`, or a `java -jar …` wrapper).
+2. CLI `application.properties` with host/scheme/port and authentication (form login, MSAL, header/CF Access, etc.) — see the configurations guide above.
+3. Confirm in a terminal: `mojito --help` and a simple call such as `mojito api /api/repositories`.
+
+The MCP server does **not** replace that setup. It only invokes the script you point it at.
+
+### Prod and dev (dual scripts)
+
+Many teams run two Mojito servers (for example **prod** with real linguistic data and **dev** for feature work). Use **two CLI entry points**, each with its own config (host + auth), both on your `PATH`:
+
+| Script (convention) | Use for |
+|---------------------|---------|
+| `mojito-prod` | Real data — linguistic bugs, production lookups |
+| `mojito-dev` | Developing against a non-prod Mojito |
+
+Name the scripts whatever you like; the MCP server only cares about the value of `MOJITO_CLI`. The conventions above match the defaults and docs in this package.
+
+Verify each script independently:
+
+```bash
+mojito-prod --help
+mojito-prod api /api/repositories
+
+mojito-dev --help
+mojito-dev api /api/repositories
+```
+
+Then register **two MCP servers** in Cursor (same package, different `MOJITO_CLI`) — see [Configure Cursor](#configure-cursor).
+
+**Default:** if `MOJITO_CLI` is unset, the MCP server uses `mojito-prod`. Prefer `mojito-dev` while building features; use prod when you need real data. Be careful with write tools (`mojito_repo_create`, `mojito_repo_delete`, `mojito_textunit_translation_add`, `mojito_review_update`) on prod.
+
+## Install
+
+From this directory (development / local checkout):
+
+```bash
+cd mojito-mcp
+npm install
+npm test
+npm run build
+```
+
+The compiled entrypoint is `dist/index.js`. Cursor should run that file with Node (stdio transport). Do not pipe JSON to stdin yourself; the MCP host owns the protocol.
+
+After an internal publish you can switch to your registry’s `npx` / package install pattern; configuration below stays the same.
+
+## Configure Cursor
+
+In **Cursor → Settings → MCP**, or in `~/.cursor/mcp.json`, add one entry per Mojito environment. Use **absolute paths** to `dist/index.js`.
+
+```json
+{
+  "mcpServers": {
+    "mojito-prod": {
+      "command": "node",
+      "args": ["/absolute/path/to/mojito/mojito-mcp/dist/index.js"],
+      "env": {
+        "MOJITO_CLI": "mojito-prod",
+        "MOJITO_CLI_TIMEOUT_MS": "600000"
+      }
+    },
+    "mojito-dev": {
+      "command": "node",
+      "args": ["/absolute/path/to/mojito/mojito-mcp/dist/index.js"],
+      "env": {
+        "MOJITO_CLI": "mojito-dev",
+        "MOJITO_CLI_TIMEOUT_MS": "600000"
+      }
+    }
+  }
+}
+```
+
+If you only use one environment, a single server entry is enough. Set `MOJITO_CLI` to that script’s name (or omit it to default to `mojito-prod`).
+
+### Environment variables
+
+| Variable | Required | Default | Meaning |
+|----------|----------|---------|---------|
+| `MOJITO_CLI` | No | `mojito-prod` | Mojito CLI executable name or path on `PATH` |
+| `MOJITO_CLI_TIMEOUT_MS` | No | `600000` (10 minutes) | Hard timeout per CLI invocation |
+
+There is **no** `MOJITO_BASE_URL` or auth token in the MCP env. Host and credentials live in the CLI configuration only.
+
+On startup the server runs `{MOJITO_CLI} --help`. If that fails (missing script, not executable), the MCP process exits with an error — fix the CLI wrapper first.
+
+### Timeouts
+
+Long CLI work (especially future drop export/import with wait) can exceed a few minutes. Raise `MOJITO_CLI_TIMEOUT_MS` in the MCP env for that server if needed. The default (10 minutes) covers typical slow jobs; large projects may need more.
+
+## Tools
+
+Tool ids follow `mojito_<object>_<action>`.
+
+### Repository
+
+| Tool | Purpose |
+|------|---------|
+| `mojito_repo_list` | List repositories (optional name filter) |
+| `mojito_repo_view` | Get one repository by id |
+| `mojito_repo_create` | Create a repository |
+| `mojito_repo_delete` | Delete a repository by id |
+
+### Text units
+
+| Tool | Purpose |
+|------|---------|
+| `mojito_textunit_search` | Workbench-style search (repos, locales, source/name/target, status, used/unused, date range, …) |
+| `mojito_textunit_info` | General info for a text unit (created date, status, current translation fields, …) |
+| `mojito_textunit_history` | Translation history for a text unit + locale (`bcp47Tag`) |
+| `mojito_textunit_translation_add` | Add / set the current translation for a locale |
+
+**Search scoping:** omit `repositoryIds` / `repositoryNames` to search **all repositories**; omit `localeTags` to include **all locales**. Providing a list restricts the search to those values. (The client expands “all repos” for the Mojito API under the hood.)
+
+Prefer scoping by repository when you can — all-repo search can return a lot of data.
+
+### Review and async tasks
+
+| Tool | Purpose |
+|------|---------|
+| `mojito_review_update` | Accept / needs-review / needs-translation / reject (workbench review actions) |
+| `mojito_pollabletask_get` | Fetch status of a pollable task by id |
+
+## How it works (brief)
+
+```
+Cursor → mojito-mcp → mojito-prod|mojito-dev api … → Mojito REST
+```
+
+The server captures CLI stdout/stderr. Successful JSON responses are returned to the model; CLI failures (non-zero exit, stderr diagnostics) are surfaced as normal MCP tool errors. List/search tools use the CLI’s pagination helpers (`--paginate --slurp`, unbounded page cap) so callers do not page manually.
+
+## Optional: Cursor skill
+
+[SKILL.md](./SKILL.md) has workflow hints (e.g. matching git repo names to Mojito repository names). Copy or symlink it into your Cursor skills directory if you want that guidance in every chat; tool descriptions alone are enough to call the APIs. The skill file is also included in the npm package `files` list.
+
+## Develop / test this package
+
+```bash
+cd mojito-mcp
+npm install
+npm test
+npm run test:watch
+npm run build
+```
+
+Unit tests use Jest + `ts-jest` (ESM) under `tests/`. Implementation should follow [DESIGN.md](./DESIGN.md).
+
+### Integration tests (real Mojito CLI / dev server)
+
+Live tests live in `tests-integration/` and are **not** part of `npm test`. They require a local config file pointing at your CLI scripts and a disposable `testRepositoryName`; they run against **dev** only and will create/view/delete that repository:
+
+```bash
+cp tests-integration/integration-config.template.json tests-integration/integration-config.json
+# edit integration-config.json — set devCli, prodCli, testRepositoryName
+npm run test:integration
+```
+
+See [tests-integration/README.md](./tests-integration/README.md).
+
+## License
+
+Apache-2.0, consistent with Mojito.

--- a/mojito-mcp/SKILL.md
+++ b/mojito-mcp/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: mojito-mcp
+description: Use when working with the Mojito MCP server — translation search, history, submitting corrections, and async pollable tasks. Apply when the user mentions Mojito, TM text units, mojito-mcp tools, or translation status in Cursor with MCP. Infer Mojito repository from the open git repo name when the user does not name one; match names case-insensitively and ignoring hyphens.
+---
+
+# Mojito MCP (mojito-mcp)
+
+## Default repository (workspace git)
+
+The user is usually already inside a product repo in Cursor (e.g. **`EndUserApp`**). At Box, **Mojito repository names often align with the git repository name**, but spelling can differ in **letter case** and **hyphens** (e.g. git folder **`PreviewClient`** vs Mojito repo **`preview-client`**).
+
+### Normalized name equality
+
+When comparing **git repo identity** to a Mojito repository **`name`** (from **`mojito_list_repositories`** or search results), treat two strings as the **same repo** if they are equal after:
+
+1. **ASCII lowercasing** (case-insensitive), and  
+2. **Removing all `-` (hyphen) characters** from both sides,
+
+then comparing the results character-for-character.
+
+Example: `PreviewClient` → `previewclient`; `preview-client` → `previewclient` → **match**.
+
+If the HTTP `name` query parameter is **strict** (exact Mojito string), a single filtered call may return nothing even when a normalized match exists—**list repositories without that filter** (or with a broad enough filter), then **choose the row whose `name` matches under this normalization**. If **zero** or **several** Mojito repos tie under normalization, **ask the user** which repo to use.
+
+When the user **does not** name a Mojito repository:
+
+1. Determine the **current workspace’s git repo identity** (e.g. root folder name, or `origin` URL basename without `.git`).
+2. Fetch Mojito repositories (**`mojito_list_repositories`**) so you can compare **`name`** fields using **normalized name equality** above.
+3. If there is **no** repository that matches, or **multiple** plausible matches after normalization, **stop and ask** the user which Mojito repo to use—do not guess silently.
+4. Once resolved, pass the **canonical Mojito `repository.name`** string (and/or **`repositoryIds`**) into **`mojito_search_text_units`** and later tools—use the name as returned by Mojito for API calls that require the server’s exact spelling.
+
+## When to use which tool
+
+1. **Resolve context** — Call **`mojito_list_repositories`** when you need ids or to confirm a repo exists. If the user gave a repo name, still use **normalized name equality** when pairing it to Mojito rows. If not, follow **Default repository (workspace git)** above before searching.
+2. **Find strings or translations** — Use **`mojito_search_text_units`** with `repositoryNames` or `repositoryIds` plus optional `source`, `name`, `assetPath`, `branchId`, `statusFilter`, `localeTags`, `searchType`, pagination.
+3. **Explain changes over time** — After you have a `tmTextUnitId`, use **`mojito_get_text_unit_history`**.
+4. **Submit a corrected or shorter translation** — Use **`mojito_add_translation`** with `tmTextUnitId`, `localeId`, and `target` (and optional comment/status/`includedInLocalizedFile`). Requires correct ids from search results.
+5. **Long-running jobs** — If another workflow returns a pollable task id, use **`mojito_get_pollable_task`** and poll until complete (respect backoff).
+
+## Id and status pitfalls
+
+- Distinguish **tm text unit id** vs **variant id** vs **current variant id**; the Mojito UI and APIs use different ids. Prefer values taken from **`mojito_search_text_units`** responses once implemented.
+- **`statusFilter`** values must match Mojito’s `StatusFilter` enum strings (e.g. `UNTRANSLATED`, `FOR_TRANSLATION`, …) — verify against the webapp when in doubt.
+- Vendor / TMS state may **not** live in Mojito; say so if the user asks about vendor queues and data is missing.
+
+## Async and errors
+
+- Until HTTP is implemented, tools will return MCP tool errors starting with `MojitoHttpClient.*: not implemented`.
+- After implementation, expect **401/403** for auth issues; surface them clearly without leaking tokens.
+
+## Repo location
+
+In the Mojito monorepo, this server lives in **`mojito-mcp/`** (npm, not Maven).

--- a/mojito-mcp/SKILL.md
+++ b/mojito-mcp/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: mojito-mcp
-description: Use when working with the Mojito MCP server — translation search, history, submitting corrections, and async pollable tasks. Apply when the user mentions Mojito, TM text units, mojito-mcp tools, or translation status in Cursor with MCP. Infer Mojito repository from the open git repo name when the user does not name one; match names case-insensitively and ignoring hyphens.
+description: Use when working with the Mojito MCP server — translation search, history, submitting corrections, review status, and pollable tasks. Apply when the user mentions Mojito, TM text units, mojito-mcp tools, or translation status in Cursor with MCP. Infer Mojito repository from the open git repo name when the user does not name one; match names case-insensitively and ignoring hyphens.
 ---
 
 # Mojito MCP (mojito-mcp)
+
+Tools are named `mojito_<object>_<action>`. Most setups use a single MCP server with **mojito-prod**. A second **mojito-dev** server is optional and only useful if the user has a local or non-prod Mojito. Prefer **mojito-dev** while experimenting when it exists. Treat write tools on prod with care: `mojito_repo_create`, `mojito_repo_delete`, `mojito_textunit_translation_add`, `mojito_review_update`.
+
+Auth and host live in the engineer’s Mojito CLI (`MOJITO_CLI`), not in MCP env. If tools fail at startup or with login/HTTP errors, the CLI config is wrong — do not invent tokens.
 
 ## Default repository (workspace git)
 
@@ -11,43 +15,46 @@ The user is usually already inside a product repo in Cursor (e.g. **`EndUserApp`
 
 ### Normalized name equality
 
-When comparing **git repo identity** to a Mojito repository **`name`** (from **`mojito_list_repositories`** or search results), treat two strings as the **same repo** if they are equal after:
+When comparing **git repo identity** to a Mojito repository **`name`** (from **`mojito_repo_list`** or search results), treat two strings as the **same repo** if they are equal after:
 
-1. **ASCII lowercasing** (case-insensitive), and  
+1. **ASCII lowercasing** (case-insensitive), and
 2. **Removing all `-` (hyphen) characters** from both sides,
 
 then comparing the results character-for-character.
 
 Example: `PreviewClient` → `previewclient`; `preview-client` → `previewclient` → **match**.
 
-If the HTTP `name` query parameter is **strict** (exact Mojito string), a single filtered call may return nothing even when a normalized match exists—**list repositories without that filter** (or with a broad enough filter), then **choose the row whose `name` matches under this normalization**. If **zero** or **several** Mojito repos tie under normalization, **ask the user** which repo to use.
+`mojito_repo_list`’s optional `name` filter is **exact** on the Mojito string. A filtered call may return nothing even when a normalized match exists — **list without that filter** (or with a broader filter), then **choose the row whose `name` matches under this normalization**. If **zero** or **several** Mojito repos tie, **ask the user** which repo to use.
 
 When the user **does not** name a Mojito repository:
 
 1. Determine the **current workspace’s git repo identity** (e.g. root folder name, or `origin` URL basename without `.git`).
-2. Fetch Mojito repositories (**`mojito_list_repositories`**) so you can compare **`name`** fields using **normalized name equality** above.
-3. If there is **no** repository that matches, or **multiple** plausible matches after normalization, **stop and ask** the user which Mojito repo to use—do not guess silently.
-4. Once resolved, pass the **canonical Mojito `repository.name`** string (and/or **`repositoryIds`**) into **`mojito_search_text_units`** and later tools—use the name as returned by Mojito for API calls that require the server’s exact spelling.
+2. Fetch Mojito repositories (**`mojito_repo_list`**) and compare **`name`** fields using **normalized name equality**.
+3. If there is **no** match, or **multiple** plausible matches, **stop and ask** — do not guess silently.
+4. Once resolved, pass the **canonical Mojito `name`** and/or **`repositoryIds`** into **`mojito_textunit_search`** and later tools — use Mojito’s exact spelling for API fields.
 
 ## When to use which tool
 
-1. **Resolve context** — Call **`mojito_list_repositories`** when you need ids or to confirm a repo exists. If the user gave a repo name, still use **normalized name equality** when pairing it to Mojito rows. If not, follow **Default repository (workspace git)** above before searching.
-2. **Find strings or translations** — Use **`mojito_search_text_units`** with `repositoryNames` or `repositoryIds` plus optional `source`, `name`, `assetPath`, `branchId`, `statusFilter`, `localeTags`, `searchType`, pagination.
-3. **Explain changes over time** — After you have a `tmTextUnitId`, use **`mojito_get_text_unit_history`**.
-4. **Submit a corrected or shorter translation** — Use **`mojito_add_translation`** with `tmTextUnitId`, `localeId`, and `target` (and optional comment/status/`includedInLocalizedFile`). Requires correct ids from search results.
-5. **Long-running jobs** — If another workflow returns a pollable task id, use **`mojito_get_pollable_task`** and poll until complete (respect backoff).
+1. **Resolve context** — **`mojito_repo_list`** (optional exact `name`) for ids and names; **`mojito_repo_view`** when you already have a numeric `repositoryId`. If the user gave a repo name, still use **normalized name equality**. If not, follow **Default repository** above before searching.
+2. **Find strings or translations** — **`mojito_textunit_search`** with `repositoryNames` or `repositoryIds` plus optional `source`, `name` (string id), `target`, `assetPath`, `branchId`, `statusFilter`, `localeTags`, `searchType` (`EXACT` / `CONTAINS` / `ILIKE`), `usedFilter`, date range, `limit`. Omit `repositoryIds`/`repositoryNames` for all repos; omit `localeTags` for all locales. Prefer scoping by repo — all-repo search can be large.
+3. **Inspect one unit** — **`mojito_textunit_info`** with `tmTextUnitId` (optional `localeTags`) for created date, status, current translation, asset path, used/DNT, etc.
+4. **Explain changes over time** — **`mojito_textunit_history`** with `tmTextUnitId` and **`bcp47Tag`** (required; e.g. `fr-FR`, not locale id).
+5. **Submit a translation** — **`mojito_textunit_translation_add`** with `tmTextUnitId`, **numeric `localeId`** (from search/info, not the BCP-47 tag), and `target`. Optional `targetComment`, `status`, `includedInLocalizedFile`.
+6. **Workbench review** — **`mojito_review_update`** with `tmTextUnitId`, `localeId`, current `target`, and `action`: `accept` / `review` / `translate` / `reject`. Prefer this over raw status fields for accept/reject/needs-review flows.
+7. **Create/delete a repository** — **`mojito_repo_create`** / **`mojito_repo_delete`**. Confirm environment and id/name with the user first, especially on prod.
+8. **Async jobs** — **`mojito_pollabletask_get`** with a pollable task id. This tool does **not** wait; poll until finished (backoff). v1 tools do not auto-wait on CLI `--wait`.
 
 ## Id and status pitfalls
 
-- Distinguish **tm text unit id** vs **variant id** vs **current variant id**; the Mojito UI and APIs use different ids. Prefer values taken from **`mojito_search_text_units`** responses once implemented.
-- **`statusFilter`** values must match Mojito’s `StatusFilter` enum strings (e.g. `UNTRANSLATED`, `FOR_TRANSLATION`, …) — verify against the webapp when in doubt.
-- Vendor / TMS state may **not** live in Mojito; say so if the user asks about vendor queues and data is missing.
+- Distinguish **tm text unit id** vs **variant id** vs **current variant id**; the UI and APIs use different ids. Prefer values from **`mojito_textunit_search`** / **`mojito_textunit_info`**.
+- Translation write tools need **`localeId`** (number). History needs **`bcp47Tag`** (string).
+- **`statusFilter`** on search is a workbench bucket (`UNTRANSLATED`, `FOR_TRANSLATION`, `REVIEW_NEEDED`, …), not the same as a variant’s `status` (`APPROVED` / `REVIEW_NEEDED` / `TRANSLATION_NEEDED`).
+- Vendor / TMS queues may **not** live in Mojito; say so if that data is missing.
 
-## Async and errors
+## Errors
 
-- Until HTTP is implemented, tools will return MCP tool errors starting with `MojitoHttpClient.*: not implemented`.
-- After implementation, expect **401/403** for auth issues; surface them clearly without leaking tokens.
+CLI failures (non-zero `mojito api`, auth, HTTP ≥ 400) surface as MCP tool errors, usually from CLI stderr. Do not leak credentials. If the MCP server never starts, `{MOJITO_CLI} --help` failed — the wrapper is missing or not on PATH.
 
 ## Repo location
 
-In the Mojito monorepo, this server lives in **`mojito-mcp/`** (npm, not Maven).
+In the Mojito monorepo, this server lives in **`mojito-mcp/`** (npm, not Maven). See [README.md](./README.md) for install and host config.

--- a/mojito-mcp/jest.config.mjs
+++ b/mojito-mcp/jest.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import("jest").Config} */
+export default {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "node",
+  roots: ["<rootDir>"],
+  testMatch: ["<rootDir>/tests/**/*.test.ts"],
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  modulePathIgnorePatterns: ["<rootDir>/dist/"],
+};

--- a/mojito-mcp/jest.integration.config.mjs
+++ b/mojito-mcp/jest.integration.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import("jest").Config} */
+export default {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "node",
+  roots: ["<rootDir>"],
+  testMatch: ["<rootDir>/tests-integration/**/*.integration.test.ts"],
+  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  modulePathIgnorePatterns: ["<rootDir>/dist/"],
+  // Live Mojito calls can be slow
+  testTimeout: 600_000,
+};

--- a/mojito-mcp/package.json
+++ b/mojito-mcp/package.json
@@ -22,6 +22,7 @@
     "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.integration.config.mjs"
   },
   "files": [
+    "LICENSE",
     "dist",
     "README.md",
     "SKILL.md"

--- a/mojito-mcp/package.json
+++ b/mojito-mcp/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "mojito-mcp",
+  "version": "0.1.0-SNAPSHOT",
+  "private": true,
+  "description": "MCP server exposing Mojito REST APIs for engineers and AI agents",
+  "license": "Apache-2.0",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "mojito-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "format": "prettier --write \"{src,tests,tests-integration}/**/*.ts\"",
+    "format:check": "prettier --check \"{src,tests,tests-integration}/**/*.ts\"",
+    "start": "node dist/index.js",
+    "dev": "node --import tsx src/index.ts",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.integration.config.mjs"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "SKILL.md"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.0",
+    "jest": "^29.7.0",
+    "prettier": "3.9.6",
+    "ts-jest": "^29.2.5",
+    "tsx": "^4.19.4",
+    "typescript": "~5.7.0"
+  }
+}

--- a/mojito-mcp/pnpm-lock.yaml
+++ b/mojito-mcp/pnpm-lock.yaml
@@ -1,0 +1,3550 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.30.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.20.1)
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1))(typescript@5.7.3)
+      tsx:
+        specifier: ^4.19.4
+        version: 4.23.12
+      typescript:
+        specifier: ~5.7.0
+        version: 5.7.3
+
+packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-bigint@7.8.3':
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-static-block@7.14.5':
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.29.7':
+    resolution: {integrity: sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-json-strings@7.8.3':
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5':
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-top-level-await@7.14.5':
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@2.1.0':
+    resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/environment@29.7.0':
+    resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/fake-timers@29.7.0':
+    resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/transform@29.7.0':
+    resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@sinclair/typebox@0.27.12':
+    resolution: {integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==}
+
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@10.3.0':
+    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/graceful-fs@4.1.9':
+    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  babel-jest@29.7.0:
+    resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+
+  babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+
+  babel-plugin-jest-hoist@29.6.3:
+    resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-jest@29.6.3:
+    resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  baseline-browser-mapping@2.11.14:
+    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron-to-chromium@1.5.405:
+    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.13.2:
+    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
+    engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@5.2.1:
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-environment-node@29.7.0:
+    resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-haste-map@29.7.0:
+    resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-mock@29.7.0:
+    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-regex-util@29.6.3:
+    resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-jest@29.4.12:
+    resolution: {integrity: sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <7'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@hono/node-server@2.1.0(hono@4.13.2)':
+    dependencies:
+      hono: 4.13.2
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.15.1
+      resolve-from: 5.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
+  '@jest/core@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.20.1)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/environment@29.7.0':
+    dependencies:
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      jest-mock: 29.7.0
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/fake-timers@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@sinonjs/fake-timers': 10.3.0
+      '@types/node': 22.20.1
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 22.20.1
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.12
+
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
+
+  '@jest/transform@29.7.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      micromatch: 4.0.8
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 22.20.1
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.0(hono@4.13.2)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.2
+      jose: 6.2.8
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sinclair/typebox@0.27.12': {}
+
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@10.3.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/graceful-fs@4.1.9':
+    dependencies:
+      '@types/node': 22.20.1
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  babel-jest@29.7.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@6.1.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.29.7
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@29.6.3:
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
+
+  babel-preset-jest@29.6.3(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+
+  balanced-match@1.0.2: {}
+
+  baseline-browser-mapping@2.11.14: {}
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.14
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.405
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
+  camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001809: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  char-regex@1.0.2: {}
+
+  ci-info@3.9.0: {}
+
+  cjs-module-lexer@1.4.3: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  create-jest@29.7.0(@types/node@22.20.1):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.20.1)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  dedent@1.7.2: {}
+
+  deepmerge@4.3.1: {}
+
+  depd@2.0.0: {}
+
+  detect-newline@3.1.0: {}
+
+  diff-sequences@29.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.405: {}
+
+  emittery@0.13.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
+
+  esprima@4.0.1: {}
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  exit@0.1.2: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.5: {}
+
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  get-stream@6.0.1: {}
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.13.2: {}
+
+  html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  human-signals@2.1.0: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.5.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-fn@2.1.0: {}
+
+  is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
+
+  is-stream@2.0.1: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-instrument@5.2.1:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.8
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.8
+      '@istanbuljs/schema': 0.1.6
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@29.7.0(@types/node@22.20.1):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.20.1)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.20.1)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@22.20.1):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+
+  jest-environment-node@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-haste-map@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/graceful-fs': 4.1.9
+      '@types/node': 22.20.1
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      jest-util: 29.7.0
+
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
+  jest-regex-util@29.6.3: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.12
+      resolve.exports: 2.0.3
+      slash: 3.0.0
+
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.3
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.8
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.2
+
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.20.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 22.20.1
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@22.20.1):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.20.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jose@6.2.8: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@3.15.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  jsesc@3.1.0: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json5@2.2.3: {}
+
+  kleur@3.0.3: {}
+
+  leven@3.1.0: {}
+
+  lines-and-columns@1.2.4: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  lodash.memoize@4.1.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  make-error@1.3.6: {}
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-fn@2.1.0: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  minimist@1.2.8: {}
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
+
+  neo-async@2.6.2: {}
+
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.53: {}
+
+  normalize-path@3.0.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parseurl@1.3.3: {}
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  pure-rand@6.1.0: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
+  react-is@18.3.1: {}
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
+  resolve-from@5.0.0: {}
+
+  resolve.exports@2.0.3: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.5: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  signal-exit@3.0.7: {}
+
+  sisteransi@1.0.5: {}
+
+  slash@3.0.0: {}
+
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  statuses@2.0.2: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 7.2.3
+      minimatch: 3.1.5
+
+  tmpl@1.0.5: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  toidentifier@1.0.1: {}
+
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1))(typescript@5.7.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@22.20.1)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.5
+      type-fest: 4.41.0
+      typescript: 5.7.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      jest-util: 29.7.0
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-detect@4.0.8: {}
+
+  type-fest@0.21.3: {}
+
+  type-fest@4.41.0: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
+  typescript@5.7.3: {}
+
+  uglify-js@3.19.3:
+    optional: true
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
+  vary@1.1.2: {}
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wordwrap@1.0.0: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  write-file-atomic@4.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/mojito-mcp/src/cli-runner.ts
+++ b/mojito-mcp/src/cli-runner.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { spawn, type ChildProcessByStdio } from "node:child_process";
 import type { Readable } from "node:stream";
 import type { MojitoMcpConfig } from "./config.js";

--- a/mojito-mcp/src/cli-runner.ts
+++ b/mojito-mcp/src/cli-runner.ts
@@ -1,0 +1,121 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import type { MojitoMcpConfig } from "./config.js";
+import { MojitoCliError } from "./errors.js";
+
+export type CliRunResult = {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+};
+
+/**
+ * Runs the Mojito CLI with captured stdout/stderr and an optional timeout.
+ * Implementations must never inherit the child's stdout onto the MCP stdio transport.
+ */
+export interface CliRunner {
+    /**
+     * @param argv Arguments after the program name (e.g. `["api", "/api/repositories"]` or `["--help"]`)
+     */
+    run(argv: string[]): Promise<CliRunResult>;
+}
+
+/**
+ * Default runner: spawns {@link MojitoMcpConfig.cliBinary} with captured stdio and a hard timeout.
+ */
+export class DefaultCliRunner implements CliRunner {
+    constructor(private readonly _config: MojitoMcpConfig) {}
+
+    get config(): MojitoMcpConfig {
+        return this._config;
+    }
+
+    async run(argv: string[]): Promise<CliRunResult> {
+        const { cliBinary, timeoutMs } = this._config;
+
+        return new Promise<CliRunResult>((resolve, reject) => {
+            let stdout = "";
+            let stderr = "";
+            let settled = false;
+            let timedOut = false;
+
+            let child: ChildProcessByStdio<null, Readable, Readable>;
+            try {
+                child = spawn(cliBinary, argv, {
+                    stdio: ["ignore", "pipe", "pipe"],
+                    env: process.env,
+                });
+            } catch (cause) {
+                reject(
+                    new MojitoCliError(`Failed to spawn Mojito CLI '${cliBinary}'`, {
+                        cause,
+                    }),
+                );
+                return;
+            }
+
+            const timer = setTimeout(() => {
+                timedOut = true;
+                child.kill("SIGTERM");
+                setTimeout(() => {
+                    if (!settled) {
+                        child.kill("SIGKILL");
+                    }
+                }, 2_000).unref();
+            }, timeoutMs);
+
+            child.stdout.setEncoding("utf8");
+            child.stderr.setEncoding("utf8");
+            child.stdout.on("data", (chunk: string) => {
+                stdout += chunk;
+            });
+            child.stderr.on("data", (chunk: string) => {
+                stderr += chunk;
+            });
+
+            child.on("error", (cause) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timer);
+                reject(
+                    new MojitoCliError(`Failed to spawn Mojito CLI '${cliBinary}'`, {
+                        stdout,
+                        stderr,
+                        cause,
+                    }),
+                );
+            });
+
+            child.on("close", (code) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timer);
+
+                if (timedOut) {
+                    reject(
+                        new MojitoCliError(
+                            `Mojito CLI '${cliBinary}' timed out after ${timeoutMs}ms`,
+                            {
+                                exitCode: code,
+                                stdout,
+                                stderr,
+                                timedOut: true,
+                            },
+                        ),
+                    );
+                    return;
+                }
+
+                resolve({
+                    exitCode: code ?? 1,
+                    stdout,
+                    stderr,
+                });
+            });
+        });
+    }
+}

--- a/mojito-mcp/src/config.ts
+++ b/mojito-mcp/src/config.ts
@@ -30,15 +30,24 @@ export const DEFAULT_TIMEOUT_MS = 600_000;
 /**
  * Reads {@link MojitoMcpConfig} from `process.env`.
  *
- * - `MOJITO_CLI` → `cliBinary` (default {@link DEFAULT_CLI_BINARY})
- * - `MOJITO_CLI_TIMEOUT_MS` → `timeoutMs` (default {@link DEFAULT_TIMEOUT_MS})
+ * - `MOJITO_CLI` → `cliBinary` (default {@link DEFAULT_CLI_BINARY}). Trimmed; blank values
+ *   fall back to the default. Names on `PATH` and filesystem paths are both accepted.
+ * - `MOJITO_CLI_TIMEOUT_MS` → `timeoutMs` (default {@link DEFAULT_TIMEOUT_MS}). Must be a
+ *   finite positive whole number of milliseconds; anything else falls back to the default.
  */
 export function loadConfigFromEnv(): MojitoMcpConfig {
     const cliBinary = process.env.MOJITO_CLI?.trim();
-    const timeoutMs = Number(process.env.MOJITO_CLI_TIMEOUT_MS);
 
     return {
         cliBinary: cliBinary ? cliBinary : DEFAULT_CLI_BINARY,
-        timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS,
+        timeoutMs: parseTimeoutMs(process.env.MOJITO_CLI_TIMEOUT_MS),
     };
+}
+
+function parseTimeoutMs(raw: string | undefined): number {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) {
+        return parsed;
+    }
+    return DEFAULT_TIMEOUT_MS;
 }

--- a/mojito-mcp/src/config.ts
+++ b/mojito-mcp/src/config.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Runtime configuration for mojito-mcp. Auth and host live in the Mojito CLI, not here.
  */
 export type MojitoMcpConfig = {

--- a/mojito-mcp/src/config.ts
+++ b/mojito-mcp/src/config.ts
@@ -1,0 +1,28 @@
+/**
+ * Runtime configuration for mojito-mcp. Auth and host live in the Mojito CLI, not here.
+ */
+export type MojitoMcpConfig = {
+    /** Executable name or path (default `mojito-prod`) */
+    cliBinary: string;
+    /** Hard kill timeout for each CLI spawn, in milliseconds */
+    timeoutMs: number;
+};
+
+export const DEFAULT_CLI_BINARY = "mojito-prod";
+export const DEFAULT_TIMEOUT_MS = 600_000;
+
+/**
+ * Reads {@link MojitoMcpConfig} from `process.env`.
+ *
+ * - `MOJITO_CLI` → `cliBinary` (default {@link DEFAULT_CLI_BINARY})
+ * - `MOJITO_CLI_TIMEOUT_MS` → `timeoutMs` (default {@link DEFAULT_TIMEOUT_MS})
+ */
+export function loadConfigFromEnv(): MojitoMcpConfig {
+    const cliBinary = process.env.MOJITO_CLI?.trim();
+    const timeoutMs = Number(process.env.MOJITO_CLI_TIMEOUT_MS);
+
+    return {
+        cliBinary: cliBinary ? cliBinary : DEFAULT_CLI_BINARY,
+        timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS,
+    };
+}

--- a/mojito-mcp/src/errors.ts
+++ b/mojito-mcp/src/errors.ts
@@ -1,0 +1,32 @@
+/**
+ * Error raised when a Mojito CLI invocation fails (non-zero exit, timeout, or spawn failure).
+ * Intended to be surfaced to the AI as a normal MCP tool error.
+ */
+export class MojitoCliError extends Error {
+    readonly exitCode: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+    readonly timedOut: boolean;
+
+    constructor(
+        message: string,
+        options: {
+            exitCode?: number | null;
+            stdout?: string;
+            stderr?: string;
+            timedOut?: boolean;
+            cause?: unknown;
+        } = {},
+    ) {
+        super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
+        this.name = "MojitoCliError";
+        this.exitCode = options.exitCode ?? null;
+        this.stdout = options.stdout ?? "";
+        this.stderr = options.stderr ?? "";
+        this.timedOut = options.timedOut ?? false;
+    }
+}
+
+export function notImplemented(what: string): never {
+    throw new Error(`${what}: not implemented`);
+}

--- a/mojito-mcp/src/errors.ts
+++ b/mojito-mcp/src/errors.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Error raised when a Mojito CLI invocation fails (non-zero exit, timeout, or spawn failure).
  * Intended to be surfaced to the AI as a normal MCP tool error.
  */

--- a/mojito-mcp/src/index.ts
+++ b/mojito-mcp/src/index.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { DefaultCliRunner } from "./cli-runner.js";
+import { loadConfigFromEnv } from "./config.js";
+import { MojitoCliClient } from "./mojito-client.js";
+import { createMojitoMcpServer } from "./server.js";
+
+async function main(): Promise<void> {
+    const config = loadConfigFromEnv();
+    const runner = new DefaultCliRunner(config);
+    const client = new MojitoCliClient(config, runner);
+
+    // Skeleton: will call client.probeHelp() once implemented
+    await client.probeHelp();
+
+    const mcpServer = createMojitoMcpServer(client);
+    const transport = new StdioServerTransport();
+    await mcpServer.connect(transport);
+}
+
+main().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/mojito-mcp/src/index.ts
+++ b/mojito-mcp/src/index.ts
@@ -1,4 +1,20 @@
 #!/usr/bin/env node
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { DefaultCliRunner } from "./cli-runner.js";
 import { loadConfigFromEnv } from "./config.js";

--- a/mojito-mcp/src/mojito-client.ts
+++ b/mojito-mcp/src/mojito-client.ts
@@ -130,6 +130,9 @@ export class MojitoCliClient {
         if (!hasRepoScope && !hasTmIds) {
             const repos = await this.repoList();
             effective.repositoryIds = extractRepositoryIds(repos);
+            if (effective.repositoryIds.length === 0) {
+                return [];
+            }
         }
 
         const argv = ["api", "/api/textunits/search", "-X", "POST"];
@@ -337,12 +340,17 @@ function extractRepositoryIds(repos: unknown): number[] {
     }
     const ids: number[] = [];
     for (const repo of repos) {
-        if (repo && typeof repo === "object" && "id" in repo) {
-            const id = (repo as { id: unknown }).id;
-            if (typeof id === "number") {
-                ids.push(id);
-            }
+        const id =
+            repo && typeof repo === "object" && "id" in repo
+                ? (repo as { id: unknown }).id
+                : undefined;
+        if (typeof id !== "number" || !Number.isSafeInteger(id) || id <= 0) {
+            throw new MojitoCliError(
+                "Expected every repository to have a positive integer id when expanding all repositories",
+                { stdout: JSON.stringify(repos) },
+            );
         }
+        ids.push(id);
     }
     return ids;
 }
@@ -383,7 +391,7 @@ export function parseEncodedRepositoryLocale(
     encoded: EncodedRepositoryLocale,
 ): Record<string, unknown> {
     const parts = encoded.split("->").map((p) => p.trim());
-    if (parts.length === 0 || parts[0] === "") {
+    if (parts.some((part) => part === "")) {
         throw new MojitoCliError(`Invalid encoded repository locale: ${encoded}`);
     }
 
@@ -391,10 +399,17 @@ export function parseEncodedRepositoryLocale(
     const locales: string[] = [];
 
     for (const part of parts) {
+        if (/^\(\s*\)$/.test(part)) {
+            throw new MojitoCliError(`Invalid encoded repository locale: ${encoded}`);
+        }
         const m = /^\((.+)\)$/.exec(part);
         if (m) {
+            const locale = m[1].trim();
+            if (locale === "") {
+                throw new MojitoCliError(`Invalid encoded repository locale: ${encoded}`);
+            }
             toBeFullyTranslated = false;
-            locales.push(m[1]);
+            locales.push(locale);
         } else {
             locales.push(part);
         }

--- a/mojito-mcp/src/mojito-client.ts
+++ b/mojito-mcp/src/mojito-client.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/mojito-mcp/src/mojito-client.ts
+++ b/mojito-mcp/src/mojito-client.ts
@@ -1,0 +1,403 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CliRunner } from "./cli-runner.js";
+import type { MojitoMcpConfig } from "./config.js";
+import { MojitoCliError } from "./errors.js";
+import type {
+    EncodedRepositoryLocale,
+    RepoCreateParams,
+    ReviewAction,
+    ReviewUpdateParams,
+    TextUnitSearchParams,
+    TextUnitTranslationAddParams,
+    TextUnitStatus,
+} from "./types.js";
+
+const PAGINATE_FLAGS = ["--paginate", "--slurp", "--max-pages", "0"] as const;
+
+/**
+ * The CLI's offset-style pagination stops when a page comes back shorter than
+ * `--page-size`, so the page size must be large enough to make a short final
+ * page likely but small enough to keep each request cheap.
+ */
+const SEARCH_PAGE_SIZE = 500;
+
+const REVIEW_ACTION_MAP: Record<
+    ReviewAction,
+    { status: TextUnitStatus; includedInLocalizedFile: boolean }
+> = {
+    accept: { status: "APPROVED", includedInLocalizedFile: true },
+    review: { status: "REVIEW_NEEDED", includedInLocalizedFile: true },
+    translate: { status: "TRANSLATION_NEEDED", includedInLocalizedFile: true },
+    reject: { status: "TRANSLATION_NEEDED", includedInLocalizedFile: false },
+};
+
+/**
+ * Mojito API access via the CLI `api` command.
+ */
+export class MojitoCliClient {
+    constructor(
+        private readonly _config: MojitoMcpConfig,
+        private readonly _runner: CliRunner,
+    ) {}
+
+    get config(): MojitoMcpConfig {
+        return this._config;
+    }
+
+    get runner(): CliRunner {
+        return this._runner;
+    }
+
+    /** Startup probe: `{cli} --help`. Throws {@link MojitoCliError} if the CLI is missing or fails. */
+    async probeHelp(): Promise<void> {
+        await this.runChecked(["--help"]);
+    }
+
+    /**
+     * GET /api/repositories — returns every repository in one response.
+     *
+     * Not paginated: the endpoint ignores offset/limit, so `--paginate` would
+     * loop forever because each "page" comes back full.
+     */
+    async repoList(params: { name?: string } = {}): Promise<unknown> {
+        const argv = ["api", "/api/repositories"];
+        if (params.name !== undefined) {
+            pushRaw(argv, "name", params.name);
+        }
+        return this.apiJson(argv);
+    }
+
+    /** GET /api/repositories/{repositoryId} */
+    async repoView(repositoryId: number): Promise<unknown> {
+        return this.apiJson(["api", `/api/repositories/${repositoryId}`]);
+    }
+
+    /** POST /api/repositories */
+    async repoCreate(params: RepoCreateParams): Promise<unknown> {
+        if (needsRepoCreateJsonBody(params)) {
+            return this.apiJsonWithInput(
+                ["api", "/api/repositories", "-X", "POST"],
+                buildRepoCreateBody(params),
+            );
+        }
+
+        const argv = ["api", "/api/repositories", "-X", "POST"];
+        pushRaw(argv, "name", params.name);
+        if (params.description !== undefined) {
+            pushRaw(argv, "description", params.description);
+        }
+        if (params.checkSLA !== undefined) {
+            pushTyped(argv, "checkSLA", params.checkSLA);
+        }
+        return this.apiJson(argv);
+    }
+
+    /** DELETE /api/repositories/{repositoryId} */
+    async repoDelete(repositoryId: number): Promise<unknown> {
+        return this.apiJson(["api", `/api/repositories/${repositoryId}`, "-X", "DELETE"]);
+    }
+
+    /**
+     * POST /api/textunits/search — paginate + slurp + max-pages 0.
+     * Omit repo lists → expand to all repo ids; omit localeTags → all locales.
+     */
+    async textunitSearch(params: TextUnitSearchParams = {}): Promise<unknown> {
+        const effective = { ...params };
+
+        const hasRepoScope =
+            (effective.repositoryIds?.length ?? 0) > 0 ||
+            (effective.repositoryNames?.length ?? 0) > 0;
+        const hasTmIds = (effective.tmTextUnitIds?.length ?? 0) > 0;
+
+        if (!hasRepoScope && !hasTmIds) {
+            const repos = await this.repoList();
+            effective.repositoryIds = extractRepositoryIds(repos);
+        }
+
+        const argv = ["api", "/api/textunits/search", "-X", "POST"];
+        // `--paginate` overwrites offset/limit in the request body, so an explicit
+        // limit only survives on a single unpaginated request.
+        if (effective.limit === undefined) {
+            argv.push(...PAGINATE_FLAGS, "--page-size", String(SEARCH_PAGE_SIZE));
+        }
+        appendSearchFields(argv, effective);
+        return this.apiJson(argv);
+    }
+
+    /** Detail via search with tmTextUnitIds (optional localeTags). */
+    async textunitInfo(params: { tmTextUnitId: number; localeTags?: string[] }): Promise<unknown> {
+        const argv = ["api", "/api/textunits/search", "-X", "POST"];
+        pushTypedArray(argv, "tmTextUnitIds", [params.tmTextUnitId]);
+        if (params.localeTags?.length) {
+            pushRawArray(argv, "localeTags", params.localeTags);
+        }
+        return this.apiJson(argv);
+    }
+
+    /** GET /api/textunits/{tmTextUnitId}/history?bcp47Tag=… */
+    async textunitHistory(params: { tmTextUnitId: number; bcp47Tag: string }): Promise<unknown> {
+        const argv = ["api", `/api/textunits/${params.tmTextUnitId}/history`];
+        pushRaw(argv, "bcp47Tag", params.bcp47Tag);
+        return this.apiJson(argv);
+    }
+
+    /** POST /api/textunits — add current translation */
+    async textunitTranslationAdd(params: TextUnitTranslationAddParams): Promise<unknown> {
+        const argv = ["api", "/api/textunits", "-X", "POST"];
+        pushTyped(argv, "tmTextUnitId", params.tmTextUnitId);
+        pushTyped(argv, "localeId", params.localeId);
+        pushRaw(argv, "target", params.target);
+        if (params.targetComment !== undefined) {
+            pushRaw(argv, "targetComment", params.targetComment);
+        }
+        if (params.status !== undefined) {
+            pushRaw(argv, "status", params.status);
+        }
+        if (params.includedInLocalizedFile !== undefined) {
+            pushTyped(argv, "includedInLocalizedFile", params.includedInLocalizedFile);
+        }
+        return this.apiJson(argv);
+    }
+
+    /** POST /api/textunits — workbench review action */
+    async reviewUpdate(params: ReviewUpdateParams): Promise<unknown> {
+        const mapped = REVIEW_ACTION_MAP[params.action];
+        const argv = ["api", "/api/textunits", "-X", "POST"];
+        pushTyped(argv, "tmTextUnitId", params.tmTextUnitId);
+        pushTyped(argv, "localeId", params.localeId);
+        pushRaw(argv, "target", params.target);
+        pushRaw(argv, "status", mapped.status);
+        pushTyped(argv, "includedInLocalizedFile", mapped.includedInLocalizedFile);
+        if (params.targetComment !== undefined) {
+            pushRaw(argv, "targetComment", params.targetComment);
+        }
+        return this.apiJson(argv);
+    }
+
+    /** GET /api/pollableTasks/{pollableTaskId} */
+    async pollabletaskGet(pollableTaskId: number): Promise<unknown> {
+        return this.apiJson(["api", `/api/pollableTasks/${pollableTaskId}`]);
+    }
+
+    // --- internals ---
+
+    private async runChecked(argv: string[]): Promise<{ stdout: string; stderr: string }> {
+        const result = await this._runner.run(argv);
+        if (result.exitCode !== 0) {
+            const summary =
+                result.stderr.trim() || `mojito CLI exited with code ${result.exitCode}`;
+            throw new MojitoCliError(summary, {
+                exitCode: result.exitCode,
+                stdout: result.stdout,
+                stderr: result.stderr,
+            });
+        }
+        return { stdout: result.stdout, stderr: result.stderr };
+    }
+
+    private async apiJson(argv: string[]): Promise<unknown> {
+        const { stdout } = await this.runChecked(argv);
+        return parseStdoutJson(stdout);
+    }
+
+    private async apiJsonWithInput(argv: string[], body: unknown): Promise<unknown> {
+        const dir = mkdtempSync(join(tmpdir(), "mojito-mcp-"));
+        const file = join(dir, "body.json");
+        try {
+            writeFileSync(file, JSON.stringify(body), "utf8");
+            return await this.apiJson([...argv, "--input", file]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }
+}
+
+function parseStdoutJson(stdout: string): unknown {
+    const trimmed = stdout.trim();
+    if (trimmed === "") {
+        return null;
+    }
+    try {
+        return JSON.parse(trimmed) as unknown;
+    } catch (cause) {
+        throw new MojitoCliError("Failed to parse mojito CLI JSON stdout", {
+            stdout,
+            cause,
+        });
+    }
+}
+
+function pushRaw(argv: string[], key: string, value: string): void {
+    argv.push("-f", `${key}=${value}`);
+}
+
+function pushTyped(argv: string[], key: string, value: string | number | boolean): void {
+    argv.push("-F", `${key}=${String(value)}`);
+}
+
+function pushRawArray(argv: string[], key: string, values: string[]): void {
+    for (const value of values) {
+        pushRaw(argv, `${key}[]`, value);
+    }
+}
+
+function pushTypedArray(argv: string[], key: string, values: number[]): void {
+    for (const value of values) {
+        pushTyped(argv, `${key}[]`, value);
+    }
+}
+
+function appendSearchFields(argv: string[], params: TextUnitSearchParams): void {
+    if (params.repositoryIds?.length) {
+        pushTypedArray(argv, "repositoryIds", params.repositoryIds);
+    }
+    if (params.repositoryNames?.length) {
+        pushRawArray(argv, "repositoryNames", params.repositoryNames);
+    }
+    if (params.tmTextUnitIds?.length) {
+        pushTypedArray(argv, "tmTextUnitIds", params.tmTextUnitIds);
+    }
+    if (params.localeTags?.length) {
+        pushRawArray(argv, "localeTags", params.localeTags);
+    }
+    if (params.name !== undefined) {
+        pushRaw(argv, "name", params.name);
+    }
+    if (params.source !== undefined) {
+        pushRaw(argv, "source", params.source);
+    }
+    if (params.target !== undefined) {
+        pushRaw(argv, "target", params.target);
+    }
+    if (params.assetPath !== undefined) {
+        pushRaw(argv, "assetPath", params.assetPath);
+    }
+    if (params.pluralFormOther !== undefined) {
+        pushRaw(argv, "pluralFormOther", params.pluralFormOther);
+    }
+    if (params.searchType !== undefined) {
+        pushRaw(argv, "searchType", params.searchType);
+    }
+    if (params.statusFilter !== undefined) {
+        pushRaw(argv, "statusFilter", params.statusFilter);
+    }
+    if (params.usedFilter !== undefined) {
+        pushRaw(argv, "usedFilter", params.usedFilter);
+    }
+    if (params.doNotTranslateFilter !== undefined) {
+        pushTyped(argv, "doNotTranslateFilter", params.doNotTranslateFilter);
+    }
+    if (params.tmTextUnitCreatedAfter !== undefined) {
+        pushRaw(argv, "tmTextUnitCreatedAfter", params.tmTextUnitCreatedAfter);
+    }
+    if (params.tmTextUnitCreatedBefore !== undefined) {
+        pushRaw(argv, "tmTextUnitCreatedBefore", params.tmTextUnitCreatedBefore);
+    }
+    if (params.branchId !== undefined) {
+        pushTyped(argv, "branchId", params.branchId);
+    }
+    if (params.pluralFormFiltered !== undefined) {
+        pushTyped(argv, "pluralFormFiltered", params.pluralFormFiltered);
+    }
+    if (params.pluralFormExcluded !== undefined) {
+        pushTyped(argv, "pluralFormExcluded", params.pluralFormExcluded);
+    }
+    if (params.limit !== undefined) {
+        pushTyped(argv, "limit", params.limit);
+    }
+    if (params.offset !== undefined) {
+        pushTyped(argv, "offset", params.offset);
+    }
+}
+
+function extractRepositoryIds(repos: unknown): number[] {
+    if (!Array.isArray(repos)) {
+        throw new MojitoCliError(
+            "Expected repository list to be a JSON array when expanding all repositories",
+            { stdout: JSON.stringify(repos) },
+        );
+    }
+    const ids: number[] = [];
+    for (const repo of repos) {
+        if (repo && typeof repo === "object" && "id" in repo) {
+            const id = (repo as { id: unknown }).id;
+            if (typeof id === "number") {
+                ids.push(id);
+            }
+        }
+    }
+    return ids;
+}
+
+function needsRepoCreateJsonBody(params: RepoCreateParams): boolean {
+    return (
+        params.sourceLocale !== undefined ||
+        (params.repositoryLocales?.length ?? 0) > 0 ||
+        (params.assetIntegrityCheckers?.length ?? 0) > 0
+    );
+}
+
+function buildRepoCreateBody(params: RepoCreateParams): Record<string, unknown> {
+    const body: Record<string, unknown> = { name: params.name };
+    if (params.description !== undefined) {
+        body.description = params.description;
+    }
+    if (params.checkSLA !== undefined) {
+        body.checkSLA = params.checkSLA;
+    }
+    if (params.sourceLocale !== undefined) {
+        body.sourceLocale = { bcp47Tag: params.sourceLocale };
+    }
+    if (params.repositoryLocales?.length) {
+        body.repositoryLocales = params.repositoryLocales.map(parseEncodedRepositoryLocale);
+    }
+    if (params.assetIntegrityCheckers?.length) {
+        body.assetIntegrityCheckers = params.assetIntegrityCheckers;
+    }
+    return body;
+}
+
+/**
+ * Parse Mojito CLI `-l` encoding into nested RepositoryLocale JSON.
+ * Mirrors {@code LocaleHelper.getRepositoryLocaleFromEncodedBcp47Tag}.
+ */
+export function parseEncodedRepositoryLocale(
+    encoded: EncodedRepositoryLocale,
+): Record<string, unknown> {
+    const parts = encoded.split("->").map((p) => p.trim());
+    if (parts.length === 0 || parts[0] === "") {
+        throw new MojitoCliError(`Invalid encoded repository locale: ${encoded}`);
+    }
+
+    let toBeFullyTranslated = true;
+    const locales: string[] = [];
+
+    for (const part of parts) {
+        const m = /^\((.+)\)$/.exec(part);
+        if (m) {
+            toBeFullyTranslated = false;
+            locales.push(m[1]);
+        } else {
+            locales.push(part);
+        }
+    }
+
+    const [child, ...parents] = locales;
+    const repositoryLocale: Record<string, unknown> = {
+        locale: { bcp47Tag: child },
+        toBeFullyTranslated,
+    };
+
+    let cursor = repositoryLocale;
+    for (const parent of parents) {
+        const parentNode: Record<string, unknown> = {
+            locale: { bcp47Tag: parent },
+        };
+        cursor.parentLocale = parentNode;
+        cursor = parentNode;
+    }
+
+    return repositoryLocale;
+}

--- a/mojito-mcp/src/register-tools.ts
+++ b/mojito-mcp/src/register-tools.ts
@@ -1,0 +1,495 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { MojitoCliClient } from "./mojito-client.js";
+
+/**
+ * AI-facing MCP tool surface for Mojito.
+ *
+ * The MCP host publishes each tool's name, description, and inputSchema (from these zod
+ * definitions) to the model. Handlers only forward validated args to {@link MojitoCliClient}.
+ *
+ * Naming: mojito_<object>_<action>
+ */
+
+// --- Shared enums / nested shapes (descriptions become JSON Schema for the model) ---
+
+const searchTypeSchema = z
+    .enum(["EXACT", "CONTAINS", "ILIKE"])
+    .describe(
+        "How name/source/target filters match. EXACT = whole-string equality; CONTAINS = substring; ILIKE = case-insensitive SQL LIKE. Default on the Mojito API is EXACT.",
+    );
+
+const usedFilterSchema = z
+    .enum(["USED", "UNUSED"])
+    .describe(
+        "USED = string still present in the latest successful asset extraction; UNUSED = no longer extracted (orphaned in TM). Omit to include both.",
+    );
+
+const statusFilterSchema = z
+    .enum([
+        "ALL",
+        "TRANSLATED",
+        "UNTRANSLATED",
+        "TRANSLATED_AND_NOT_REJECTED",
+        "APPROVED_OR_NEEDS_REVIEW_AND_NOT_REJECTED",
+        "APPROVED_AND_NOT_REJECTED",
+        "FOR_TRANSLATION",
+        "REVIEW_NEEDED",
+        "REVIEW_NEEDED_OR_REJECTED",
+        "REVIEW_NOT_NEEDED",
+        "TRANSLATION_NEEDED",
+        "REJECTED",
+        "NOT_REJECTED",
+    ])
+    .describe(
+        [
+            "Workbench status bucket (combines translation presence, variant status, and includedInLocalizedFile):",
+            "ALL = everything;",
+            "TRANSLATED / UNTRANSLATED = has or lacks a current translation;",
+            "FOR_TRANSLATION = needs work (missing translation, TRANSLATION_NEEDED, or rejected);",
+            "REVIEW_NEEDED = current status is needs review;",
+            "TRANSLATION_NEEDED = current status is needs translation;",
+            "REJECTED = not included in localized file;",
+            "NOT_REJECTED = included in localized file;",
+            "APPROVED_AND_NOT_REJECTED / APPROVED_OR_NEEDS_REVIEW_AND_NOT_REJECTED / TRANSLATED_AND_NOT_REJECTED = quality filters;",
+            "REVIEW_NEEDED_OR_REJECTED / REVIEW_NOT_NEEDED = review-oriented buckets.",
+        ].join(" "),
+    );
+
+const textUnitStatusSchema = z
+    .enum(["APPROVED", "REVIEW_NEEDED", "TRANSLATION_NEEDED"])
+    .describe(
+        "Current translation status: APPROVED = accepted; REVIEW_NEEDED = needs linguistic review; TRANSLATION_NEEDED = needs (re)translation.",
+    );
+
+const reviewActionSchema = z
+    .enum(["accept", "review", "translate", "reject"])
+    .describe(
+        [
+            "Workbench review action (maps to status + includedInLocalizedFile):",
+            "accept → APPROVED, included;",
+            "review → REVIEW_NEEDED, included;",
+            "translate → TRANSLATION_NEEDED, included;",
+            "reject → TRANSLATION_NEEDED, NOT included (rejected from file).",
+        ].join(" "),
+    );
+
+const bcp47TagSchema = z.string().describe("BCP-47 locale tag, e.g. en-US, fr-FR, ja-JP.");
+
+/**
+ * Same encoding as `mojito repo-create -l` / `repo-update -l` (see Mojito “Managing Locales” docs).
+ */
+const encodedRepositoryLocaleSchema = z
+    .string()
+    .describe(
+        [
+            "Encoded locale, Mojito CLI -l syntax:",
+            "`fr-FR` = fully translated;",
+            "`(en-GB)` = not fully translated (parentheses);",
+            "`(fr-CA)->fr-FR` = fr-CA inherits from parent fr-FR (child is not fully translated).",
+            "Parent on the right must also be listed as its own entry if it should exist in the repo (e.g. include both `(fr-CA)->fr-FR` and `fr-FR`).",
+        ].join(" "),
+    );
+
+const assetIntegrityCheckerInputSchema = z.object({
+    assetExtension: z
+        .string()
+        .describe("Resource file extension without a dot, e.g. properties, resw, xlf."),
+    integrityCheckerType: z
+        .string()
+        .describe(
+            "Integrity checker type name, e.g. COMPOSITE_FORMAT, PRINTF_LIKE. Validates placeholders/format in translations.",
+        ),
+});
+
+function jsonResult(data: unknown) {
+    return {
+        content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    };
+}
+
+/**
+ * Registers all Mojito MCP tools on the given server.
+ */
+export function registerMojitoTools(server: McpServer, client: MojitoCliClient): void {
+    // --- Repository ---
+
+    server.registerTool(
+        "mojito_repo_list",
+        {
+            description: [
+                "List Mojito repositories (undeleted), optionally filtered by exact repository name.",
+                "Use this to discover repository ids/names before search, or to resolve a product git repo name to a Mojito repository.",
+                "Returns JSON array of repository summaries (id, name, description, locales summary depending on API view).",
+                "Talks to whichever Mojito instance this MCP server was configured for (mojito-prod vs mojito-dev via MOJITO_CLI).",
+            ].join(" "),
+            inputSchema: {
+                name: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Exact Mojito repository name filter. Omit to list all undeleted repositories. Matching is server-side exact name, not fuzzy.",
+                    ),
+            },
+        },
+        async ({ name }) => jsonResult(await client.repoList({ name })),
+    );
+
+    server.registerTool(
+        "mojito_repo_view",
+        {
+            description: [
+                "Get full details for one Mojito repository by numeric id,",
+                "including description, source locale, repository locales, and integrity checkers when present.",
+                "Prefer mojito_repo_list first if you only know the name.",
+            ].join(" "),
+            inputSchema: {
+                repositoryId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe(
+                        "Numeric Mojito repository id (from mojito_repo_list or prior search results).",
+                    ),
+            },
+        },
+        async ({ repositoryId }) => jsonResult(await client.repoView(repositoryId)),
+    );
+
+    server.registerTool(
+        "mojito_repo_create",
+        {
+            description: [
+                "Create a new Mojito repository (container for strings, locales, and localization config).",
+                "Requires a unique name. Optionally set description, source locale, target locales, SLA flag, and integrity checkers.",
+                "WARNING: Prefer mojito-dev while experimenting. Creating repos on prod affects shared production data.",
+                "On name conflict the API returns HTTP 409.",
+            ].join(" "),
+            inputSchema: {
+                name: z
+                    .string()
+                    .describe(
+                        "Unique repository name (often aligned with the product/git project name).",
+                    ),
+                description: z
+                    .string()
+                    .optional()
+                    .describe("Optional human-readable description of the project/repository."),
+                checkSLA: z
+                    .boolean()
+                    .optional()
+                    .describe("Whether SLA tracking is enabled for this repository."),
+                sourceLocale: bcp47TagSchema
+                    .optional()
+                    .describe(
+                        "Source/root locale of the repository as a BCP-47 tag string, e.g. en-US. If omitted, server defaults apply.",
+                    ),
+                repositoryLocales: z
+                    .array(encodedRepositoryLocaleSchema)
+                    .optional()
+                    .describe(
+                        'Target locales as Mojito CLI -l strings, e.g. ["de-DE", "fr-FR", "(fr-CA)->fr-FR", "(en-GB)"].',
+                    ),
+                assetIntegrityCheckers: z
+                    .array(assetIntegrityCheckerInputSchema)
+                    .optional()
+                    .describe(
+                        'Optional integrity checkers per file extension, e.g. [{ "assetExtension": "properties", "integrityCheckerType": "PRINTF_LIKE" }].',
+                    ),
+            },
+        },
+        async (args) => jsonResult(await client.repoCreate(args)),
+    );
+
+    server.registerTool(
+        "mojito_repo_delete",
+        {
+            description: [
+                "Soft-delete a Mojito repository by id so it no longer appears in normal listings.",
+                "DESTRUCTIVE: confirm the repository id and environment (prod vs dev) with the user before calling.",
+                "Prefer mojito-dev for tests. Deleting on prod removes visibility of real project data from the UI.",
+            ].join(" "),
+            inputSchema: {
+                repositoryId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe(
+                        "Numeric id of the repository to delete. Resolve via mojito_repo_list if unsure.",
+                    ),
+            },
+        },
+        async ({ repositoryId }) => jsonResult(await client.repoDelete(repositoryId)),
+    );
+
+    // --- Text units ---
+
+    server.registerTool(
+        "mojito_textunit_search",
+        {
+            description: [
+                "Search translation-memory / workbench text units — primary tool for “where is my string?” and listing translations.",
+                "You can match against string id (name), source text, and/or target (translated) text via searchType.",
+                "Scoping: omit repositoryIds and repositoryNames to search ALL repositories; omit localeTags to include ALL locales.",
+                "Provide repositoryIds, repositoryNames, and/or localeTags to restrict. Prefer scoping by repo when possible (all-repo search can be large).",
+                "You may also pass tmTextUnitIds to fetch specific units. Returns TextUnitDTO-like JSON (ids, source/target, status, asset path, dates, used flag, etc.).",
+            ].join(" "),
+            inputSchema: {
+                repositoryIds: z
+                    .array(z.number().int().positive())
+                    .optional()
+                    .describe(
+                        "Restrict to these repository ids. Omit (with repositoryNames also omitted) to search all repositories.",
+                    ),
+                repositoryNames: z
+                    .array(z.string())
+                    .optional()
+                    .describe(
+                        "Restrict to these exact Mojito repository names. Omit (with repositoryIds also omitted) for all repos.",
+                    ),
+                tmTextUnitIds: z
+                    .array(z.number().int().positive())
+                    .optional()
+                    .describe(
+                        "Restrict to these TM text unit ids. When set, repository lists are not required.",
+                    ),
+                localeTags: z
+                    .array(z.string())
+                    .optional()
+                    .describe(
+                        "Restrict to these BCP-47 locale tags (e.g. fr-FR, ja-JP). Omit to include all locales.",
+                    ),
+                name: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Filter by string id / resource key (TextUnit name), matched according to searchType.",
+                    ),
+                source: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Filter by source (typically English) text, matched according to searchType.",
+                    ),
+                target: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Filter by target translation text for the selected locales, matched according to searchType.",
+                    ),
+                assetPath: z
+                    .string()
+                    .optional()
+                    .describe("Filter by asset/path of the resource file containing the string."),
+                pluralFormOther: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Filter related to plural “other” form content when working with plurals.",
+                    ),
+                searchType: searchTypeSchema.optional(),
+                statusFilter: statusFilterSchema.optional(),
+                usedFilter: usedFilterSchema.optional(),
+                doNotTranslateFilter: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                        "If true, only do-not-translate (DNT) strings; if false, only non-DNT; omit for both.",
+                    ),
+                tmTextUnitCreatedAfter: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Only text units created at/after this instant (ISO-8601 datetime, e.g. 2024-01-15T00:00:00Z).",
+                    ),
+                tmTextUnitCreatedBefore: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Only text units created at/before this instant (ISO-8601 datetime).",
+                    ),
+                branchId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .optional()
+                    .describe("Restrict search to strings associated with this Mojito branch id."),
+                pluralFormFiltered: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                        "API default true. Controls plural-form row filtering in search results.",
+                    ),
+                pluralFormExcluded: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                        "API default false. When true, excludes plural forms per server rules.",
+                    ),
+                limit: z
+                    .number()
+                    .int()
+                    .positive()
+                    .optional()
+                    .describe(
+                        "Page size hint for each underlying request. The tool still aggregates pages automatically.",
+                    ),
+                offset: z
+                    .number()
+                    .int()
+                    .nonnegative()
+                    .optional()
+                    .describe(
+                        "Starting offset for pagination (advanced; usually omit and let the tool paginate).",
+                    ),
+            },
+        },
+        async (args) => jsonResult(await client.textunitSearch(args)),
+    );
+
+    server.registerTool(
+        "mojito_textunit_info",
+        {
+            description: [
+                "Get general information about one TM text unit: created date, current status, source/target,",
+                "asset path, repository name, used/unused, do-not-translate, plural fields, and related ids.",
+                "Implemented via search by tmTextUnitId (there is no dedicated GET-by-id endpoint).",
+                "Optional localeTags restrict which locale rows are returned; omit for all locales.",
+            ].join(" "),
+            inputSchema: {
+                tmTextUnitId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe(
+                        "TM text unit id (from mojito_textunit_search results: tmTextUnitId).",
+                    ),
+                localeTags: z
+                    .array(z.string())
+                    .optional()
+                    .describe(
+                        "Optional BCP-47 tags to limit which locale variants are returned. Omit for all locales.",
+                    ),
+            },
+        },
+        async (args) => jsonResult(await client.textunitInfo(args)),
+    );
+
+    server.registerTool(
+        "mojito_textunit_history",
+        {
+            description: [
+                "Get translation change history for a TM text unit in one locale (who/what changed over time).",
+                "Requires tmTextUnitId and bcp47Tag. Use after search/info when you need historical variants, not just the current translation.",
+            ].join(" "),
+            inputSchema: {
+                tmTextUnitId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe("TM text unit id whose history you want."),
+                bcp47Tag: z
+                    .string()
+                    .describe(
+                        "Locale BCP-47 tag for the history, e.g. fr-FR. Required by the Mojito API (not locale id).",
+                    ),
+            },
+        },
+        async (args) => jsonResult(await client.textunitHistory(args)),
+    );
+
+    server.registerTool(
+        "mojito_textunit_translation_add",
+        {
+            description: [
+                "Add or set the current translation for a text unit in a locale (creates a new current TMTextUnitVariant).",
+                "Requires tmTextUnitId, localeId (numeric locale id from search results), and target text.",
+                "Optional status and includedInLocalizedFile control review state; optional targetComment stores a translator/reviewer comment.",
+                "WARNING: Prefer mojito-dev for experiments. On prod this changes live translations.",
+                "For workbench-style accept/reject/needs-review flows, prefer mojito_review_update.",
+            ].join(" "),
+            inputSchema: {
+                tmTextUnitId: z.number().int().positive().describe("TM text unit id to translate."),
+                localeId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe(
+                        "Numeric Mojito locale id (from search/info results: localeId), not the BCP-47 tag.",
+                    ),
+                target: z.string().describe("Translation text to save as the current target."),
+                targetComment: z
+                    .string()
+                    .optional()
+                    .describe("Optional comment attached to this translation variant."),
+                status: textUnitStatusSchema.optional(),
+                includedInLocalizedFile: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                        "If false, translation is treated as rejected (not included in localized files). Default/typical for good translations is true.",
+                    ),
+            },
+        },
+        async (args) => jsonResult(await client.textunitTranslationAdd(args)),
+    );
+
+    // --- Review ---
+
+    server.registerTool(
+        "mojito_review_update",
+        {
+            description: [
+                "Update review outcome for a current translation, matching the Mojito workbench review modal.",
+                "Actions: accept (APPROVED), review (REVIEW_NEEDED), translate (TRANSLATION_NEEDED), reject (TRANSLATION_NEEDED + excluded from file).",
+                "Requires the current target text because the underlying API updates via POST /api/textunits.",
+                "WARNING: Prefer mojito-dev for experiments. On prod this changes live review state.",
+            ].join(" "),
+            inputSchema: {
+                tmTextUnitId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe("TM text unit id of the string being reviewed."),
+                localeId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe("Numeric locale id for the translation being reviewed."),
+                target: z
+                    .string()
+                    .describe(
+                        "Current translation text to keep/save with the new review status (required by the API).",
+                    ),
+                action: reviewActionSchema,
+                targetComment: z
+                    .string()
+                    .optional()
+                    .describe("Optional review comment stored on the translation variant."),
+            },
+        },
+        async (args) => jsonResult(await client.reviewUpdate(args)),
+    );
+
+    // --- Pollable tasks ---
+
+    server.registerTool(
+        "mojito_pollabletask_get",
+        {
+            description: [
+                "Fetch status of an asynchronous Mojito pollable task by id",
+                "(imports, batch jobs, and other long-running operations that return a PollableTask).",
+                "Use when a previous operation returned a pollableTask id; poll until allFinished is true or an error appears.",
+                "This tool does not wait/block; call again as needed.",
+            ].join(" "),
+            inputSchema: {
+                pollableTaskId: z
+                    .number()
+                    .int()
+                    .positive()
+                    .describe("Pollable task id from a previous Mojito async response."),
+            },
+        },
+        async ({ pollableTaskId }) => jsonResult(await client.pollabletaskGet(pollableTaskId)),
+    );
+}

--- a/mojito-mcp/src/register-tools.ts
+++ b/mojito-mcp/src/register-tools.ts
@@ -348,7 +348,7 @@ export function registerMojitoTools(server: McpServer, client: MojitoCliClient):
                     .positive()
                     .optional()
                     .describe(
-                        "Page size hint for each underlying request. The tool still aggregates pages automatically.",
+                        "Maximum rows to return. When set, the tool makes one unpaginated request so the limit is preserved.",
                     ),
                 offset: z
                     .number()

--- a/mojito-mcp/src/register-tools.ts
+++ b/mojito-mcp/src/register-tools.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { MojitoCliClient } from "./mojito-client.js";

--- a/mojito-mcp/src/server.ts
+++ b/mojito-mcp/src/server.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MojitoCliClient } from "./mojito-client.js";
 import { registerMojitoTools } from "./register-tools.js";

--- a/mojito-mcp/src/server.ts
+++ b/mojito-mcp/src/server.ts
@@ -1,0 +1,28 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { MojitoCliClient } from "./mojito-client.js";
+import { registerMojitoTools } from "./register-tools.js";
+import { MOJITO_MCP_TOOL_IDS } from "./tool-metadata.js";
+
+export { MOJITO_MCP_TOOL_IDS } from "./tool-metadata.js";
+
+const SERVER_NAME = "mojito-mcp";
+const SERVER_VERSION = "0.1.0-SNAPSHOT";
+
+/**
+ * Builds the stdio MCP server wired to the given Mojito CLI client.
+ */
+export function createMojitoMcpServer(client: MojitoCliClient): McpServer {
+    const server = new McpServer({
+        name: SERVER_NAME,
+        version: SERVER_VERSION,
+    });
+
+    registerMojitoTools(server, client);
+
+    return server;
+}
+
+/** @internal Exported for tests that assert documentation parity with registration. */
+export function expectedToolCount(): number {
+    return MOJITO_MCP_TOOL_IDS.length;
+}

--- a/mojito-mcp/src/tool-metadata.ts
+++ b/mojito-mcp/src/tool-metadata.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Canonical tool ids for this server. Keep in sync with {@link registerMojitoTools}.
  */
 export const MOJITO_MCP_TOOL_IDS = [

--- a/mojito-mcp/src/tool-metadata.ts
+++ b/mojito-mcp/src/tool-metadata.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical tool ids for this server. Keep in sync with {@link registerMojitoTools}.
+ */
+export const MOJITO_MCP_TOOL_IDS = [
+    "mojito_repo_list",
+    "mojito_repo_view",
+    "mojito_repo_create",
+    "mojito_repo_delete",
+    "mojito_textunit_search",
+    "mojito_textunit_info",
+    "mojito_textunit_history",
+    "mojito_textunit_translation_add",
+    "mojito_review_update",
+    "mojito_pollabletask_get",
+] as const;
+
+export type MojitoMcpToolId = (typeof MOJITO_MCP_TOOL_IDS)[number];

--- a/mojito-mcp/src/types.ts
+++ b/mojito-mcp/src/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared parameter / enum types for Mojito MCP tools and the CLI client.
+ * Keep in sync with the zod schemas in {@link registerMojitoTools}.
+ */
+
+/** How name / source / target string filters match in text-unit search. */
+export type SearchType = "EXACT" | "CONTAINS" | "ILIKE";
+
+/** Whether the string is still present in the latest asset extraction. */
+export type UsedFilter = "USED" | "UNUSED";
+
+/**
+ * Workbench status buckets for search (not the same as a single variant status).
+ * Combines translation presence, TMTextUnitVariant.Status, and includedInLocalizedFile.
+ */
+export type StatusFilter =
+    | "ALL"
+    | "TRANSLATED"
+    | "UNTRANSLATED"
+    | "TRANSLATED_AND_NOT_REJECTED"
+    | "APPROVED_OR_NEEDS_REVIEW_AND_NOT_REJECTED"
+    | "APPROVED_AND_NOT_REJECTED"
+    | "FOR_TRANSLATION"
+    | "REVIEW_NEEDED"
+    | "REVIEW_NEEDED_OR_REJECTED"
+    | "REVIEW_NOT_NEEDED"
+    | "TRANSLATION_NEEDED"
+    | "REJECTED"
+    | "NOT_REJECTED";
+
+/** Workbench review modal actions for {@link ReviewUpdateParams}. */
+export type ReviewAction = "accept" | "review" | "translate" | "reject";
+
+/** Current-translation status written by translation_add / review_update. */
+export type TextUnitStatus = "APPROVED" | "REVIEW_NEEDED" | "TRANSLATION_NEEDED";
+
+/**
+ * Parameters for text-unit search.
+ * Omit repository lists = all repositories; omit localeTags = all locales.
+ */
+export type TextUnitSearchParams = {
+    repositoryIds?: number[];
+    repositoryNames?: string[];
+    tmTextUnitIds?: number[];
+    localeTags?: string[];
+    name?: string;
+    source?: string;
+    target?: string;
+    assetPath?: string;
+    pluralFormOther?: string;
+    searchType?: SearchType;
+    statusFilter?: StatusFilter;
+    usedFilter?: UsedFilter;
+    doNotTranslateFilter?: boolean;
+    tmTextUnitCreatedAfter?: string;
+    tmTextUnitCreatedBefore?: string;
+    branchId?: number;
+    pluralFormFiltered?: boolean;
+    pluralFormExcluded?: boolean;
+    limit?: number;
+    offset?: number;
+};
+
+/**
+ * Encoded repository locale string, same syntax as `mojito repo-create -l`:
+ * - `fr-FR` — fully translated locale
+ * - `(en-GB)` — not fully translated (parentheses)
+ * - `(fr-CA)->fr-FR` — fr-CA inherits from parent fr-FR (and is not fully translated)
+ */
+export type EncodedRepositoryLocale = string;
+
+/** Integrity checker binding for an asset file extension. */
+export type AssetIntegrityCheckerInput = {
+    /** File extension without dot, e.g. `properties`, `resw`, `xlf`. */
+    assetExtension: string;
+    /**
+     * Checker type name as configured in Mojito, e.g. `COMPOSITE_FORMAT`, `PRINTF_LIKE`.
+     * See Mojito integrity-checker docs for valid values.
+     */
+    integrityCheckerType: string;
+};
+
+export type RepoCreateParams = {
+    name: string;
+    description?: string;
+    /** Source / root locale as a BCP-47 tag, e.g. `en-US`. */
+    sourceLocale?: string;
+    checkSLA?: boolean;
+    /**
+     * Target locales using Mojito CLI encoding (`fr-FR`, `(en-GB)`, `(fr-CA)->fr-FR`).
+     * The client parses these into Mojito's nested RepositoryLocale JSON.
+     */
+    repositoryLocales?: EncodedRepositoryLocale[];
+    assetIntegrityCheckers?: AssetIntegrityCheckerInput[];
+};
+
+export type TextUnitTranslationAddParams = {
+    tmTextUnitId: number;
+    localeId: number;
+    target: string;
+    targetComment?: string;
+    status?: TextUnitStatus;
+    includedInLocalizedFile?: boolean;
+};
+
+export type ReviewUpdateParams = {
+    tmTextUnitId: number;
+    localeId: number;
+    target: string;
+    action: ReviewAction;
+    targetComment?: string;
+};

--- a/mojito-mcp/src/types.ts
+++ b/mojito-mcp/src/types.ts
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Shared parameter / enum types for Mojito MCP tools and the CLI client.
  * Keep in sync with the zod schemas in {@link registerMojitoTools}.
  */

--- a/mojito-mcp/tests-integration/README.md
+++ b/mojito-mcp/tests-integration/README.md
@@ -1,0 +1,71 @@
+# Integration tests
+
+These tests call a **real Mojito CLI** against a **real Mojito server**. They are separate from the unit tests under `tests/` and are **not** run by `npm test`.
+
+They always use the **dev** CLI script from your config (never prod), so they talk to your non-production Mojito instance.
+
+## Prerequisites
+
+1. Working Mojito CLI wrappers on your `PATH` (or absolute paths), typically `mojito-dev` and `mojito-prod`, each configured to authenticate to the matching server. See the main [README.md](../README.md) and Mojito CLI docs.
+2. Confirm in a shell:
+
+```bash
+mojito-dev --help
+mojito-dev api /api/repositories
+```
+
+3. Permission on **dev** to create and delete repositories (the suite mutates data).
+
+## Config file
+
+1. Copy the template:
+
+```bash
+cp tests-integration/integration-config.template.json tests-integration/integration-config.json
+```
+
+2. Edit `integration-config.json`:
+
+| Field | Meaning |
+|-------|---------|
+| `prodCli` | Name or path of the prod Mojito CLI script (documented for completeness; integration tests do **not** use it) |
+| `devCli` | Name or path of the **dev** Mojito CLI script — used by all integration tests |
+| `testRepositoryName` | Disposable repository name the suite will **create, view, and delete** on dev. Use something unique that is not a real project (e.g. `mojito-mcp-integration-test`). |
+| `timeoutMs` | Optional per-invocation timeout in milliseconds (default `600000`) |
+
+Example:
+
+```json
+{
+  "prodCli": "mojito-prod",
+  "devCli": "mojito-dev",
+  "testRepositoryName": "mojito-mcp-integration-test",
+  "timeoutMs": 600000
+}
+```
+
+`integration-config.json` is gitignored. Do not commit machine-specific paths or secrets (auth stays in the CLI config, not this file).
+
+## Run
+
+```bash
+cd mojito-mcp
+npm run test:integration
+```
+
+If `integration-config.json` is missing, the suite fails immediately with instructions to copy the template.
+
+## What the tests do
+
+Against **dev** only:
+
+1. `probeHelp` — CLI is runnable  
+2. `repoList` — can list repositories  
+3. **Repository lifecycle** using `testRepositoryName`:
+   - Delete any leftover repo with that name (from a prior interrupted run)
+   - `repoCreate` (with sample locales including `(fr-CA)->fr-FR`)
+   - `repoView` by id
+   - `textunitSearch` scoped to that new repo (empty results are fine)
+   - `repoDelete` and confirm it no longer appears in a name-filtered list  
+
+If a test fails after create, `afterAll` attempts to delete the created repository id.

--- a/mojito-mcp/tests-integration/README.md
+++ b/mojito-mcp/tests-integration/README.md
@@ -31,7 +31,7 @@ cp tests-integration/integration-config.template.json tests-integration/integrat
 | `prodCli` | Name or path of the prod Mojito CLI script (documented for completeness; integration tests do **not** use it) |
 | `devCli` | Name or path of the **dev** Mojito CLI script — used by all integration tests |
 | `testRepositoryName` | Disposable repository name the suite will **create, view, and delete** on dev. Use something unique that is not a real project (e.g. `mojito-mcp-integration-test`). |
-| `timeoutMs` | Optional per-invocation timeout in milliseconds (default `600000`) |
+| `timeoutMs` | Optional per-invocation timeout as a positive whole number of milliseconds (default `600000`) |
 
 Example:
 
@@ -64,6 +64,7 @@ Against **dev** only:
 3. **Repository lifecycle** using `testRepositoryName`:
    - Delete any leftover repo with that name (from a prior interrupted run)
    - `repoCreate` (with sample locales including `(fr-CA)->fr-FR`)
+   - Confirm creating the same repository name again is rejected
    - `repoView` by id
    - `textunitSearch` scoped to that new repo (empty results are fine)
    - `repoDelete` and confirm it no longer appears in a name-filtered list  

--- a/mojito-mcp/tests-integration/integration-config.template.json
+++ b/mojito-mcp/tests-integration/integration-config.template.json
@@ -1,0 +1,6 @@
+{
+  "prodCli": "mojito-prod",
+  "devCli": "mojito-dev",
+  "testRepositoryName": "mojito-mcp-integration-test",
+  "timeoutMs": 600000
+}

--- a/mojito-mcp/tests-integration/load-integration-config.ts
+++ b/mojito-mcp/tests-integration/load-integration-config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/mojito-mcp/tests-integration/load-integration-config.ts
+++ b/mojito-mcp/tests-integration/load-integration-config.ts
@@ -69,7 +69,12 @@ export function loadIntegrationConfig(): IntegrationConfig {
         throw new Error(`Invalid JSON in ${path}`, { cause });
     }
 
-    if (!parsed || typeof parsed !== "object") {
+    return parseIntegrationConfig(parsed);
+}
+
+/** Parses and validates integration config independently of filesystem access. */
+export function parseIntegrationConfig(parsed: unknown): IntegrationConfig {
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
         throw new Error(`${CONFIG_FILE} must be a JSON object`);
     }
 
@@ -88,9 +93,9 @@ export function loadIntegrationConfig(): IntegrationConfig {
     }
     if (
         timeoutMs !== undefined &&
-        (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0)
+        (typeof timeoutMs !== "number" || !Number.isSafeInteger(timeoutMs) || timeoutMs <= 0)
     ) {
-        throw new Error(`${CONFIG_FILE}: "timeoutMs" must be a positive number when set`);
+        throw new Error(`${CONFIG_FILE}: "timeoutMs" must be a positive whole number when set`);
     }
 
     return {

--- a/mojito-mcp/tests-integration/load-integration-config.ts
+++ b/mojito-mcp/tests-integration/load-integration-config.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type IntegrationConfig = {
+    /** Prod Mojito CLI script name/path (not used by integration tests). */
+    prodCli: string;
+    /** Dev Mojito CLI script name/path — integration tests use this. */
+    devCli: string;
+    /**
+     * Repository name created/viewed/deleted on the **dev** server during integration tests.
+     * Use a dedicated disposable name (not a real project repo).
+     */
+    testRepositoryName: string;
+    /** Optional spawn timeout in ms (default 600000). */
+    timeoutMs?: number;
+};
+
+const CONFIG_FILE = "integration-config.json";
+const TEMPLATE_FILE = "integration-config.template.json";
+
+export function integrationConfigPath(): string {
+    const dir = dirname(fileURLToPath(import.meta.url));
+    return join(dir, CONFIG_FILE);
+}
+
+export function integrationConfigTemplatePath(): string {
+    const dir = dirname(fileURLToPath(import.meta.url));
+    return join(dir, TEMPLATE_FILE);
+}
+
+/**
+ * Loads `tests-integration/integration-config.json`.
+ * @throws Error with setup instructions if the file is missing or invalid.
+ */
+export function loadIntegrationConfig(): IntegrationConfig {
+    const path = integrationConfigPath();
+    if (!existsSync(path)) {
+        throw new Error(
+            [
+                `Missing ${CONFIG_FILE}.`,
+                `Copy the template and fill in your CLI script names:`,
+                `  cp tests-integration/${TEMPLATE_FILE} tests-integration/${CONFIG_FILE}`,
+                `See tests-integration/README.md for details.`,
+            ].join("\n"),
+        );
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    } catch (cause) {
+        throw new Error(`Invalid JSON in ${path}`, { cause });
+    }
+
+    if (!parsed || typeof parsed !== "object") {
+        throw new Error(`${CONFIG_FILE} must be a JSON object`);
+    }
+
+    const { prodCli, devCli, testRepositoryName, timeoutMs } = parsed as Record<string, unknown>;
+
+    if (typeof prodCli !== "string" || !prodCli.trim()) {
+        throw new Error(`${CONFIG_FILE}: "prodCli" must be a non-empty string`);
+    }
+    if (typeof devCli !== "string" || !devCli.trim()) {
+        throw new Error(`${CONFIG_FILE}: "devCli" must be a non-empty string`);
+    }
+    if (typeof testRepositoryName !== "string" || !testRepositoryName.trim()) {
+        throw new Error(
+            `${CONFIG_FILE}: "testRepositoryName" must be a non-empty string (disposable repo used for create/view/delete)`,
+        );
+    }
+    if (
+        timeoutMs !== undefined &&
+        (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0)
+    ) {
+        throw new Error(`${CONFIG_FILE}: "timeoutMs" must be a positive number when set`);
+    }
+
+    return {
+        prodCli: prodCli.trim(),
+        devCli: devCli.trim(),
+        testRepositoryName: testRepositoryName.trim(),
+        timeoutMs,
+    };
+}

--- a/mojito-mcp/tests-integration/mojito-client.integration.test.ts
+++ b/mojito-mcp/tests-integration/mojito-client.integration.test.ts
@@ -14,8 +14,37 @@
  * limitations under the License.
  */
 
+/**
+ * Test scenarios: end-to-end against a real dev Mojito.
+ *
+ * The unit tests prove we build the right CLI arguments; only these tests prove the
+ * arguments are ones Mojito accepts. They spawn a genuine CLI wrapper against a live
+ * server, so they are excluded from the default `pnpm test` run and require a local
+ * tests-integration/integration-config.json (see README.md in this directory). Point
+ * them at a dev instance and a disposable repository name, never at production.
+ *
+ * 1. The configured dev CLI is usable. `probeHelp` is the same check the server performs
+ *    at startup, so running it first means a broken wrapper or bad config fails with an
+ *    obvious message instead of surfacing as a confusing failure in a later test.
+ * 2. Listing repositories returns JSON. The cheapest read-only proof that authentication
+ *    works, the host is reachable, and stdout parses as the shape we expect.
+ * 3. The full repository lifecycle: create, view, search, delete. This is the one path
+ *    that exercises writes against a real server, including the nested JSON body for
+ *    derived locales (`fr-FR` plus `(fr-CA)->fr-FR`) that the CLI receives via a temp
+ *    file. It first deletes any leftover repository of the same name so an interrupted
+ *    earlier run cannot fail the suite, verifies a duplicate name is rejected, confirms
+ *    the created repository can be read back and searched, then deletes it and confirms
+ *    it is gone. An afterAll hook removes the repository if the test dies midway, so a
+ *    failure does not litter the dev server.
+ *
+ * Not covered here: translation writes and review updates, text unit history, pollable
+ * tasks, and the all-repositories search expansion. Those are argv-level unit tests only,
+ * because asserting them live would need seeded translation data on the dev instance.
+ */
+
 import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
 import { DefaultCliRunner } from "../src/cli-runner.js";
+import { MojitoCliError } from "../src/errors.js";
 import { MojitoCliClient } from "../src/mojito-client.js";
 import { loadIntegrationConfig, type IntegrationConfig } from "./load-integration-config.js";
 
@@ -99,6 +128,8 @@ describe("MojitoCliClient integration (dev)", () => {
             id: repositoryId,
             name: repoName,
         });
+
+        await expect(client.repoCreate({ name: repoName })).rejects.toBeInstanceOf(MojitoCliError);
 
         const viewed = await client.repoView(repositoryId);
         expect(viewed).toMatchObject({

--- a/mojito-mcp/tests-integration/mojito-client.integration.test.ts
+++ b/mojito-mcp/tests-integration/mojito-client.integration.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
+import { DefaultCliRunner } from "../src/cli-runner.js";
+import { MojitoCliClient } from "../src/mojito-client.js";
+import { loadIntegrationConfig, type IntegrationConfig } from "./load-integration-config.js";
+
+type RepoRow = { id?: number; name?: string };
+
+function asRepoArray(value: unknown): RepoRow[] {
+    return Array.isArray(value) ? (value as RepoRow[]) : [];
+}
+
+function requireRepoId(value: unknown, context: string): number {
+    if (value && typeof value === "object" && "id" in value) {
+        const id = (value as { id: unknown }).id;
+        if (typeof id === "number" && Number.isFinite(id)) {
+            return id;
+        }
+    }
+    throw new Error(
+        `${context}: expected repository JSON with numeric id, got ${JSON.stringify(value)}`,
+    );
+}
+
+/**
+ * Live integration tests against the **dev** Mojito CLI / server.
+ * Requires tests-integration/integration-config.json (see README.md).
+ */
+describe("MojitoCliClient integration (dev)", () => {
+    let integration: IntegrationConfig;
+    let client: MojitoCliClient;
+    /** Set when create succeeds so afterAll can clean up on failure mid-suite. */
+    let createdRepositoryId: number | undefined;
+
+    beforeAll(() => {
+        integration = loadIntegrationConfig();
+        const runner = new DefaultCliRunner({
+            cliBinary: integration.devCli,
+            timeoutMs: integration.timeoutMs ?? 600_000,
+        });
+        client = new MojitoCliClient(runner.config, runner);
+    });
+
+    afterAll(async () => {
+        if (createdRepositoryId === undefined) {
+            return;
+        }
+        try {
+            await client.repoDelete(createdRepositoryId);
+        } catch {
+            // Best-effort cleanup if the delete test already removed it or the server rejected.
+        }
+    });
+
+    test("probeHelp succeeds with the configured dev CLI", async () => {
+        await expect(client.probeHelp()).resolves.toBeUndefined();
+    });
+
+    test("repoList returns a JSON array from the dev server", async () => {
+        const repos = await client.repoList();
+        expect(Array.isArray(repos)).toBe(true);
+    });
+
+    test("creates, views, and deletes the configured test repository on dev", async () => {
+        const repoName = integration.testRepositoryName;
+
+        // Leftover from a previous interrupted run
+        const existing = asRepoArray(await client.repoList({ name: repoName }));
+        for (const row of existing) {
+            if (typeof row.id === "number") {
+                await client.repoDelete(row.id);
+            }
+        }
+
+        const created = await client.repoCreate({
+            name: repoName,
+            description: "Created by mojito-mcp integration tests; safe to delete",
+            repositoryLocales: ["fr-FR", "(fr-CA)->fr-FR"],
+        });
+        const repositoryId = requireRepoId(created, "repoCreate");
+        createdRepositoryId = repositoryId;
+
+        expect(created).toMatchObject({
+            id: repositoryId,
+            name: repoName,
+        });
+
+        const viewed = await client.repoView(repositoryId);
+        expect(viewed).toMatchObject({
+            id: repositoryId,
+            name: repoName,
+        });
+
+        const searchHits = await client.textunitSearch({
+            repositoryNames: [repoName],
+            searchType: "CONTAINS",
+            limit: 5,
+        });
+        expect(Array.isArray(searchHits)).toBe(true);
+
+        await client.repoDelete(repositoryId);
+        createdRepositoryId = undefined;
+
+        const afterDelete = asRepoArray(await client.repoList({ name: repoName }));
+        expect(afterDelete.find((r) => r.id === repositoryId)).toBeUndefined();
+    });
+});

--- a/mojito-mcp/tests-integration/mojito-client.integration.test.ts
+++ b/mojito-mcp/tests-integration/mojito-client.integration.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
 import { DefaultCliRunner } from "../src/cli-runner.js";
 import { MojitoCliClient } from "../src/mojito-client.js";

--- a/mojito-mcp/tests/cli-runner.test.ts
+++ b/mojito-mcp/tests/cli-runner.test.ts
@@ -14,6 +14,32 @@
  * limitations under the License.
  */
 
+/**
+ * Test scenarios: spawning the Mojito CLI as a child process.
+ *
+ * This is the only place mojito-mcp touches the operating system, and it runs underneath
+ * an MCP stdio transport where the server's own stdout *is* the protocol channel. The
+ * tests use `process.execPath` (the Node binary already running Jest) as a stand-in CLI,
+ * so they need neither a Mojito install nor network access.
+ *
+ * 1. A command that succeeds. The two output streams are captured separately and handed
+ *    back alongside exit code 0. Capturing rather than inheriting is the point of the
+ *    case: child output written onto the parent's stdout would corrupt the MCP stream.
+ * 2. A command that exits non-zero. The runner reports the real exit code and does not
+ *    throw, because deciding what a failure means belongs to the client layer, which
+ *    needs the captured stderr to build a message worth showing the agent.
+ * 3. A command that never exits. Given a short timeout, the runner kills the child and
+ *    rejects with a MojitoCliError flagged `timedOut`, so a hung or unreachable Mojito
+ *    instance cannot wedge the MCP server indefinitely.
+ * 4. A program that does not exist. A missing or misnamed CLI wrapper is the most common
+ *    setup mistake, and it has to arrive as a MojitoCliError like every other failure
+ *    rather than as an unhandled spawn error that takes the process down.
+ * 5. The child receives environment variables from the MCP process. Mojito authentication
+ *    wrappers often rely on HOME, PATH, profiles, or access-token helper variables.
+ * 6. A child that ignores SIGTERM is escalated to SIGKILL. The timeout must remain a hard
+ *    bound even when a broken wrapper installs its own signal handler.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { DefaultCliRunner } from "../src/cli-runner.js";
 import { MojitoCliError } from "../src/errors.js";
@@ -71,4 +97,42 @@ describe("DefaultCliRunner", () => {
 
         await expect(runner.run(["--help"])).rejects.toBeInstanceOf(MojitoCliError);
     });
+
+    test("run passes the parent environment to the child", async () => {
+        const runner = new DefaultCliRunner({
+            cliBinary: process.execPath,
+            timeoutMs: 10_000,
+        });
+        const original = process.env.MOJITO_MCP_RUNNER_TEST;
+        process.env.MOJITO_MCP_RUNNER_TEST = "available";
+        try {
+            const result = await runner.run([
+                "-e",
+                "process.stdout.write(process.env.MOJITO_MCP_RUNNER_TEST ?? 'missing')",
+            ]);
+            expect(result.stdout).toBe("available");
+        } finally {
+            if (original === undefined) {
+                delete process.env.MOJITO_MCP_RUNNER_TEST;
+            } else {
+                process.env.MOJITO_MCP_RUNNER_TEST = original;
+            }
+        }
+    });
+
+    test("run escalates to SIGKILL when a timed-out child ignores SIGTERM", async () => {
+        const runner = new DefaultCliRunner({
+            cliBinary: process.execPath,
+            timeoutMs: 100,
+        });
+        const startedAt = Date.now();
+
+        await expect(
+            runner.run(["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"]),
+        ).rejects.toMatchObject({
+            name: "MojitoCliError",
+            timedOut: true,
+        });
+        expect(Date.now() - startedAt).toBeLessThan(5_000);
+    }, 10_000);
 });

--- a/mojito-mcp/tests/cli-runner.test.ts
+++ b/mojito-mcp/tests/cli-runner.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { DefaultCliRunner } from "../src/cli-runner.js";
 import { MojitoCliError } from "../src/errors.js";

--- a/mojito-mcp/tests/cli-runner.test.ts
+++ b/mojito-mcp/tests/cli-runner.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "@jest/globals";
+import { DefaultCliRunner } from "../src/cli-runner.js";
+import { MojitoCliError } from "../src/errors.js";
+
+/**
+ * Contract tests for DefaultCliRunner.
+ * These will fail until the runner is implemented (TDD red phase).
+ */
+describe("DefaultCliRunner", () => {
+    test("run executes the configured binary with argv and returns exitCode/stdout/stderr", async () => {
+        // Use a portable command: node -e prints and exits 0
+        const runner = new DefaultCliRunner({
+            cliBinary: process.execPath,
+            timeoutMs: 10_000,
+        });
+
+        const result = await runner.run([
+            "-e",
+            "process.stdout.write('out'); process.stderr.write('err');",
+        ]);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("out");
+        expect(result.stderr).toBe("err");
+    });
+
+    test("run returns non-zero exitCode without throwing when the child exits failed", async () => {
+        const runner = new DefaultCliRunner({
+            cliBinary: process.execPath,
+            timeoutMs: 10_000,
+        });
+
+        const result = await runner.run(["-e", "process.exit(7)"]);
+
+        expect(result.exitCode).toBe(7);
+    });
+
+    test("run times out and throws MojitoCliError with timedOut=true", async () => {
+        const runner = new DefaultCliRunner({
+            cliBinary: process.execPath,
+            timeoutMs: 200,
+        });
+
+        await expect(runner.run(["-e", "setTimeout(() => {}, 10_000)"])).rejects.toMatchObject({
+            name: "MojitoCliError",
+            timedOut: true,
+        } satisfies Partial<MojitoCliError>);
+    });
+
+    test("run throws MojitoCliError when the binary cannot be spawned", async () => {
+        const runner = new DefaultCliRunner({
+            cliBinary: "/nonexistent/mojito-binary-for-tests",
+            timeoutMs: 5_000,
+        });
+
+        await expect(runner.run(["--help"])).rejects.toBeInstanceOf(MojitoCliError);
+    });
+});

--- a/mojito-mcp/tests/config.test.ts
+++ b/mojito-mcp/tests/config.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { DEFAULT_CLI_BINARY, DEFAULT_TIMEOUT_MS, loadConfigFromEnv } from "../src/config.js";
 

--- a/mojito-mcp/tests/config.test.ts
+++ b/mojito-mcp/tests/config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "@jest/globals";
+import { DEFAULT_CLI_BINARY, DEFAULT_TIMEOUT_MS, loadConfigFromEnv } from "../src/config.js";
+
+describe("loadConfigFromEnv", () => {
+    const originalEnv = process.env;
+
+    function withEnv(env: NodeJS.ProcessEnv, fn: () => void): void {
+        process.env = { ...env };
+        try {
+            fn();
+        } finally {
+            process.env = originalEnv;
+        }
+    }
+
+    test("defaults to mojito-prod and 10 minute timeout when env is empty", () => {
+        withEnv({}, () => {
+            const config = loadConfigFromEnv();
+            expect(config.cliBinary).toBe(DEFAULT_CLI_BINARY);
+            expect(config.cliBinary).toBe("mojito-prod");
+            expect(config.timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+            expect(config.timeoutMs).toBe(600_000);
+        });
+    });
+
+    test("reads MOJITO_CLI", () => {
+        withEnv({ MOJITO_CLI: "mojito-dev" }, () => {
+            expect(loadConfigFromEnv().cliBinary).toBe("mojito-dev");
+        });
+    });
+
+    test("trims MOJITO_CLI", () => {
+        withEnv({ MOJITO_CLI: "  mojito-dev  " }, () => {
+            expect(loadConfigFromEnv().cliBinary).toBe("mojito-dev");
+        });
+    });
+
+    test("reads MOJITO_CLI_TIMEOUT_MS", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "120000" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(120_000);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is invalid", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "nope" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is non-positive", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "0" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+});

--- a/mojito-mcp/tests/config.test.ts
+++ b/mojito-mcp/tests/config.test.ts
@@ -14,6 +14,50 @@
  * limitations under the License.
  */
 
+/**
+ * Test scenarios: reading server configuration from the environment.
+ *
+ * The MCP host (for example Cursor) hands this server its configuration only through
+ * environment variables, so these tests pin the behaviour for each shape of input an
+ * operator can realistically produce. Mojito credentials and host are deliberately out
+ * of scope: they live in the Mojito CLI's own config, never in ours. Whether the named
+ * CLI actually exists on disk is also out of scope: that is a spawn failure in the
+ * runner, not a config-parse failure.
+ *
+ * 1. Nothing is set. The server must still come up with usable defaults, namely the
+ *    `mojito-prod` wrapper and a ten minute per-call timeout. This is the path most
+ *    people get, so the defaults are asserted both through the exported constants and
+ *    as literal values, to catch someone quietly retuning them.
+ * 2. MOJITO_CLI names a wrapper. The operator's chosen script (say `mojito-dev`)
+ *    replaces the default; this is how one machine runs both a prod and a dev server
+ *    from the same package.
+ * 3. MOJITO_CLI has surrounding whitespace. Hand-edited JSON config easily picks up a
+ *    stray space, and a padded program name would fail to spawn, so it is trimmed.
+ * 4. MOJITO_CLI is empty or only whitespace. A blank Cursor env value must not become
+ *    an empty program name that can never spawn; it falls back to the default wrapper.
+ * 5. MOJITO_CLI is a filesystem path rather than a name on PATH. Absolute and relative
+ *    paths are accepted unchanged (after trim), because some operators launch a specific
+ *    jar wrapper instead of a PATH script.
+ * 6. MOJITO_CLI_TIMEOUT_MS is a valid positive whole number. Operators need to raise the
+ *    spawn timeout for slow instances and long-running jobs, so the override is honoured.
+ * 7. MOJITO_CLI_TIMEOUT_MS has surrounding whitespace. Number parsing already tolerates
+ *    that, and it must still be accepted so a padded JSON value does not silently revert
+ *    to the default.
+ * 8. MOJITO_CLI_TIMEOUT_MS is not a number at all. A typo must not become NaN, which
+ *    would make every CLI call fail instantly, so we fall back to the default.
+ * 9. MOJITO_CLI_TIMEOUT_MS is an empty string. Number("") is zero; that must not kill
+ *    every call, so we fall back to the default.
+ * 10. MOJITO_CLI_TIMEOUT_MS is zero. A non-positive timeout would kill every call
+ *     immediately, so the default wins.
+ * 11. MOJITO_CLI_TIMEOUT_MS is negative. Same as zero: the default wins.
+ * 12. MOJITO_CLI_TIMEOUT_MS is a fraction such as 1500.9. Timeouts are whole milliseconds
+ *     only; a fractional value is rejected and the default is used.
+ * 13. MOJITO_CLI_TIMEOUT_MS is non-finite, such as Infinity or an overflow like 1e1000.
+ *     Those parse as Infinity, which must not disable the timer, so we fall back.
+ * 14. Both variables are set together. Reading one field must not clobber or ignore the
+ *     other.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { DEFAULT_CLI_BINARY, DEFAULT_TIMEOUT_MS, loadConfigFromEnv } from "../src/config.js";
 
@@ -51,8 +95,38 @@ describe("loadConfigFromEnv", () => {
         });
     });
 
+    test("falls back to default CLI when MOJITO_CLI is empty", () => {
+        withEnv({ MOJITO_CLI: "" }, () => {
+            expect(loadConfigFromEnv().cliBinary).toBe(DEFAULT_CLI_BINARY);
+        });
+    });
+
+    test("falls back to default CLI when MOJITO_CLI is whitespace-only", () => {
+        withEnv({ MOJITO_CLI: "   " }, () => {
+            expect(loadConfigFromEnv().cliBinary).toBe(DEFAULT_CLI_BINARY);
+        });
+    });
+
+    test("accepts an absolute path for MOJITO_CLI", () => {
+        withEnv({ MOJITO_CLI: "/Users/me/bin/mojito-prod" }, () => {
+            expect(loadConfigFromEnv().cliBinary).toBe("/Users/me/bin/mojito-prod");
+        });
+    });
+
+    test("accepts a relative path for MOJITO_CLI", () => {
+        withEnv({ MOJITO_CLI: "./scripts/mojito-dev" }, () => {
+            expect(loadConfigFromEnv().cliBinary).toBe("./scripts/mojito-dev");
+        });
+    });
+
     test("reads MOJITO_CLI_TIMEOUT_MS", () => {
         withEnv({ MOJITO_CLI_TIMEOUT_MS: "120000" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(120_000);
+        });
+    });
+
+    test("trims MOJITO_CLI_TIMEOUT_MS", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "  120000  " }, () => {
             expect(loadConfigFromEnv().timeoutMs).toBe(120_000);
         });
     });
@@ -63,9 +137,47 @@ describe("loadConfigFromEnv", () => {
         });
     });
 
-    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is non-positive", () => {
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is empty", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is zero", () => {
         withEnv({ MOJITO_CLI_TIMEOUT_MS: "0" }, () => {
             expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is negative", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "-1" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is fractional", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "1500.9" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS is Infinity", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "Infinity" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("falls back to default timeout when MOJITO_CLI_TIMEOUT_MS overflows to Infinity", () => {
+        withEnv({ MOJITO_CLI_TIMEOUT_MS: "1e1000" }, () => {
+            expect(loadConfigFromEnv().timeoutMs).toBe(DEFAULT_TIMEOUT_MS);
+        });
+    });
+
+    test("reads both MOJITO_CLI and MOJITO_CLI_TIMEOUT_MS together", () => {
+        withEnv({ MOJITO_CLI: "mojito-dev", MOJITO_CLI_TIMEOUT_MS: "120000" }, () => {
+            const config = loadConfigFromEnv();
+            expect(config.cliBinary).toBe("mojito-dev");
+            expect(config.timeoutMs).toBe(120_000);
         });
     });
 });

--- a/mojito-mcp/tests/errors.test.ts
+++ b/mojito-mcp/tests/errors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "@jest/globals";
+import { MojitoCliError } from "../src/errors.js";
+
+describe("MojitoCliError", () => {
+    test("stores exit metadata for MCP error surfacing", () => {
+        const err = new MojitoCliError("failed", {
+            exitCode: 1,
+            stdout: '{"message":"x"}',
+            stderr: "mojito: x (HTTP 400)",
+            timedOut: false,
+        });
+
+        expect(err.name).toBe("MojitoCliError");
+        expect(err.message).toBe("failed");
+        expect(err.exitCode).toBe(1);
+        expect(err.stdout).toContain("message");
+        expect(err.stderr).toContain("mojito:");
+        expect(err.timedOut).toBe(false);
+    });
+
+    test("defaults optional fields", () => {
+        const err = new MojitoCliError("timeout", { timedOut: true });
+        expect(err.exitCode).toBeNull();
+        expect(err.stdout).toBe("");
+        expect(err.stderr).toBe("");
+        expect(err.timedOut).toBe(true);
+    });
+});

--- a/mojito-mcp/tests/errors.test.ts
+++ b/mojito-mcp/tests/errors.test.ts
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
+/**
+ * Test scenarios: the failure payload that reaches the AI agent.
+ *
+ * Every error an agent sees from this server is a MojitoCliError, so the fields it
+ * carries decide whether the agent can tell "your CLI is not installed" apart from
+ * "Mojito rejected the request with HTTP 400". These tests pin that payload's shape.
+ *
+ * 1. A failure where the CLI actually ran. The error retains the exit code, both output
+ *    streams, and the timeout flag, and reports a stable `name` that callers and tests
+ *    can match on rather than parsing the message text.
+ * 2. A failure with almost nothing known, such as a timeout. The optional fields default
+ *    to empty string and null instead of `undefined`, so code that formats an MCP error
+ *    message can never end up showing the agent the word "undefined".
+ * 3. A lower-level exception is retained as `cause`. Spawn and JSON parse failures need
+ *    their original exception for diagnostics without replacing the stable public error.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { MojitoCliError } from "../src/errors.js";
 
@@ -40,5 +57,12 @@ describe("MojitoCliError", () => {
         expect(err.stdout).toBe("");
         expect(err.stderr).toBe("");
         expect(err.timedOut).toBe(true);
+    });
+
+    test("retains an underlying cause", () => {
+        const cause = new Error("spawn failed");
+        const err = new MojitoCliError("could not run CLI", { cause });
+
+        expect(err.cause).toBe(cause);
     });
 });

--- a/mojito-mcp/tests/errors.test.ts
+++ b/mojito-mcp/tests/errors.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { MojitoCliError } from "../src/errors.js";
 

--- a/mojito-mcp/tests/load-integration-config.test.ts
+++ b/mojito-mcp/tests/load-integration-config.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test scenarios: validating the opt-in live-test configuration.
+ *
+ * These tests exercise the data parser without reading a developer's machine-specific
+ * `integration-config.json`. That keeps the default unit suite hermetic while pinning the
+ * safety checks applied before live tests can create and delete a repository.
+ *
+ * 1. A complete valid object is accepted, surrounding whitespace is removed from every
+ *    string, and a positive whole-number timeout is retained.
+ * 2. The timeout is optional because the integration runner has a ten-minute default.
+ * 3. Null, primitive values, and arrays are rejected; JSON config must be an object.
+ * 4. Each required string rejects a missing, non-string, empty, or whitespace-only value.
+ *    In particular, a blank test repository name must never reach a destructive live test.
+ * 5. Timeout rejects strings, NaN, Infinity, zero, negatives, fractions, and unsafe integers.
+ *    It must represent a finite positive whole number of milliseconds, matching runtime
+ *    `MOJITO_CLI_TIMEOUT_MS` semantics.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { parseIntegrationConfig } from "../tests-integration/load-integration-config.js";
+
+const valid = {
+    prodCli: "mojito-prod",
+    devCli: "mojito-dev",
+    testRepositoryName: "mojito-mcp-integration-test",
+};
+
+describe("parseIntegrationConfig", () => {
+    test("accepts and trims a complete valid config", () => {
+        expect(
+            parseIntegrationConfig({
+                prodCli: "  mojito-prod  ",
+                devCli: "  ./bin/mojito-dev  ",
+                testRepositoryName: "  disposable-repo  ",
+                timeoutMs: 120_000,
+            }),
+        ).toEqual({
+            prodCli: "mojito-prod",
+            devCli: "./bin/mojito-dev",
+            testRepositoryName: "disposable-repo",
+            timeoutMs: 120_000,
+        });
+    });
+
+    test("accepts an omitted timeout", () => {
+        expect(parseIntegrationConfig(valid)).toEqual({ ...valid, timeoutMs: undefined });
+    });
+
+    test.each([null, true, "config", 3, []])("rejects non-object config: %p", (value) => {
+        expect(() => parseIntegrationConfig(value)).toThrow(/must be a JSON object/);
+    });
+
+    test.each(["prodCli", "devCli", "testRepositoryName"] as const)(
+        "rejects an invalid %s",
+        (field) => {
+            for (const value of [undefined, null, 1, "", "   "]) {
+                expect(() => parseIntegrationConfig({ ...valid, [field]: value })).toThrow();
+            }
+        },
+    );
+
+    test.each([
+        "120000",
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        0,
+        -1,
+        1500.9,
+        Number.MAX_SAFE_INTEGER + 1,
+    ])("rejects invalid timeout %p", (timeoutMs) => {
+        expect(() => parseIntegrationConfig({ ...valid, timeoutMs })).toThrow(
+            /positive whole number/,
+        );
+    });
+});

--- a/mojito-mcp/tests/mojito-client.test.ts
+++ b/mojito-mcp/tests/mojito-client.test.ts
@@ -14,8 +14,126 @@
  * limitations under the License.
  */
 
+/**
+ * Test scenarios: translating tool calls into Mojito CLI invocations.
+ *
+ * This is the contract between the MCP tool surface and the `mojito api` command line.
+ * A fake CliRunner records the argv it is handed and returns canned output, so every
+ * case below is an assertion about the command we would have run, with no Mojito
+ * install, no authentication, and no network involved.
+ *
+ * The file covers two units, in this order.
+ *
+ * ## Encoded repository locales (`parseEncodedRepositoryLocale`)
+ *
+ * Repository locales reach us as a compact string so an agent can express a whole locale
+ * tree without nested JSON: `fr-CA` is a locale, parentheses mean "not fully translated",
+ * and `->` points at the locale it inherits from. The parser turns that into the nested
+ * shape Mojito's API expects, and getting it wrong would silently misconfigure which
+ * locales a repository translates.
+ *
+ * 1. A bare tag such as `fr-FR` is fully translated and has no parent, the common case.
+ * 2. Parentheses, as in `(en-GB)`, mark the locale as not fully translated.
+ * 3. `(fr-CA)->fr-FR` combines both features: inherits from a parent and is not fully
+ *    translated, which is the standard shape for a regional variant.
+ * 4. `fr-CA->fr-FR` inherits from a parent while staying fully translated, confirming the
+ *    two features are independent rather than implied by each other.
+ * 5. A three-level chain nests correctly, so inheritance is not capped at one hop.
+ * 6. Parentheses on a later segment (`fr-CA->(fr-FR)`) still mark the child as not fully
+ *    translated. This pins a deliberate decision: the flag is read from the whole string,
+ *    not only from the leading segment.
+ * 7. Whitespace around segments and around the arrow is trimmed, because these strings are
+ *    typed by hand and by agents.
+ * 8. A language-only tag such as `ja` is accepted; a region is not required.
+ * 9. An empty string is rejected with a MojitoCliError naming the bad input, so a blank
+ *    field fails loudly rather than creating a nameless locale.
+ * 10. A whitespace-only string is rejected the same way.
+ * 11. A missing child before the arrow, as in `->fr-FR`, is rejected: a parent with nothing
+ *     inheriting from it is meaningless.
+ * 12. Unbalanced parentheses like `(fr-FR` are *not* an error; they are kept as a literal
+ *     tag and left for the server to reject. This documents that we only strip a matched
+ *     pair rather than guessing at the author's intent.
+ * 13. Nested parentheses strip only the outer pair, for the same reason.
+ * 14. A trailing arrow (`fr-FR->`) is rejected rather than producing a parent with an
+ *     empty tag that Mojito cannot use.
+ * 15. Parentheses at more than one level of a chain apply to their own segment.
+ * 16. A comma is not a separator: `de-DE,fr-FR` stays one literal tag. Agents are likely to
+ *     try comma-separated lists, and this fixes what happens when they do.
+ * 17. Commas inside a chain likewise stay part of each segment's tag.
+ * 18. An empty middle segment and empty parentheses are rejected. Both otherwise produce
+ *     malformed locale trees that fail later and less clearly at the Mojito API.
+ *
+ * ## CLI argument contracts (`MojitoCliClient`)
+ *
+ * One case per tool, asserting the exact `api` path, HTTP method, pagination flags, and
+ * field encoding. `-f` sends a value as a string and `-F` sends it typed, so mixing them
+ * up would send Mojito the wrong JSON types.
+ *
+ * 1. The startup probe runs `--help` and succeeds on exit 0. This is what the server does
+ *    before serving traffic, and it must not touch the network.
+ * 2. The startup probe fails on a non-zero exit, which is how a missing or broken CLI
+ *    wrapper stops the server at boot instead of failing later on every tool call.
+ * 3. Listing repositories deliberately does *not* paginate. The endpoint ignores offset and
+ *    limit and returns everything at once, so `--paginate` would loop forever on pages that
+ *    always look full. The most important case in this group.
+ * 4. Listing with a name filter passes it as a string field.
+ * 5. Viewing a repository is a plain GET on the id.
+ * 6. Creating a simple repository POSTs with an explicit `-X POST` and string fields.
+ * 7. Creating a repository with several derived locales switches to a JSON body written to a
+ *    temp file and passed with `--input`, because the nested locale tree cannot be expressed
+ *    as flat fields. The assertion reads that temp file inside the fake runner, since the
+ *    file is deleted as soon as the call returns.
+ * 8. Deleting a repository requires an explicit `-X DELETE`, never an implied method.
+ * 9. Searching text units POSTs to the search endpoint with the full pagination flag set
+ *    (`--paginate --slurp --max-pages 0`), and passes repository, source, search type, and
+ *    locale filters through as fields.
+ * 10. Searching with an explicit `limit` drops pagination and sends the limit as a typed
+ *     field, so a caller who asked for a handful of rows gets one cheap request instead of a
+ *     full slurp of every page.
+ * 11. Searching with no repository scope first lists every repository and then searches with
+ *     all of their ids. Mojito's search API demands a scope, so "all repositories" has to be
+ *     expanded here rather than pushed onto the agent.
+ * 12. Inspecting one text unit reuses the search endpoint filtered by id, because Mojito has
+ *     no get-by-id route for text units.
+ * 13. Fetching history sends the required BCP-47 tag as a query field. History takes a tag
+ *     while the write tools take a numeric locale id, and confusing the two is an easy
+ *     mistake for both humans and agents.
+ * 14. Adding a translation POSTs numeric ids as typed fields and the target text as a string,
+ *     so a translation that happens to look like a number is not coerced.
+ * 15. The review action `accept` maps to status APPROVED and included-in-localized-file true.
+ * 16. The review action `reject` maps to status TRANSLATION_NEEDED and included false. Reject
+ *     is the case where a wrong mapping would quietly drop a string from shipped files.
+ * 17. Fetching a pollable task is a plain GET on the id; it never waits on the task.
+ * 18. Any non-zero CLI exit becomes a MojitoCliError that carries the exit code and stderr,
+ *     which is how a Mojito HTTP error reaches the agent as a readable message.
+ * 19. A successful call parses the JSON on stdout and returns it as data.
+ *
+ * 20. Empty descriptions and a false SLA flag survive a simple repository create. Checks
+ *     based on truthiness would otherwise silently discard both valid values.
+ * 21. A nested repository create writes every optional field and removes its temporary JSON
+ *     file after success; a separate failure path proves cleanup also happens when CLI exits
+ *     non-zero, preventing abandoned request bodies in the system temp directory.
+ * 22. One exhaustive search encodes every supported filter with the right raw (`-f`) or
+ *     typed (`-F`) flag, including false booleans and offset zero.
+ * 23. An all-repository search on a server with no repositories returns an empty array
+ *     without issuing an invalid unscoped search request.
+ * 24. A malformed repository row is rejected during all-repository expansion instead of
+ *     being silently omitted and producing incomplete search results.
+ * 25. Text-unit info forwards multiple locale tags as repeated raw array fields.
+ * 26. Translation add preserves empty target/comment strings and false inclusion instead of
+ *     dropping them as falsy values.
+ * 27. The `review` and `translate` actions are pinned in addition to accept and reject, and
+ *     an empty review comment is preserved.
+ * 28. A CLI failure with blank stderr falls back to an exit-code message, so the agent still
+ *     receives a useful explanation.
+ * 29. Successful empty stdout (the normal DELETE response) maps to null rather than causing
+ *     a JSON parse error.
+ * 30. Successful but malformed JSON becomes a MojitoCliError that preserves stdout and the
+ *     SyntaxError cause for diagnosis.
+ */
+
 import { describe, expect, test } from "@jest/globals";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import type { CliRunResult, CliRunner } from "../src/cli-runner.js";
 import { MojitoCliError } from "../src/errors.js";
 import { MojitoCliClient, parseEncodedRepositoryLocale } from "../src/mojito-client.js";
@@ -145,14 +263,25 @@ describe("parseEncodedRepositoryLocale", () => {
         });
     });
 
-    test("empty parent segment after -> becomes an empty-tag parent node", () => {
-        expect(parseEncodedRepositoryLocale("fr-FR->")).toEqual({
-            locale: { bcp47Tag: "fr-FR" },
-            toBeFullyTranslated: true,
-            parentLocale: {
-                locale: { bcp47Tag: "" },
-            },
-        });
+    test("throws when the parent segment after -> is empty", () => {
+        expect(() => parseEncodedRepositoryLocale("fr-FR->")).toThrow(
+            /Invalid encoded repository locale/,
+        );
+    });
+
+    test("throws when a middle segment is empty", () => {
+        expect(() => parseEncodedRepositoryLocale("fr-CA-> ->fr-FR")).toThrow(
+            /Invalid encoded repository locale/,
+        );
+    });
+
+    test("throws when a parenthesized locale is empty", () => {
+        expect(() => parseEncodedRepositoryLocale("()")).toThrow(
+            /Invalid encoded repository locale/,
+        );
+        expect(() => parseEncodedRepositoryLocale("(   )")).toThrow(
+            /Invalid encoded repository locale/,
+        );
     });
 
     test("parentheses at more than one level of a derived chain", () => {
@@ -242,6 +371,16 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
         expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "name=r"]));
     });
 
+    test("repoCreate keeps false and empty optional fields in a flat request", async () => {
+        const runner = mockRunner(() => okJson({ id: 1 }));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoCreate({ name: "r", description: "", checkSLA: false });
+
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "description="]));
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-F", "checkSLA=false"]));
+    });
+
     test("repoCreate sends a list of locales with several derived locales as JSON body", async () => {
         let body: Record<string, unknown> | undefined;
         // The temp body file is deleted once the call returns, so read it inside the runner.
@@ -288,6 +427,55 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
                 },
             },
         ]);
+    });
+
+    test("repoCreate JSON body includes every optional nested field and removes its temp file", async () => {
+        let inputFile = "";
+        let body: Record<string, unknown> | undefined;
+        const runner = mockRunner((argv) => {
+            inputFile = argv[argv.indexOf("--input") + 1];
+            body = JSON.parse(readFileSync(inputFile, "utf8")) as Record<string, unknown>;
+            return okJson({ id: 1 });
+        });
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoCreate({
+            name: "full",
+            description: "",
+            checkSLA: false,
+            sourceLocale: "en-US",
+            repositoryLocales: ["fr-FR"],
+            assetIntegrityCheckers: [
+                { assetExtension: "properties", integrityCheckerType: "PRINTF_LIKE" },
+            ],
+        });
+
+        expect(body).toMatchObject({
+            name: "full",
+            description: "",
+            checkSLA: false,
+            sourceLocale: { bcp47Tag: "en-US" },
+            assetIntegrityCheckers: [
+                { assetExtension: "properties", integrityCheckerType: "PRINTF_LIKE" },
+            ],
+        });
+        expect(inputFile).not.toBe("");
+        expect(existsSync(inputFile)).toBe(false);
+    });
+
+    test("repoCreate removes its temp body when the CLI fails", async () => {
+        let inputFile = "";
+        const runner = mockRunner((argv) => {
+            inputFile = argv[argv.indexOf("--input") + 1];
+            return { exitCode: 1, stdout: "", stderr: "create failed" };
+        });
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(
+            client.repoCreate({ name: "r", sourceLocale: "en-US" }),
+        ).rejects.toBeInstanceOf(MojitoCliError);
+        expect(inputFile).not.toBe("");
+        expect(existsSync(inputFile)).toBe(false);
     });
 
     test("repoDelete uses -X DELETE", async () => {
@@ -364,6 +552,97 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
         expect(searchArgv).toEqual(expect.arrayContaining(["-F", "repositoryIds[]=2"]));
     });
 
+    test("textunitSearch encodes every optional search field with the correct type", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitSearch({
+            repositoryIds: [1],
+            repositoryNames: ["demo"],
+            tmTextUnitIds: [2],
+            localeTags: ["fr-FR"],
+            name: "welcome",
+            source: "Hello",
+            target: "Bonjour",
+            assetPath: "messages.properties",
+            pluralFormOther: "items",
+            searchType: "ILIKE",
+            statusFilter: "REVIEW_NEEDED",
+            usedFilter: "UNUSED",
+            doNotTranslateFilter: false,
+            tmTextUnitCreatedAfter: "2024-01-01T00:00:00Z",
+            tmTextUnitCreatedBefore: "2024-02-01T00:00:00Z",
+            branchId: 3,
+            pluralFormFiltered: false,
+            pluralFormExcluded: true,
+            limit: 10,
+            offset: 0,
+        });
+
+        expect(runner.calls[0]).toEqual([
+            "api",
+            "/api/textunits/search",
+            "-X",
+            "POST",
+            "-F",
+            "repositoryIds[]=1",
+            "-f",
+            "repositoryNames[]=demo",
+            "-F",
+            "tmTextUnitIds[]=2",
+            "-f",
+            "localeTags[]=fr-FR",
+            "-f",
+            "name=welcome",
+            "-f",
+            "source=Hello",
+            "-f",
+            "target=Bonjour",
+            "-f",
+            "assetPath=messages.properties",
+            "-f",
+            "pluralFormOther=items",
+            "-f",
+            "searchType=ILIKE",
+            "-f",
+            "statusFilter=REVIEW_NEEDED",
+            "-f",
+            "usedFilter=UNUSED",
+            "-F",
+            "doNotTranslateFilter=false",
+            "-f",
+            "tmTextUnitCreatedAfter=2024-01-01T00:00:00Z",
+            "-f",
+            "tmTextUnitCreatedBefore=2024-02-01T00:00:00Z",
+            "-F",
+            "branchId=3",
+            "-F",
+            "pluralFormFiltered=false",
+            "-F",
+            "pluralFormExcluded=true",
+            "-F",
+            "limit=10",
+            "-F",
+            "offset=0",
+        ]);
+    });
+
+    test("textunitSearch returns an empty result without searching when there are no repositories", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.textunitSearch({ source: "x" })).resolves.toEqual([]);
+        expect(runner.calls).toEqual([["api", "/api/repositories"]]);
+    });
+
+    test("textunitSearch rejects malformed repository rows during all-repository expansion", async () => {
+        const runner = mockRunner(() => okJson([{ id: 1 }, { name: "missing-id" }]));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.textunitSearch({ source: "x" })).rejects.toThrow(/positive integer id/);
+        expect(runner.calls).toEqual([["api", "/api/repositories"]]);
+    });
+
     test("textunitInfo searches by tmTextUnitIds", async () => {
         const runner = mockRunner(() => okJson([]));
         const client = new MojitoCliClient(config, runner);
@@ -378,6 +657,17 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
                 "-F",
                 "tmTextUnitIds[]=100",
             ]),
+        );
+    });
+
+    test("textunitInfo passes every locale tag as a raw array field", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitInfo({ tmTextUnitId: 100, localeTags: ["fr-FR", "ja-JP"] });
+
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["-f", "localeTags[]=fr-FR", "-f", "localeTags[]=ja-JP"]),
         );
     });
 
@@ -411,6 +701,25 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
         expect(runner.calls[0]).toEqual(expect.arrayContaining(["-F", "tmTextUnitId=1"]));
         expect(runner.calls[0]).toEqual(expect.arrayContaining(["-F", "localeId=2"]));
         expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "target=Bonjour"]));
+    });
+
+    test("textunitTranslationAdd preserves empty comments and false inclusion", async () => {
+        const runner = mockRunner(() => okJson({}));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitTranslationAdd({
+            tmTextUnitId: 1,
+            localeId: 2,
+            target: "",
+            targetComment: "",
+            includedInLocalizedFile: false,
+        });
+
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "target="]));
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "targetComment="]));
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["-F", "includedInLocalizedFile=false"]),
+        );
     });
 
     test("reviewUpdate maps accept to APPROVED and includedInLocalizedFile true", async () => {
@@ -449,6 +758,28 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
         );
     });
 
+    test.each([
+        ["review", "REVIEW_NEEDED", true],
+        ["translate", "TRANSLATION_NEEDED", true],
+    ] as const)("reviewUpdate maps %s to %s and inclusion %s", async (action, status, included) => {
+        const runner = mockRunner(() => okJson({}));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.reviewUpdate({
+            tmTextUnitId: 1,
+            localeId: 2,
+            target: "Hi",
+            targetComment: "",
+            action,
+        });
+
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", `status=${status}`]));
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["-F", `includedInLocalizedFile=${included}`]),
+        );
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "targetComment="]));
+    });
+
     test("pollabletaskGet GETs by id", async () => {
         const runner = mockRunner(() => okJson({ id: 3 }));
         const client = new MojitoCliClient(config, runner);
@@ -472,10 +803,40 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
         });
     });
 
+    test("non-zero exit with blank stderr uses an exit-code summary", async () => {
+        const runner = mockRunner(() => ({ exitCode: 17, stdout: "", stderr: "   " }));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.repoView(999)).rejects.toMatchObject({
+            message: "mojito CLI exited with code 17",
+            exitCode: 17,
+            stderr: "   ",
+        });
+    });
+
     test("successful JSON stdout is parsed and returned", async () => {
         const runner = mockRunner(() => okJson([{ id: 1 }]));
         const client = new MojitoCliClient(config, runner);
 
         await expect(client.repoList()).resolves.toEqual([{ id: 1 }]);
+    });
+
+    test("successful empty stdout returns null", async () => {
+        const runner = mockRunner(() => ({ exitCode: 0, stdout: " \n ", stderr: "" }));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.repoDelete(1)).resolves.toBeNull();
+    });
+
+    test("successful non-JSON stdout throws MojitoCliError and preserves stdout", async () => {
+        const runner = mockRunner(() => ({ exitCode: 0, stdout: "not json", stderr: "" }));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.repoList()).rejects.toMatchObject({
+            name: "MojitoCliError",
+            message: "Failed to parse mojito CLI JSON stdout",
+            stdout: "not json",
+            cause: expect.any(SyntaxError),
+        });
     });
 });

--- a/mojito-mcp/tests/mojito-client.test.ts
+++ b/mojito-mcp/tests/mojito-client.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "@jest/globals";
+import type { CliRunResult, CliRunner } from "../src/cli-runner.js";
+import { MojitoCliError } from "../src/errors.js";
+import { MojitoCliClient } from "../src/mojito-client.js";
+
+function mockRunner(
+    handler: (argv: string[]) => Promise<CliRunResult> | CliRunResult,
+): CliRunner & { calls: string[][] } {
+    const calls: string[][] = [];
+    return {
+        calls,
+        async run(argv: string[]) {
+            calls.push([...argv]);
+            return handler(argv);
+        },
+    };
+}
+
+function okJson(body: unknown): CliRunResult {
+    return { exitCode: 0, stdout: JSON.stringify(body), stderr: "" };
+}
+
+const config = { cliBinary: "mojito-prod", timeoutMs: 60_000 };
+
+describe("MojitoCliClient (CLI argv contracts)", () => {
+    test("probeHelp runs --help and succeeds on exit 0", async () => {
+        const runner = mockRunner(() => ({ exitCode: 0, stdout: "usage", stderr: "" }));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.probeHelp()).resolves.toBeUndefined();
+        expect(runner.calls[0]).toEqual(["--help"]);
+    });
+
+    test("probeHelp throws MojitoCliError on non-zero exit", async () => {
+        const runner = mockRunner(() => ({
+            exitCode: 1,
+            stdout: "",
+            stderr: "command not found",
+        }));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.probeHelp()).rejects.toBeInstanceOf(MojitoCliError);
+    });
+
+    test("repoList does not paginate: the endpoint returns every repository at once", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoList();
+        expect(runner.calls[0]).toEqual(["api", "/api/repositories"]);
+    });
+
+    test("repoList adds name filter as -f", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoList({ name: "my-repo" });
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "name=my-repo"]));
+    });
+
+    test("repoView GETs by id", async () => {
+        const runner = mockRunner(() => okJson({ id: 42 }));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoView(42);
+        expect(runner.calls[0]).toEqual(["api", "/api/repositories/42"]);
+    });
+
+    test("repoCreate POSTs with -X POST", async () => {
+        const runner = mockRunner(() => okJson({ id: 1, name: "r" }));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoCreate({ name: "r", description: "d" });
+        expect(runner.calls[0][0]).toBe("api");
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["/api/repositories", "-X", "POST"]),
+        );
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "name=r"]));
+    });
+
+    test("repoDelete uses -X DELETE", async () => {
+        const runner = mockRunner(() => ({ exitCode: 0, stdout: "", stderr: "" }));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoDelete(9);
+        expect(runner.calls[0]).toEqual(["api", "/api/repositories/9", "-X", "DELETE"]);
+    });
+
+    test("textunitSearch POSTs search with pagination flags", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitSearch({
+            repositoryNames: ["demo"],
+            source: "Hello",
+            searchType: "CONTAINS",
+            localeTags: ["fr-FR"],
+        });
+
+        const argv = runner.calls[0];
+        expect(argv).toEqual(
+            expect.arrayContaining([
+                "api",
+                "/api/textunits/search",
+                "-X",
+                "POST",
+                "--paginate",
+                "--slurp",
+                "--max-pages",
+                "0",
+            ]),
+        );
+        expect(argv).toEqual(expect.arrayContaining(["-f", "repositoryNames[]=demo"]));
+        expect(argv).toEqual(expect.arrayContaining(["-f", "source=Hello"]));
+        expect(argv).toEqual(expect.arrayContaining(["-f", "searchType=CONTAINS"]));
+        expect(argv).toEqual(expect.arrayContaining(["-f", "localeTags[]=fr-FR"]));
+    });
+
+    test("textunitSearch with an explicit limit skips pagination", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitSearch({
+            repositoryNames: ["demo"],
+            searchType: "CONTAINS",
+            limit: 5,
+        });
+
+        const argv = runner.calls[0];
+        expect(argv).not.toContain("--paginate");
+        expect(argv).toEqual(expect.arrayContaining(["-F", "limit=5"]));
+    });
+
+    test("textunitSearch with no repos lists all repos then searches with ids", async () => {
+        const runner = mockRunner((argv) => {
+            if (argv.includes("/api/repositories")) {
+                return okJson([
+                    { id: 1, name: "a" },
+                    { id: 2, name: "b" },
+                ]);
+            }
+            return okJson([]);
+        });
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitSearch({ source: "x", searchType: "CONTAINS" });
+
+        expect(runner.calls.length).toBeGreaterThanOrEqual(2);
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["api", "/api/repositories"]));
+        const searchArgv = runner.calls.find((c) => c.includes("/api/textunits/search"));
+        expect(searchArgv).toEqual(expect.arrayContaining(["-F", "repositoryIds[]=1"]));
+        expect(searchArgv).toEqual(expect.arrayContaining(["-F", "repositoryIds[]=2"]));
+    });
+
+    test("textunitInfo searches by tmTextUnitIds", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitInfo({ tmTextUnitId: 100 });
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining([
+                "api",
+                "/api/textunits/search",
+                "-X",
+                "POST",
+                "-F",
+                "tmTextUnitIds[]=100",
+            ]),
+        );
+    });
+
+    test("textunitHistory requires bcp47Tag query field", async () => {
+        const runner = mockRunner(() => okJson([]));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitHistory({ tmTextUnitId: 5, bcp47Tag: "ja-JP" });
+        expect(runner.calls[0]).toEqual([
+            "api",
+            "/api/textunits/5/history",
+            "-f",
+            "bcp47Tag=ja-JP",
+        ]);
+    });
+
+    test("textunitTranslationAdd POSTs typed fields", async () => {
+        const runner = mockRunner(() => okJson({}));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.textunitTranslationAdd({
+            tmTextUnitId: 1,
+            localeId: 2,
+            target: "Bonjour",
+            status: "APPROVED",
+        });
+
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["api", "/api/textunits", "-X", "POST"]),
+        );
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-F", "tmTextUnitId=1"]));
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-F", "localeId=2"]));
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "target=Bonjour"]));
+    });
+
+    test("reviewUpdate maps accept to APPROVED and includedInLocalizedFile true", async () => {
+        const runner = mockRunner(() => okJson({}));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.reviewUpdate({
+            tmTextUnitId: 1,
+            localeId: 2,
+            target: "Hi",
+            action: "accept",
+        });
+
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "status=APPROVED"]));
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["-F", "includedInLocalizedFile=true"]),
+        );
+    });
+
+    test("reviewUpdate maps reject to TRANSLATION_NEEDED and includedInLocalizedFile false", async () => {
+        const runner = mockRunner(() => okJson({}));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.reviewUpdate({
+            tmTextUnitId: 1,
+            localeId: 2,
+            target: "Hi",
+            action: "reject",
+        });
+
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["-f", "status=TRANSLATION_NEEDED"]),
+        );
+        expect(runner.calls[0]).toEqual(
+            expect.arrayContaining(["-F", "includedInLocalizedFile=false"]),
+        );
+    });
+
+    test("pollabletaskGet GETs by id", async () => {
+        const runner = mockRunner(() => okJson({ id: 3 }));
+        const client = new MojitoCliClient(config, runner);
+
+        await client.pollabletaskGet(3);
+        expect(runner.calls[0]).toEqual(["api", "/api/pollableTasks/3"]);
+    });
+
+    test("non-zero exit throws MojitoCliError including stderr", async () => {
+        const runner = mockRunner(() => ({
+            exitCode: 1,
+            stdout: '{"message":"nope"}',
+            stderr: "mojito: nope (HTTP 404)",
+        }));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.repoView(999)).rejects.toMatchObject({
+            name: "MojitoCliError",
+            exitCode: 1,
+            stderr: expect.stringContaining("mojito:"),
+        });
+    });
+
+    test("successful JSON stdout is parsed and returned", async () => {
+        const runner = mockRunner(() => okJson([{ id: 1 }]));
+        const client = new MojitoCliClient(config, runner);
+
+        await expect(client.repoList()).resolves.toEqual([{ id: 1 }]);
+    });
+});

--- a/mojito-mcp/tests/mojito-client.test.ts
+++ b/mojito-mcp/tests/mojito-client.test.ts
@@ -1,7 +1,24 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
 import type { CliRunResult, CliRunner } from "../src/cli-runner.js";
 import { MojitoCliError } from "../src/errors.js";
-import { MojitoCliClient } from "../src/mojito-client.js";
+import { MojitoCliClient, parseEncodedRepositoryLocale } from "../src/mojito-client.js";
 
 function mockRunner(
     handler: (argv: string[]) => Promise<CliRunResult> | CliRunResult,
@@ -21,6 +38,153 @@ function okJson(body: unknown): CliRunResult {
 }
 
 const config = { cliBinary: "mojito-prod", timeoutMs: 60_000 };
+
+describe("parseEncodedRepositoryLocale", () => {
+    test("fully translated locale with no parent", () => {
+        expect(parseEncodedRepositoryLocale("fr-FR")).toEqual({
+            locale: { bcp47Tag: "fr-FR" },
+            toBeFullyTranslated: true,
+        });
+    });
+
+    test("not fully translated locale with parentheses", () => {
+        expect(parseEncodedRepositoryLocale("(en-GB)")).toEqual({
+            locale: { bcp47Tag: "en-GB" },
+            toBeFullyTranslated: false,
+        });
+    });
+
+    test("inherits from parent and is not fully translated", () => {
+        expect(parseEncodedRepositoryLocale("(fr-CA)->fr-FR")).toEqual({
+            locale: { bcp47Tag: "fr-CA" },
+            toBeFullyTranslated: false,
+            parentLocale: {
+                locale: { bcp47Tag: "fr-FR" },
+            },
+        });
+    });
+
+    test("inherits from parent while remaining fully translated", () => {
+        expect(parseEncodedRepositoryLocale("fr-CA->fr-FR")).toEqual({
+            locale: { bcp47Tag: "fr-CA" },
+            toBeFullyTranslated: true,
+            parentLocale: {
+                locale: { bcp47Tag: "fr-FR" },
+            },
+        });
+    });
+
+    test("builds a multi-level parent chain", () => {
+        expect(parseEncodedRepositoryLocale("fr-CA->fr-FR->en-US")).toEqual({
+            locale: { bcp47Tag: "fr-CA" },
+            toBeFullyTranslated: true,
+            parentLocale: {
+                locale: { bcp47Tag: "fr-FR" },
+                parentLocale: {
+                    locale: { bcp47Tag: "en-US" },
+                },
+            },
+        });
+    });
+
+    test("parentheses on any segment mark the locale as not fully translated", () => {
+        expect(parseEncodedRepositoryLocale("fr-CA->(fr-FR)")).toEqual({
+            locale: { bcp47Tag: "fr-CA" },
+            toBeFullyTranslated: false,
+            parentLocale: {
+                locale: { bcp47Tag: "fr-FR" },
+            },
+        });
+    });
+
+    test("trims whitespace around segments and the arrow", () => {
+        expect(parseEncodedRepositoryLocale("  (fr-CA)  ->  fr-FR  ")).toEqual({
+            locale: { bcp47Tag: "fr-CA" },
+            toBeFullyTranslated: false,
+            parentLocale: {
+                locale: { bcp47Tag: "fr-FR" },
+            },
+        });
+    });
+
+    test("accepts simple language tags without region", () => {
+        expect(parseEncodedRepositoryLocale("ja")).toEqual({
+            locale: { bcp47Tag: "ja" },
+            toBeFullyTranslated: true,
+        });
+    });
+
+    test("throws on empty string", () => {
+        expect(() => parseEncodedRepositoryLocale("")).toThrow(MojitoCliError);
+        expect(() => parseEncodedRepositoryLocale("")).toThrow(/Invalid encoded repository locale/);
+    });
+
+    test("throws on whitespace-only string", () => {
+        expect(() => parseEncodedRepositoryLocale("   ")).toThrow(MojitoCliError);
+    });
+
+    test("throws when the child segment before -> is empty", () => {
+        expect(() => parseEncodedRepositoryLocale("->fr-FR")).toThrow(MojitoCliError);
+    });
+
+    test("unbalanced parentheses are treated as a literal bcp47 tag", () => {
+        expect(parseEncodedRepositoryLocale("(fr-FR")).toEqual({
+            locale: { bcp47Tag: "(fr-FR" },
+            toBeFullyTranslated: true,
+        });
+        expect(parseEncodedRepositoryLocale("fr-FR)")).toEqual({
+            locale: { bcp47Tag: "fr-FR)" },
+            toBeFullyTranslated: true,
+        });
+    });
+
+    test("nested parentheses strip only the outer pair", () => {
+        expect(parseEncodedRepositoryLocale("((fr-FR))")).toEqual({
+            locale: { bcp47Tag: "(fr-FR)" },
+            toBeFullyTranslated: false,
+        });
+    });
+
+    test("empty parent segment after -> becomes an empty-tag parent node", () => {
+        expect(parseEncodedRepositoryLocale("fr-FR->")).toEqual({
+            locale: { bcp47Tag: "fr-FR" },
+            toBeFullyTranslated: true,
+            parentLocale: {
+                locale: { bcp47Tag: "" },
+            },
+        });
+    });
+
+    test("parentheses at more than one level of a derived chain", () => {
+        expect(parseEncodedRepositoryLocale("(es-MX)->(es-ES)->en-US")).toEqual({
+            locale: { bcp47Tag: "es-MX" },
+            toBeFullyTranslated: false,
+            parentLocale: {
+                locale: { bcp47Tag: "es-ES" },
+                parentLocale: {
+                    locale: { bcp47Tag: "en-US" },
+                },
+            },
+        });
+    });
+
+    test("comma is not a separator: a comma-separated list stays one literal tag", () => {
+        expect(parseEncodedRepositoryLocale("de-DE,fr-FR")).toEqual({
+            locale: { bcp47Tag: "de-DE,fr-FR" },
+            toBeFullyTranslated: true,
+        });
+    });
+
+    test("commas inside a derived chain stay part of each segment's tag", () => {
+        expect(parseEncodedRepositoryLocale("(fr-CA,fr-BE)->fr-FR")).toEqual({
+            locale: { bcp47Tag: "fr-CA,fr-BE" },
+            toBeFullyTranslated: false,
+            parentLocale: {
+                locale: { bcp47Tag: "fr-FR" },
+            },
+        });
+    });
+});
 
 describe("MojitoCliClient (CLI argv contracts)", () => {
     test("probeHelp runs --help and succeeds on exit 0", async () => {
@@ -76,6 +240,54 @@ describe("MojitoCliClient (CLI argv contracts)", () => {
             expect.arrayContaining(["/api/repositories", "-X", "POST"]),
         );
         expect(runner.calls[0]).toEqual(expect.arrayContaining(["-f", "name=r"]));
+    });
+
+    test("repoCreate sends a list of locales with several derived locales as JSON body", async () => {
+        let body: Record<string, unknown> | undefined;
+        // The temp body file is deleted once the call returns, so read it inside the runner.
+        const runner = mockRunner((argv) => {
+            const file = argv[argv.indexOf("--input") + 1];
+            body = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+            return okJson({ id: 1, name: "multi" });
+        });
+        const client = new MojitoCliClient(config, runner);
+
+        await client.repoCreate({
+            name: "multi",
+            sourceLocale: "en-US",
+            repositoryLocales: [
+                "de-DE",
+                "(en-GB)",
+                "(fr-CA)->fr-FR",
+                "(es-MX)->es-ES",
+                "(pt-BR)->pt-PT->en-US",
+            ],
+        });
+
+        expect(runner.calls[0]).toEqual(expect.arrayContaining(["--input"]));
+        expect(body?.sourceLocale).toEqual({ bcp47Tag: "en-US" });
+        expect(body?.repositoryLocales).toEqual([
+            { locale: { bcp47Tag: "de-DE" }, toBeFullyTranslated: true },
+            { locale: { bcp47Tag: "en-GB" }, toBeFullyTranslated: false },
+            {
+                locale: { bcp47Tag: "fr-CA" },
+                toBeFullyTranslated: false,
+                parentLocale: { locale: { bcp47Tag: "fr-FR" } },
+            },
+            {
+                locale: { bcp47Tag: "es-MX" },
+                toBeFullyTranslated: false,
+                parentLocale: { locale: { bcp47Tag: "es-ES" } },
+            },
+            {
+                locale: { bcp47Tag: "pt-BR" },
+                toBeFullyTranslated: false,
+                parentLocale: {
+                    locale: { bcp47Tag: "pt-PT" },
+                    parentLocale: { locale: { bcp47Tag: "en-US" } },
+                },
+            },
+        ]);
     });
 
     test("repoDelete uses -X DELETE", async () => {

--- a/mojito-mcp/tests/tool-surface.test.ts
+++ b/mojito-mcp/tests/tool-surface.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "@jest/globals";
+import { MOJITO_MCP_TOOL_IDS } from "../src/tool-metadata.js";
+import { expectedToolCount } from "../src/server.js";
+
+describe("MCP tool surface", () => {
+    test("exports a stable ordered list of tool ids", () => {
+        expect(MOJITO_MCP_TOOL_IDS).toEqual([
+            "mojito_repo_list",
+            "mojito_repo_view",
+            "mojito_repo_create",
+            "mojito_repo_delete",
+            "mojito_textunit_search",
+            "mojito_textunit_info",
+            "mojito_textunit_history",
+            "mojito_textunit_translation_add",
+            "mojito_review_update",
+            "mojito_pollabletask_get",
+        ]);
+    });
+
+    test("tool ids are unique", () => {
+        expect(new Set(MOJITO_MCP_TOOL_IDS).size).toBe(MOJITO_MCP_TOOL_IDS.length);
+    });
+
+    test("expectedToolCount matches MOJITO_MCP_TOOL_IDS", () => {
+        expect(expectedToolCount()).toBe(MOJITO_MCP_TOOL_IDS.length);
+    });
+
+    test("all tool ids follow mojito_<object>_<action> shape", () => {
+        for (const id of MOJITO_MCP_TOOL_IDS) {
+            expect(id.startsWith("mojito_")).toBe(true);
+            const parts = id.split("_");
+            expect(parts.length).toBeGreaterThanOrEqual(3);
+        }
+    });
+});

--- a/mojito-mcp/tests/tool-surface.test.ts
+++ b/mojito-mcp/tests/tool-surface.test.ts
@@ -14,9 +14,63 @@
  * limitations under the License.
  */
 
+/**
+ * Test scenarios: the published tool surface.
+ *
+ * Tool ids are the API this server exposes to AI agents, and they are also quoted by
+ * name in README.md and SKILL.md. Renaming or reordering one silently breaks agent
+ * prompts and skills that reference it, so these tests treat the list as a contract
+ * rather than an implementation detail.
+ *
+ * 1. The exact list, in order. Spelling the ten ids out literally means any rename,
+ *    removal, addition, or reshuffle shows up as a failing test and therefore as a
+ *    deliberate diff a reviewer has to approve, not an accident.
+ * 2. No duplicate ids. A repeated id would silently shadow one tool with another during
+ *    registration, leaving the agent with a tool that quietly does the wrong thing.
+ * 3. The count the server reports matches the list. `expectedToolCount()` is what other
+ *    tests and docs parity checks lean on, so it must not drift from the ids themselves.
+ * 4. Every id follows the `mojito_<object>_<action>` convention. The naming scheme is
+ *    what lets an agent guess a tool's purpose from its name, so it is enforced rather
+ *    than just documented.
+ * 5. The registrations made against McpServer exactly match the canonical list. This
+ *    closes the dangerous gap where metadata could advertise a tool that the server
+ *    forgot to register, or registration could expose an undocumented extra tool.
+ * 6. Every registered tool has a non-empty description. Tool descriptions are the model's
+ *    primary instructions, so a nameless contract is not sufficient.
+ * 7. Numeric identifiers reject zero, negative, and fractional values at the MCP boundary,
+ *    while search offset deliberately accepts zero.
+ * 8. README.md and SKILL.md mention every published id, keeping human setup docs and agent
+ *    operating guidance synchronized with the server.
+ */
+
 import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { MojitoCliClient } from "../src/mojito-client.js";
+import { registerMojitoTools } from "../src/register-tools.js";
 import { MOJITO_MCP_TOOL_IDS } from "../src/tool-metadata.js";
 import { expectedToolCount } from "../src/server.js";
+
+type Schema = { safeParse(value: unknown): { success: boolean } };
+type Registration = {
+    name: string;
+    options: {
+        description?: string;
+        inputSchema: Record<string, Schema>;
+    };
+};
+
+function captureRegistrations(): Registration[] {
+    const registrations: Registration[] = [];
+    const server = {
+        registerTool(name: string, options: Registration["options"]) {
+            registrations.push({ name, options });
+        },
+    } as unknown as McpServer;
+
+    registerMojitoTools(server, {} as MojitoCliClient);
+    return registrations;
+}
 
 describe("MCP tool surface", () => {
     test("exports a stable ordered list of tool ids", () => {
@@ -47,6 +101,45 @@ describe("MCP tool surface", () => {
             expect(id.startsWith("mojito_")).toBe(true);
             const parts = id.split("_");
             expect(parts.length).toBeGreaterThanOrEqual(3);
+        }
+    });
+
+    test("registered tool ids exactly match the canonical list", () => {
+        expect(captureRegistrations().map(({ name }) => name)).toEqual(MOJITO_MCP_TOOL_IDS);
+    });
+
+    test("every registered tool has a non-empty description", () => {
+        for (const { options } of captureRegistrations()) {
+            expect(options.description?.trim()).not.toBe("");
+        }
+    });
+
+    test("numeric id, limit, and offset schemas enforce their boundaries", () => {
+        const byName = new Map(captureRegistrations().map((entry) => [entry.name, entry]));
+        const repositoryId = byName.get("mojito_repo_view")!.options.inputSchema.repositoryId;
+        expect(repositoryId.safeParse(1).success).toBe(true);
+        expect(repositoryId.safeParse(0).success).toBe(false);
+        expect(repositoryId.safeParse(-1).success).toBe(false);
+        expect(repositoryId.safeParse(1.5).success).toBe(false);
+
+        const search = byName.get("mojito_textunit_search")!.options.inputSchema;
+        expect(search.limit.safeParse(1).success).toBe(true);
+        expect(search.limit.safeParse(0).success).toBe(false);
+        expect(search.offset.safeParse(0).success).toBe(true);
+        expect(search.offset.safeParse(-1).success).toBe(false);
+        expect(search.offset.safeParse(1.5).success).toBe(false);
+    });
+
+    test("README and SKILL mention every published tool id", () => {
+        const docs = [
+            readFileSync(new URL("../README.md", import.meta.url), "utf8"),
+            readFileSync(new URL("../SKILL.md", import.meta.url), "utf8"),
+        ];
+
+        for (const document of docs) {
+            for (const toolId of MOJITO_MCP_TOOL_IDS) {
+                expect(document).toContain(toolId);
+            }
         }
     });
 });

--- a/mojito-mcp/tests/tool-surface.test.ts
+++ b/mojito-mcp/tests/tool-surface.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "@jest/globals";
 import { MOJITO_MCP_TOOL_IDS } from "../src/tool-metadata.js";
 import { expectedToolCount } from "../src/server.js";

--- a/mojito-mcp/tsconfig.json
+++ b/mojito-mcp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/restclient/src/test/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerTypeTest.java
+++ b/restclient/src/test/java/com/box/l10n/mojito/rest/entity/IntegrityCheckerTypeTest.java
@@ -25,8 +25,7 @@ public class IntegrityCheckerTypeTest {
   @Test
   public void everyTypeDeserializesInACheckerPayload() throws Exception {
     for (IntegrityCheckerType type : IntegrityCheckerType.values()) {
-      String json =
-          "{\"assetExtension\":\"ftl\",\"integrityCheckerType\":\"" + type.name() + "\"}";
+      String json = "{\"assetExtension\":\"ftl\",\"integrityCheckerType\":\"" + type.name() + "\"}";
       IntegrityChecker checker = objectMapper.readValue(json, IntegrityChecker.class);
       assertEquals(type.name(), "ftl", checker.getAssetExtension());
       assertEquals(type.name(), type, checker.getIntegrityCheckerType());


### PR DESCRIPTION
## Summary

Adds **`mojito-mcp`**, a standalone Node package (not a Maven module) that exposes a curated set of Mojito REST operations to AI hosts (Cursor, Claude Code, and other MCP clients).

Agents do **not** talk to Mojito over HTTP with tokens in the MCP env. The server shells out to the engineer’s existing Mojito CLI (`mojito api …`). If `mojito-prod api /api/repositories` works in a terminal, the corresponding MCP tools work the same way: host, auth (form login, MSAL, CF Access, etc.), and cookies stay in the CLI Spring config under `~/.l10n/…`.

```
Cursor / Claude Code
  └─ mojito-mcp (stdio)
       └─ spawn(MOJITO_CLI, ["api", …])   // stdout/stderr captured, never mixed into MCP stdio
            └─ Mojito CLI → REST /api/…
```

`MOJITO_CLI` defaults to `mojito-prod`. A second **`mojito-dev`** wrapper and MCP server entry is **optional** and only useful if you run a local or non-prod Mojito.

### Tools (`mojito_<object>_<action>`)

| Area | Tools |
|------|--------|
| Repository | `mojito_repo_list`, `mojito_repo_view`, `mojito_repo_create`, `mojito_repo_delete` |
| Text units | `mojito_textunit_search` (workbench-style filters), `mojito_textunit_info`, `mojito_textunit_history`, `mojito_textunit_translation_add` |
| Review | `mojito_review_update` (`accept` / `review` / `translate` / `reject`) |
| Async | `mojito_pollabletask_get` (status only; v1 does not `--wait`) |

List/search tools use CLI `--paginate --slurp` (unbounded page cap where the endpoint actually pages). Write tools should be used carefully on prod.

### Out of scope for this PR (v1)

- Reimplementing Mojito auth or a generic “raw API” MCP tool
- Drop export/import with `--wait`
- Publishing the package to npm (still `private`, `0.1.0-SNAPSHOT`); README describes `npm install -g` once a registry exists

### Docs and packaging

- [mojito-mcp/README.md](mojito-mcp/README.md): download `mojito-cli.jar` from `{instance}/cli/mojito-cli.jar`, example prod/dev wrappers, global install + Cursor `mcp.json` / `claude mcp add` (absolute binary path, not `npx`)
- [mojito-mcp/Architecture.md](mojito-mcp/Architecture.md): design notes
- [mojito-mcp/SKILL.md](mojito-mcp/SKILL.md): agent workflow (repo name matching, which tool to call)
- [mojito-mcp/LICENSE](mojito-mcp/LICENSE): Apache-2.0, same as Mojito

## Test plan

- [ ] `cd mojito-mcp && npm install && npm test` (Jest unit tests with a fake CLI runner: argv, errors, timeouts, tool-id surface)
- [ ] `npm run build` produces `dist/index.js`
- [ ] With a working CLI: `mojito-prod --help` and `mojito-prod api /api/repositories`
- [ ] Optional: copy `tests-integration/integration-config.template.json` → `integration-config.json` and run `npm run test:integration` against **dev** only (creates/views/deletes a disposable repo)
- [ ] Point Cursor or Claude Code at the built (or globally installed) binary with `MOJITO_CLI` set; smoke `mojito_repo_list` (and a read-only `mojito_textunit_search` if using prod)


Made with [Cursor](https://cursor.com)