### PR TITLE
Repo Type List

### DIFF
--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeListCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeListCommand.java
@@ -1,0 +1,82 @@
+package com.box.l10n.mojito.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import com.box.l10n.mojito.rest.entity.RepoType;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * Lists every repo type. Default prints id, name, description, and whether an AI prompt is set.
+ * {@code --verbose} prints the prompt body (same as {@code repo-type-view}).
+ */
+@Component
+@Scope("prototype")
+@Parameters(
+    commandNames = {"repo-type-list"},
+    commandDescription = "List all repo types")
+public class RepoTypeListCommand extends Command {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeListCommand.class);
+
+  @Autowired ConsoleWriter consoleWriter;
+
+  @Autowired RepoTypeClient repoTypeClient;
+
+  @Parameter(
+      names = {Param.REPO_TYPE_LIST_VERBOSE_LONG},
+      arity = 0,
+      required = false,
+      description = Param.REPO_TYPE_LIST_VERBOSE_DESCRIPTION)
+  boolean verboseParam = false;
+
+  @Override
+  protected void execute() throws CommandException {
+    consoleWriter.a("List repo types").println();
+
+    try {
+      List<RepoType> repoTypes = repoTypeClient.getRepoTypes(null);
+      if (repoTypes.isEmpty()) {
+        consoleWriter.newLine().a("No repo types found").println();
+        return;
+      }
+      for (RepoType repoType : repoTypes) {
+        printRepoType(repoType);
+      }
+    } catch (HttpClientErrorException ex) {
+      throw CommandHelper.repoTypeClientError(ex);
+    }
+  }
+
+  private void printRepoType(RepoType repoType) {
+    String description = repoType.getDescription() != null ? repoType.getDescription() : "";
+    String aiPrompt = aiPromptLine(repoType.getAiPrompt());
+
+    consoleWriter
+        .newLine()
+        .a("Repo type id --> ")
+        .fg(Ansi.Color.MAGENTA)
+        .a(repoType.getId())
+        .println();
+    consoleWriter.a("Name --> ").fg(Ansi.Color.MAGENTA).a(repoType.getName()).println();
+    consoleWriter.a("Description --> ").fg(Ansi.Color.MAGENTA).a(description).println();
+    consoleWriter.a("AI prompt --> ").fg(Ansi.Color.MAGENTA).a(aiPrompt).println();
+  }
+
+  String aiPromptLine(String aiPrompt) {
+    if (verboseParam) {
+      return aiPrompt != null ? aiPrompt : "";
+    }
+    return StringUtils.isNotBlank(aiPrompt) ? "set" : "";
+  }
+}

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeListCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeListCommand.java
@@ -16,9 +16,9 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 /**
- * Lists every repo type. Default prints id, name, description, and {@code set} when the AI prompt
- * is non-empty (body omitted). {@code --verbose} / {@code -vb} prints the prompt body (same as
- * {@code repo-type-view}).
+ * Lists every repo type. Default prints id, name, description, and {@code contains a value} when
+ * the AI prompt is non-empty (body omitted). {@code --verbose} / {@code -vb} prints the prompt body
+ * (same as {@code repo-type-view}).
  */
 @Component
 @Scope("prototype")
@@ -73,6 +73,6 @@ public class RepoTypeListCommand extends Command {
     if (verboseParam) {
       return aiPrompt != null ? aiPrompt : "";
     }
-    return StringUtils.isNotEmpty(aiPrompt) ? "set" : "";
+    return StringUtils.isNotEmpty(aiPrompt) ? "contains a value" : "";
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeListCommand.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/RepoTypeListCommand.java
@@ -14,11 +14,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
 
 /**
- * Lists every repo type. Default prints id, name, description, and whether an AI prompt is set.
- * {@code --verbose} prints the prompt body (same as {@code repo-type-view}).
+ * Lists every repo type. Default prints id, name, description, and {@code set} when the AI prompt
+ * is non-empty (body omitted). {@code --verbose} / {@code -vb} prints the prompt body (same as
+ * {@code repo-type-view}).
  */
 @Component
 @Scope("prototype")
@@ -34,9 +34,8 @@ public class RepoTypeListCommand extends Command {
   @Autowired RepoTypeClient repoTypeClient;
 
   @Parameter(
-      names = {Param.REPO_TYPE_LIST_VERBOSE_LONG},
+      names = {Param.REPO_TYPE_LIST_VERBOSE_LONG, Param.REPO_TYPE_LIST_VERBOSE_SHORT},
       arity = 0,
-      required = false,
       description = Param.REPO_TYPE_LIST_VERBOSE_DESCRIPTION)
   boolean verboseParam = false;
 
@@ -44,17 +43,13 @@ public class RepoTypeListCommand extends Command {
   protected void execute() throws CommandException {
     consoleWriter.a("List repo types").println();
 
-    try {
-      List<RepoType> repoTypes = repoTypeClient.getRepoTypes(null);
-      if (repoTypes.isEmpty()) {
-        consoleWriter.newLine().a("No repo types found").println();
-        return;
-      }
-      for (RepoType repoType : repoTypes) {
-        printRepoType(repoType);
-      }
-    } catch (HttpClientErrorException ex) {
-      throw CommandHelper.repoTypeClientError(ex);
+    List<RepoType> repoTypes = repoTypeClient.getRepoTypes(null);
+    if (repoTypes.isEmpty()) {
+      consoleWriter.newLine().a("No repo types found").println();
+      return;
+    }
+    for (RepoType repoType : repoTypes) {
+      printRepoType(repoType);
     }
   }
 
@@ -71,12 +66,13 @@ public class RepoTypeListCommand extends Command {
     consoleWriter.a("Name --> ").fg(Ansi.Color.MAGENTA).a(repoType.getName()).println();
     consoleWriter.a("Description --> ").fg(Ansi.Color.MAGENTA).a(description).println();
     consoleWriter.a("AI prompt --> ").fg(Ansi.Color.MAGENTA).a(aiPrompt).println();
+    consoleWriter.println();
   }
 
   String aiPromptLine(String aiPrompt) {
     if (verboseParam) {
       return aiPrompt != null ? aiPrompt : "";
     }
-    return StringUtils.isNotBlank(aiPrompt) ? "set" : "";
+    return StringUtils.isNotEmpty(aiPrompt) ? "set" : "";
   }
 }

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
@@ -99,7 +99,8 @@ public class Param {
   public static final String REPO_TYPE_LIST_VERBOSE_SHORT = "-vb";
   public static final String REPO_TYPE_LIST_VERBOSE_DESCRIPTION =
       "Print the full AI prompt body for each type (same as repo-type-view). Default prints"
-          + " set when the prompt is non-empty (including whitespace-only), not the body";
+          + " contains a value when the prompt is non-empty (including whitespace-only), not the"
+          + " body";
 
   public static final String REPOSITORY_LOCALES_LONG = "--locales";
   public static final String REPOSITORY_LOCALES_SHORT = "-l";

--- a/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
+++ b/cli/src/main/java/com/box/l10n/mojito/cli/command/param/Param.java
@@ -95,6 +95,12 @@ public class Param {
           + " (LF or CRLF) are not stored; newlines inside the file are kept. On update, an empty"
           + " file clears the prompt";
 
+  public static final String REPO_TYPE_LIST_VERBOSE_LONG = "--verbose";
+  public static final String REPO_TYPE_LIST_VERBOSE_SHORT = "-vb";
+  public static final String REPO_TYPE_LIST_VERBOSE_DESCRIPTION =
+      "Print the full AI prompt body for each type (same as repo-type-view). Default prints"
+          + " set when the prompt is non-empty (including whitespace-only), not the body";
+
   public static final String REPOSITORY_LOCALES_LONG = "--locales";
   public static final String REPOSITORY_LOCALES_SHORT = "-l";
   public static final String REPOSITORY_LOCALES_DESCRIPTION =

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandClientTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandClientTest.java
@@ -1,27 +1,21 @@
 package com.box.l10n.mojito.cli.command;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.box.l10n.mojito.cli.console.ConsoleWriter;
 import com.box.l10n.mojito.rest.client.RepoTypeClient;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.boot.test.system.OutputCaptureRule;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
 
 /**
  * {@code repo-type-list} {@code execute()} against a stubbed {@link RepoTypeClient} (no JCommander,
- * no HTTP). Empty list print and 4xx mapping.
+ * no HTTP). Empty list print only; HTTP errors are not mapped (same as {@code repo-type-view}).
  */
 public class RepoTypeListCommandClientTest {
 
@@ -49,43 +43,5 @@ public class RepoTypeListCommandClientTest {
     assertTrue(output.contains("List repo types"));
     assertTrue(output.contains("No repo types found"));
     assertFalse(output.contains("Repo type id -->"));
-  }
-
-  @Test
-  public void listHttpErrorDoesNotUseMutateNotFoundCopy() throws Exception {
-    when(repoTypeClient.getRepoTypes(null))
-        .thenThrow(
-            HttpClientErrorException.create(
-                HttpStatus.NOT_FOUND,
-                HttpStatus.NOT_FOUND.getReasonPhrase(),
-                HttpHeaders.EMPTY,
-                new byte[0],
-                StandardCharsets.UTF_8));
-
-    try {
-      command.execute();
-      fail("expected CommandException");
-    } catch (CommandException e) {
-      assertEquals("Failed to list repo types", e.getMessage());
-    }
-  }
-
-  @Test
-  public void listHttpErrorUsesResponseBodyWhenPresent() throws Exception {
-    when(repoTypeClient.getRepoTypes(null))
-        .thenThrow(
-            HttpClientErrorException.create(
-                HttpStatus.BAD_REQUEST,
-                HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                HttpHeaders.EMPTY,
-                "list request rejected".getBytes(StandardCharsets.UTF_8),
-                StandardCharsets.UTF_8));
-
-    try {
-      command.execute();
-      fail("expected CommandException");
-    } catch (CommandException e) {
-      assertEquals("list request rejected", e.getMessage());
-    }
   }
 }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandClientTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandClientTest.java
@@ -1,0 +1,91 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * {@code repo-type-list} {@code execute()} against a stubbed {@link RepoTypeClient} (no JCommander,
+ * no HTTP). Empty list print and 4xx mapping.
+ */
+public class RepoTypeListCommandClientTest {
+
+  @Rule public OutputCaptureRule outputCapture = new OutputCaptureRule();
+
+  RepoTypeClient repoTypeClient;
+  RepoTypeListCommand command;
+
+  @Before
+  public void setUp() {
+    repoTypeClient = mock(RepoTypeClient.class);
+    command = new RepoTypeListCommand();
+    command.repoTypeClient = repoTypeClient;
+    command.consoleWriter =
+        new ConsoleWriter(false, ConsoleWriter.OutputType.ANSI_CONSOLE_AND_LOGGER);
+  }
+
+  @Test
+  public void printsNoRepoTypesFoundAndNoTypeBlocks() throws Exception {
+    when(repoTypeClient.getRepoTypes(null)).thenReturn(Collections.emptyList());
+
+    command.execute();
+
+    String output = outputCapture.toString();
+    assertTrue(output.contains("List repo types"));
+    assertTrue(output.contains("No repo types found"));
+    assertFalse(output.contains("Repo type id -->"));
+  }
+
+  @Test
+  public void listHttpErrorDoesNotUseMutateNotFoundCopy() throws Exception {
+    when(repoTypeClient.getRepoTypes(null))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND,
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                HttpHeaders.EMPTY,
+                new byte[0],
+                StandardCharsets.UTF_8));
+
+    try {
+      command.execute();
+      fail("expected CommandException");
+    } catch (CommandException e) {
+      assertEquals("Failed to list repo types", e.getMessage());
+    }
+  }
+
+  @Test
+  public void listHttpErrorUsesResponseBodyWhenPresent() throws Exception {
+    when(repoTypeClient.getRepoTypes(null))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                HttpHeaders.EMPTY,
+                "list request rejected".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+    try {
+      command.execute();
+      fail("expected CommandException");
+    } catch (CommandException e) {
+      assertEquals("list request rejected", e.getMessage());
+    }
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
@@ -99,8 +99,7 @@ public class RepoTypeListCommandTest extends CLITestBase {
 
   static String typeBlock(String output, Long id) {
     Pattern start =
-        Pattern.compile(
-            "^" + Pattern.quote("Repo type id --> " + id) + "$", Pattern.MULTILINE);
+        Pattern.compile("^" + Pattern.quote("Repo type id --> " + id) + "$", Pattern.MULTILINE);
     Matcher matcher = start.matcher(output);
     assertTrue("missing output block for repo type id " + id, matcher.find());
     int from = matcher.start();

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
@@ -44,14 +44,14 @@ public class RepoTypeListCommandTest extends CLITestBase {
     String appleBlock = typeBlock(output, apple.getId());
     assertLabeledLine(appleBlock, "Name --> ", nameApple);
     assertLabeledLine(appleBlock, "Description --> ", "first type");
-    assertLabeledLine(appleBlock, "AI prompt --> ", "set");
+    assertLabeledLine(appleBlock, "AI prompt --> ", "contains a value");
     assertFalse(
         "Default list must not dump this type's AI prompt body (use --verbose)",
         appleBlock.contains(prompt));
 
     String spaceBlock = typeBlock(output, space.getId());
     assertLabeledLine(spaceBlock, "Name --> ", nameSpace);
-    assertLabeledLine(spaceBlock, "AI prompt --> ", "set");
+    assertLabeledLine(spaceBlock, "AI prompt --> ", "contains a value");
 
     String zebraBlock = typeBlock(output, zebra.getId());
     assertLabeledLine(zebraBlock, "Name --> ", nameZebra);
@@ -59,7 +59,7 @@ public class RepoTypeListCommandTest extends CLITestBase {
         "Null description must print an empty value after the label",
         Pattern.compile("Description --> $", Pattern.MULTILINE).matcher(zebraBlock).find());
     assertTrue(
-        "Empty AI prompt must print an empty value after the label, not \"set\"",
+        "Empty AI prompt must print an empty value after the label, not \"contains a value\"",
         Pattern.compile("AI prompt --> $", Pattern.MULTILINE).matcher(zebraBlock).find());
   }
 

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
@@ -2,16 +2,12 @@ package com.box.l10n.mojito.cli.command;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.box.l10n.mojito.cli.CLITestBase;
 import com.box.l10n.mojito.cli.command.param.Param;
-import com.box.l10n.mojito.cli.console.ConsoleWriter;
 import com.box.l10n.mojito.entity.RepoType;
-import com.box.l10n.mojito.rest.client.RepoTypeClient;
 import com.box.l10n.mojito.service.repotype.RepoTypeService;
-import java.util.Collections;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -27,10 +23,12 @@ public class RepoTypeListCommandTest extends CLITestBase {
   @Test
   public void testListAllRepoTypes() throws Exception {
     String nameApple = testIdWatcher.getEntityName("Apple");
+    String nameSpace = testIdWatcher.getEntityName("Space");
     String nameZebra = testIdWatcher.getEntityName("Zebra");
-    String prompt = "You are a React i18n expert — keep this body off the list";
+    String prompt = "compact-omit-body-" + nameApple;
 
     RepoType apple = repoTypeService.createRepoType(nameApple, "first type", prompt, null);
+    RepoType space = repoTypeService.createRepoType(nameSpace, "whitespace prompt", " ", null);
     RepoType zebra = repoTypeService.createRepoType(nameZebra, null, null, null);
 
     getL10nJCommander().run("repo-type-list");
@@ -39,39 +37,30 @@ public class RepoTypeListCommandTest extends CLITestBase {
     assertTrue(output.contains("List repo types"));
 
     int appleIdx = labeledLineIndex(output, "Name --> ", nameApple);
+    int spaceIdx = labeledLineIndex(output, "Name --> ", nameSpace);
     int zebraIdx = labeledLineIndex(output, "Name --> ", nameZebra);
-    assertTrue("Listed types must be ordered by name", appleIdx < zebraIdx);
+    assertTrue("Listed types must be ordered by name", appleIdx < spaceIdx && spaceIdx < zebraIdx);
 
-    assertLabeledLine(output, "Repo type id --> ", String.valueOf(apple.getId()));
-    assertLabeledLine(output, "Description --> ", "first type");
-    assertLabeledLine(output, "AI prompt --> ", "set");
-    assertLabeledLine(output, "Repo type id --> ", String.valueOf(zebra.getId()));
+    String appleBlock = typeBlock(output, apple.getId());
+    assertLabeledLine(appleBlock, "Name --> ", nameApple);
+    assertLabeledLine(appleBlock, "Description --> ", "first type");
+    assertLabeledLine(appleBlock, "AI prompt --> ", "set");
+    assertFalse(
+        "Default list must not dump this type's AI prompt body (use --verbose)",
+        appleBlock.contains(prompt));
+
+    String spaceBlock = typeBlock(output, space.getId());
+    assertLabeledLine(spaceBlock, "Name --> ", nameSpace);
+    assertLabeledLine(spaceBlock, "AI prompt --> ", "set");
+
+    String zebraBlock = typeBlock(output, zebra.getId());
+    assertLabeledLine(zebraBlock, "Name --> ", nameZebra);
     assertTrue(
         "Null description must print an empty value after the label",
-        Pattern.compile("Description --> $", Pattern.MULTILINE).matcher(output).find());
+        Pattern.compile("Description --> $", Pattern.MULTILINE).matcher(zebraBlock).find());
     assertTrue(
         "Empty AI prompt must print an empty value after the label, not \"set\"",
-        Pattern.compile("AI prompt --> $", Pattern.MULTILINE).matcher(output).find());
-    assertFalse(
-        "List must not dump the AI prompt body; use repo-type-view for that",
-        output.contains(prompt));
-  }
-
-  @Test
-  public void testListEmptyCatalog() throws Exception {
-    RepoTypeListCommand command = new RepoTypeListCommand();
-    RepoTypeClient repoTypeClient = mock(RepoTypeClient.class);
-    when(repoTypeClient.getRepoTypes(null)).thenReturn(Collections.emptyList());
-    command.repoTypeClient = repoTypeClient;
-    command.consoleWriter =
-        new ConsoleWriter(false, ConsoleWriter.OutputType.ANSI_CONSOLE_AND_LOGGER);
-
-    command.execute();
-
-    String output = outputCapture.toString();
-    assertTrue(output.contains("List repo types"));
-    assertTrue(output.contains("No repo types found"));
-    assertFalse(output.contains("Repo type id -->"));
+        Pattern.compile("AI prompt --> $", Pattern.MULTILINE).matcher(zebraBlock).find());
   }
 
   @Test
@@ -82,44 +71,48 @@ public class RepoTypeListCommandTest extends CLITestBase {
     assertTrue("CLI help must document list-all usage", output.contains("List all repo types"));
     assertTrue(output.contains("repo-type-list"));
     assertTrue(output.contains(Param.REPO_TYPE_LIST_VERBOSE_LONG));
+    assertTrue(output.contains(Param.REPO_TYPE_LIST_VERBOSE_SHORT));
   }
 
   @Test
   public void testListVerbosePrintsAiPromptBody() throws Exception {
     String name = testIdWatcher.getEntityName("WithPrompt");
-    String prompt = "You are a React i18n expert";
+    String emptyName = testIdWatcher.getEntityName("EmptyPrompt");
+    String prompt = "verbose-body-" + name;
 
-    repoTypeService.createRepoType(name, "desc", prompt, null);
+    RepoType created = repoTypeService.createRepoType(name, "desc", prompt, null);
+    RepoType empty = repoTypeService.createRepoType(emptyName, "no prompt", null, null);
 
     getL10nJCommander().run("repo-type-list", Param.REPO_TYPE_LIST_VERBOSE_LONG);
 
     String output = outputCapture.toString();
-    assertLabeledLine(output, "Name --> ", name);
-    assertLabeledLine(output, "AI prompt --> ", prompt);
-    assertFalse(
-        "Verbose must print the prompt body, not the compact \"set\" marker",
-        Pattern.compile("AI prompt --> set$", Pattern.MULTILINE).matcher(output).find());
+    String block = typeBlock(output, created.getId());
+    assertLabeledLine(block, "Name --> ", name);
+    assertLabeledLine(block, "AI prompt --> ", prompt);
+
+    String emptyBlock = typeBlock(output, empty.getId());
+    assertLabeledLine(emptyBlock, "Name --> ", emptyName);
+    assertTrue(
+        "Verbose null prompt must print an empty value, not the string \"null\"",
+        Pattern.compile("AI prompt --> $", Pattern.MULTILINE).matcher(emptyBlock).find());
   }
 
-  @Test
-  public void testViewUnknownNameStillFails() throws Exception {
-    String name = testIdWatcher.getEntityName("OnlyForList");
-    repoTypeService.createRepoType(name, "listed type", null, null);
-
-    String missing = testIdWatcher.getEntityName("missing");
-    getL10nJCommander().run("repo-type-view", Param.REPO_TYPE_NAME_SHORT, missing);
-
-    String output = outputCapture.toString();
-    assertTrue(
-        "Exact-name view must still fail when the name is unknown",
-        output.contains("Repo type with name [" + missing + "] is not found"));
-    assertFalse(output.contains("List repo types"));
+  static String typeBlock(String output, Long id) {
+    Pattern start =
+        Pattern.compile(
+            "^" + Pattern.quote("Repo type id --> " + id) + "$", Pattern.MULTILINE);
+    Matcher matcher = start.matcher(output);
+    assertTrue("missing output block for repo type id " + id, matcher.find());
+    int from = matcher.start();
+    Matcher next = Pattern.compile("^Repo type id --> ", Pattern.MULTILINE).matcher(output);
+    int end = next.find(matcher.end()) ? next.start() : output.length();
+    return output.substring(from, end);
   }
 
   private static int labeledLineIndex(String output, String label, String value) {
     Pattern pattern =
         Pattern.compile(Pattern.quote(label) + Pattern.quote(value) + "$", Pattern.MULTILINE);
-    java.util.regex.Matcher matcher = pattern.matcher(output);
+    Matcher matcher = pattern.matcher(output);
     assertTrue(label + " is missing or incorrect from output", matcher.find());
     return matcher.start();
   }

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListCommandTest.java
@@ -1,0 +1,130 @@
+package com.box.l10n.mojito.cli.command;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.box.l10n.mojito.cli.CLITestBase;
+import com.box.l10n.mojito.cli.command.param.Param;
+import com.box.l10n.mojito.cli.console.ConsoleWriter;
+import com.box.l10n.mojito.entity.RepoType;
+import com.box.l10n.mojito.rest.client.RepoTypeClient;
+import com.box.l10n.mojito.service.repotype.RepoTypeService;
+import java.util.Collections;
+import java.util.regex.Pattern;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RepoTypeListCommandTest extends CLITestBase {
+
+  static Logger logger = LoggerFactory.getLogger(RepoTypeListCommandTest.class);
+
+  @Autowired RepoTypeService repoTypeService;
+
+  @Test
+  public void testListAllRepoTypes() throws Exception {
+    String nameApple = testIdWatcher.getEntityName("Apple");
+    String nameZebra = testIdWatcher.getEntityName("Zebra");
+    String prompt = "You are a React i18n expert — keep this body off the list";
+
+    RepoType apple = repoTypeService.createRepoType(nameApple, "first type", prompt, null);
+    RepoType zebra = repoTypeService.createRepoType(nameZebra, null, null, null);
+
+    getL10nJCommander().run("repo-type-list");
+
+    String output = outputCapture.toString();
+    assertTrue(output.contains("List repo types"));
+
+    int appleIdx = labeledLineIndex(output, "Name --> ", nameApple);
+    int zebraIdx = labeledLineIndex(output, "Name --> ", nameZebra);
+    assertTrue("Listed types must be ordered by name", appleIdx < zebraIdx);
+
+    assertLabeledLine(output, "Repo type id --> ", String.valueOf(apple.getId()));
+    assertLabeledLine(output, "Description --> ", "first type");
+    assertLabeledLine(output, "AI prompt --> ", "set");
+    assertLabeledLine(output, "Repo type id --> ", String.valueOf(zebra.getId()));
+    assertTrue(
+        "Null description must print an empty value after the label",
+        Pattern.compile("Description --> $", Pattern.MULTILINE).matcher(output).find());
+    assertTrue(
+        "Empty AI prompt must print an empty value after the label, not \"set\"",
+        Pattern.compile("AI prompt --> $", Pattern.MULTILINE).matcher(output).find());
+    assertFalse(
+        "List must not dump the AI prompt body; use repo-type-view for that",
+        output.contains(prompt));
+  }
+
+  @Test
+  public void testListEmptyCatalog() throws Exception {
+    RepoTypeListCommand command = new RepoTypeListCommand();
+    RepoTypeClient repoTypeClient = mock(RepoTypeClient.class);
+    when(repoTypeClient.getRepoTypes(null)).thenReturn(Collections.emptyList());
+    command.repoTypeClient = repoTypeClient;
+    command.consoleWriter =
+        new ConsoleWriter(false, ConsoleWriter.OutputType.ANSI_CONSOLE_AND_LOGGER);
+
+    command.execute();
+
+    String output = outputCapture.toString();
+    assertTrue(output.contains("List repo types"));
+    assertTrue(output.contains("No repo types found"));
+    assertFalse(output.contains("Repo type id -->"));
+  }
+
+  @Test
+  public void testListHelpDocumentsListAll() throws Exception {
+    getL10nJCommander().run("repo-type-list", "-h");
+
+    String output = outputCapture.toString();
+    assertTrue("CLI help must document list-all usage", output.contains("List all repo types"));
+    assertTrue(output.contains("repo-type-list"));
+    assertTrue(output.contains(Param.REPO_TYPE_LIST_VERBOSE_LONG));
+  }
+
+  @Test
+  public void testListVerbosePrintsAiPromptBody() throws Exception {
+    String name = testIdWatcher.getEntityName("WithPrompt");
+    String prompt = "You are a React i18n expert";
+
+    repoTypeService.createRepoType(name, "desc", prompt, null);
+
+    getL10nJCommander().run("repo-type-list", Param.REPO_TYPE_LIST_VERBOSE_LONG);
+
+    String output = outputCapture.toString();
+    assertLabeledLine(output, "Name --> ", name);
+    assertLabeledLine(output, "AI prompt --> ", prompt);
+    assertFalse(
+        "Verbose must print the prompt body, not the compact \"set\" marker",
+        Pattern.compile("AI prompt --> set$", Pattern.MULTILINE).matcher(output).find());
+  }
+
+  @Test
+  public void testViewUnknownNameStillFails() throws Exception {
+    String name = testIdWatcher.getEntityName("OnlyForList");
+    repoTypeService.createRepoType(name, "listed type", null, null);
+
+    String missing = testIdWatcher.getEntityName("missing");
+    getL10nJCommander().run("repo-type-view", Param.REPO_TYPE_NAME_SHORT, missing);
+
+    String output = outputCapture.toString();
+    assertTrue(
+        "Exact-name view must still fail when the name is unknown",
+        output.contains("Repo type with name [" + missing + "] is not found"));
+    assertFalse(output.contains("List repo types"));
+  }
+
+  private static int labeledLineIndex(String output, String label, String value) {
+    Pattern pattern =
+        Pattern.compile(Pattern.quote(label) + Pattern.quote(value) + "$", Pattern.MULTILINE);
+    java.util.regex.Matcher matcher = pattern.matcher(output);
+    assertTrue(label + " is missing or incorrect from output", matcher.find());
+    return matcher.start();
+  }
+
+  private static void assertLabeledLine(String output, String label, String value) {
+    labeledLineIndex(output, label, value);
+  }
+}

--- a/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListEmptyCommandTest.java
+++ b/cli/src/test/java/com/box/l10n/mojito/cli/command/RepoTypeListEmptyCommandTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.system.OutputCaptureRule;
  * {@code repo-type-list} {@code execute()} against a stubbed {@link RepoTypeClient} (no JCommander,
  * no HTTP). Empty list print only; HTTP errors are not mapped (same as {@code repo-type-view}).
  */
-public class RepoTypeListCommandClientTest {
+public class RepoTypeListEmptyCommandTest {
 
   @Rule public OutputCaptureRule outputCapture = new OutputCaptureRule();
 

--- a/docs/internal/Architecture.md
+++ b/docs/internal/Architecture.md
@@ -334,13 +334,14 @@ Name, description, and AI-prompt CLI for repo types. Commands are JCommander `Co
 
 **In scope**
 
-- `repo-type-create`, `repo-type-update`, `repo-type-delete`, `repo-type-view`
+- `repo-type-create`, `repo-type-update`, `repo-type-delete`, `repo-type-view`, `repo-type-list`
 - Setting **name**, **description**, and **`aiPrompt`** (`--ai-prompt` / `-ap`, or `--ai-prompt-file` / `-apf`)
+- Listing every type in one invocation (`repo-type-list`); exact-name view stays on `repo-type-view`
 
 **Out of scope (follow-up)**
 
 - CLI for `integrityCheckers` (separate story)
-- Listing all types (no `repo-type-list`; view is by exact name)
+- Pagination or filtering on the list beyond “all types, ordered by name”
 
 ##### Commands
 
@@ -350,12 +351,13 @@ Name, description, and AI-prompt CLI for repo types. Commands are JCommander `Co
 | `repo-type-update` | PATCH `/api/repo-types/{id}` | `--name` / `-n` (existing type) | `--new-name` / `-nn`, `--description` / `-d`, `--ai-prompt` / `-ap`, `--ai-prompt-file` / `-apf` |
 | `repo-type-delete` | DELETE `/api/repo-types/{id}` | `--name` / `-n` | — |
 | `repo-type-view` | GET list filtered by name | `--name` / `-n` | — |
+| `repo-type-list` | GET `/api/repo-types` with no `name` filter | — | `--verbose` / `-vb` |
 
 Flag constants live in `cli/.../command/param/Param.java` (`REPO_TYPE_*`). Help text comes from those descriptions.
 
 ##### Lookup by name
 
-Update, delete, and view resolve the type with `CommandHelper.findRepoTypeByName`. A blank `-n` is rejected with `Repo type name is required` before calling the API — the server treats a blank `?name=` as list-all, so a single existing type would otherwise be selected. Non-blank names are trimmed and looked up with `RepoTypeClient.getRepoTypes(name)`. If the list size is not exactly `1`, the command fails with `Repo type with name [<name>] is not found` (`CommandException`). There is no dedicated get-by-name client method.
+Update, delete, and view resolve the type with `CommandHelper.findRepoTypeByName`. A blank `-n` is rejected with `Repo type name is required` before calling the API — the server treats a blank `?name=` as list-all, so a single existing type would otherwise be selected. Non-blank names are trimmed and looked up with `RepoTypeClient.getRepoTypes(name)`. If the list size is not exactly `1`, the command fails with `Repo type with name [<name>] is not found` (`CommandException`). There is no dedicated get-by-name client method. `repo-type-list` does not take `-n` and does not use this helper. Optional `--verbose` / `-vb` only changes list output (see [List](#list)).
 
 ##### Create
 
@@ -391,6 +393,22 @@ Prints four fields for an existing type:
 - `Description --> <description>` (`null` description prints as empty)
 - `AI prompt --> <aiPrompt>` (`null` prompt prints as empty)
 
+##### List
+
+`mojito repo-type-list` (no flags) calls `RepoTypeClient.getRepoTypes(null)` — GET `/api/repo-types` with no `name` query. Help (`-h` / `--help`) describes it as `List all repo types`. There is no new REST endpoint. `--verbose` / `-vb` is a CLI print switch only; the same GET is used either way. The short form is `-vb`, not `-v` (`-v` is CLI `--version`).
+
+Prints one block per type, same labels as view, in the server’s name-ascending order:
+
+- `Repo type id --> <id>`
+- `Name --> <name>`
+- `Description --> <description>` (`null` description prints as empty)
+- Default (no `--verbose`): `AI prompt --> set` when the prompt is **non-empty** (`StringUtils.isNotEmpty`; whitespace-only counts as set); otherwise `AI prompt -->` with an empty value. The prompt **body** is not printed.
+- `--verbose` / `-vb`: `AI prompt --> <aiPrompt>` (`null` prompt prints as empty), same as `repo-type-view`. Use this when you need the body without calling view per type.
+
+HTTP errors on this GET are not mapped (same as `repo-type-view`). `CommandHelper.repoTypeClientError` stays on create/update/delete. A successful empty list is HTTP 200 `[]` and prints `No repo types found` (not an error). Other failures dump via `L10nJCommander`.
+
+Types already in the catalog are not filtered or paginated. The empty-list print is covered by a stubbed-client unit test (`RepoTypeListCommandClientTest`) that asserts captured console text; list-all (including whitespace-only prompt → `set`) and `--verbose` go through `CLITestBase` / HTTP. Unknown-name `repo-type-view` stays covered by `RepoTypeViewCommandTest`.
+
 ##### Package layout (CLI)
 
 | File | Role |
@@ -399,8 +417,9 @@ Prints four fields for an existing type:
 | `cli/.../command/RepoTypeUpdateCommand.java` | Update |
 | `cli/.../command/RepoTypeDeleteCommand.java` | Delete |
 | `cli/.../command/RepoTypeViewCommand.java` | View |
-| `cli/.../command/param/Param.java` | `--name` / `--new-name` / `--description` / `--ai-prompt` / `--ai-prompt-file` constants |
-| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags, create/update/clear/view `aiPrompt` including `--ai-prompt-file`, UTF-8 BOM and one trailing newline stripped from files, mutual exclusion and missing file, description/rename/prompt-only updates must not clear checkers) |
+| `cli/.../command/RepoTypeListCommand.java` | List all |
+| `cli/.../command/param/Param.java` | `--name` / `--new-name` / `--description` / `--ai-prompt` / `--ai-prompt-file` / `--verbose` (`-vb`) constants |
+| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags, create/update/clear/view `aiPrompt` including `--ai-prompt-file`, UTF-8 BOM and one trailing newline stripped from files, mutual exclusion and missing file, description/rename/prompt-only updates must not clear checkers, `repo-type-list` list-all with per-type blocks including whitespace-only prompt → `set` / `--verbose` including empty prompt / help). Empty-list print: `RepoTypeListCommandClientTest` (stubbed `RepoTypeClient`, captured console text, not HTTP). |
 
 ---
 

--- a/docs/internal/Architecture.md
+++ b/docs/internal/Architecture.md
@@ -402,12 +402,12 @@ Prints one block per type, same labels as view, in the server’s name-ascending
 - `Repo type id --> <id>`
 - `Name --> <name>`
 - `Description --> <description>` (`null` description prints as empty)
-- Default (no `--verbose`): `AI prompt --> set` when the prompt is **non-empty** (`StringUtils.isNotEmpty`; whitespace-only counts as set); otherwise `AI prompt -->` with an empty value. The prompt **body** is not printed.
+- Default (no `--verbose`): `AI prompt --> contains a value` when the prompt is **non-empty** (`StringUtils.isNotEmpty`; whitespace-only counts as present); otherwise `AI prompt -->` with an empty value. The prompt **body** is not printed.
 - `--verbose` / `-vb`: `AI prompt --> <aiPrompt>` (`null` prompt prints as empty), same as `repo-type-view`. Use this when you need the body without calling view per type.
 
 HTTP errors on this GET are not mapped (same as `repo-type-view`). `CommandHelper.repoTypeClientError` stays on create/update/delete. A successful empty list is HTTP 200 `[]` and prints `No repo types found` (not an error). Other failures dump via `L10nJCommander`.
 
-Types already in the catalog are not filtered or paginated. The empty-list print is covered by a stubbed-client unit test (`RepoTypeListEmptyCommandTest`) that asserts captured console text; list-all (including whitespace-only prompt → `set`) and `--verbose` go through `CLITestBase` / HTTP. Unknown-name `repo-type-view` stays covered by `RepoTypeViewCommandTest`.
+Types already in the catalog are not filtered or paginated. The empty-list print is covered by a stubbed-client unit test (`RepoTypeListEmptyCommandTest`) that asserts captured console text; list-all (including whitespace-only prompt → `contains a value`) and `--verbose` go through `CLITestBase` / HTTP. Unknown-name `repo-type-view` stays covered by `RepoTypeViewCommandTest`.
 
 ##### Package layout (CLI)
 
@@ -419,7 +419,7 @@ Types already in the catalog are not filtered or paginated. The empty-list print
 | `cli/.../command/RepoTypeViewCommand.java` | View |
 | `cli/.../command/RepoTypeListCommand.java` | List all |
 | `cli/.../command/param/Param.java` | `--name` / `--new-name` / `--description` / `--ai-prompt` / `--ai-prompt-file` / `--verbose` (`-vb`) constants |
-| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags, create/update/clear/view `aiPrompt` including `--ai-prompt-file`, UTF-8 BOM and one trailing newline stripped from files, mutual exclusion and missing file, description/rename/prompt-only updates must not clear checkers, `repo-type-list` list-all with per-type blocks including whitespace-only prompt → `set` / `--verbose` including empty prompt / help). Empty-list print: `RepoTypeListEmptyCommandTest` (stubbed `RepoTypeClient`, captured console text, not HTTP). |
+| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags, create/update/clear/view `aiPrompt` including `--ai-prompt-file`, UTF-8 BOM and one trailing newline stripped from files, mutual exclusion and missing file, description/rename/prompt-only updates must not clear checkers, `repo-type-list` list-all with per-type blocks including whitespace-only prompt → `contains a value` / `--verbose` including empty prompt / help). Empty-list print: `RepoTypeListEmptyCommandTest` (stubbed `RepoTypeClient`, captured console text, not HTTP). |
 
 ---
 

--- a/docs/internal/Architecture.md
+++ b/docs/internal/Architecture.md
@@ -407,7 +407,7 @@ Prints one block per type, same labels as view, in the server’s name-ascending
 
 HTTP errors on this GET are not mapped (same as `repo-type-view`). `CommandHelper.repoTypeClientError` stays on create/update/delete. A successful empty list is HTTP 200 `[]` and prints `No repo types found` (not an error). Other failures dump via `L10nJCommander`.
 
-Types already in the catalog are not filtered or paginated. The empty-list print is covered by a stubbed-client unit test (`RepoTypeListCommandClientTest`) that asserts captured console text; list-all (including whitespace-only prompt → `set`) and `--verbose` go through `CLITestBase` / HTTP. Unknown-name `repo-type-view` stays covered by `RepoTypeViewCommandTest`.
+Types already in the catalog are not filtered or paginated. The empty-list print is covered by a stubbed-client unit test (`RepoTypeListEmptyCommandTest`) that asserts captured console text; list-all (including whitespace-only prompt → `set`) and `--verbose` go through `CLITestBase` / HTTP. Unknown-name `repo-type-view` stays covered by `RepoTypeViewCommandTest`.
 
 ##### Package layout (CLI)
 
@@ -419,7 +419,7 @@ Types already in the catalog are not filtered or paginated. The empty-list print
 | `cli/.../command/RepoTypeViewCommand.java` | View |
 | `cli/.../command/RepoTypeListCommand.java` | List all |
 | `cli/.../command/param/Param.java` | `--name` / `--new-name` / `--description` / `--ai-prompt` / `--ai-prompt-file` / `--verbose` (`-vb`) constants |
-| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags, create/update/clear/view `aiPrompt` including `--ai-prompt-file`, UTF-8 BOM and one trailing newline stripped from files, mutual exclusion and missing file, description/rename/prompt-only updates must not clear checkers, `repo-type-list` list-all with per-type blocks including whitespace-only prompt → `set` / `--verbose` including empty prompt / help). Empty-list print: `RepoTypeListCommandClientTest` (stubbed `RepoTypeClient`, captured console text, not HTTP). |
+| `cli/.../command/RepoType*CommandTest.java` | `CLITestBase` happy path and error cases (duplicate name, unknown type, update with no optional flags, create/update/clear/view `aiPrompt` including `--ai-prompt-file`, UTF-8 BOM and one trailing newline stripped from files, mutual exclusion and missing file, description/rename/prompt-only updates must not clear checkers, `repo-type-list` list-all with per-type blocks including whitespace-only prompt → `set` / `--verbose` including empty prompt / help). Empty-list print: `RepoTypeListEmptyCommandTest` (stubbed `RepoTypeClient`, captured console text, not HTTP). |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `repo-type-list` so one CLI call prints the whole repo type catalog. It reuses the existing `GET /api/repo-types` with no `name` filter (`RepoTypeClient.getRepoTypes(null)`) — no new REST endpoint.
- Default output is compact: id, name, description, and `AI prompt --> set` when the stored prompt is non-empty (whitespace-only counts as set). The prompt body is not printed, so a catalog of types with long prompts stays scannable.
- `--verbose` / `-vb` prints the prompt body for every type, same as `repo-type-view`. It is a print switch only; the same GET is used either way. The short form is `-vb` because `-v` is already the CLI's `--version`.
- Exact-name `repo-type-view` is unchanged: the list is the index, view is the detail. Listing all types is no longer out of scope in the CLI Architecture docs.

## Test plan

CLI jar rebuilt from this branch, webapp running on `localhost:8080` with an in-memory DB (restart gives an empty catalog):

```bash
alias mojito-local='java \
  -Dl10n.resttemplate.host=localhost \
  -Dl10n.resttemplate.port=8080 \
  -Dl10n.resttemplate.scheme=http \
  -Dl10n.resttemplate.authentication.username=<username> \
  -Dl10n.resttemplate.authentication.password=<pwd> \
  -jar '"$PWD"'/cli/target/mojito-cli-*-SNAPSHOT-exec.jar'
```

- [x] `repo-type-list` is registered next to the other `repo-type-*` commands, and its help documents list-all plus `--verbose` / `-vb`. No `--name` / `-n` and no `-v` on the command.

```
$ mojito-local --help | grep repo-type
    repo-type-create Creates a repo type
    repo-type-delete Deletes a repo type
      repo-type-list List all repo types
    repo-type-update Updates a repo type
      repo-type-view View a repo type

$ mojito-local repo-type-list --help
List all repo types
Usage: repo-type-list [options]
  Options:
    --help, -h
       Show help
       Default: false
    --verbose, -vb
       Print the full AI prompt body for each type (same as repo-type-view).
       Default prints set when the prompt is non-empty (including whitespace-only), not
       the body
       Default: false
```

- [x] Empty catalog prints `No repo types found` and no type blocks (exit is success, not an error).

```
$ mojito-local repo-type-list
List repo types

No repo types found
```

- [x] Default list prints one block per type in name-ascending order, with `AI prompt --> set` for a stored prompt, an empty value when there is none, and never the prompt body.

```
$ mojito-local repo-type-create -n Apple -d "first type" -ap "compact-omit-body-Apple"
Create repo type: Apple

created --> repo type id: 1

$ mojito-local repo-type-create -n Space -d "whitespace prompt" -ap " "
Create repo type: Space

created --> repo type id: 2

$ mojito-local repo-type-create -n Zebra
Create repo type: Zebra

created --> repo type id: 3

$ mojito-local repo-type-list
List repo types

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> set


Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt -->


Repo type id --> 3
Name --> Zebra
Description -->
AI prompt -->
```

- [x] `Space` above lists with an empty prompt because JCommander trims `--ai-prompt`, so `-ap " "` stores `""` — the input path, not the list printer. Storing a real space with `--ai-prompt-file` (spaces in the file are kept; only a BOM and one trailing newline are stripped) makes the same type list as `set`, confirming whitespace-only counts as set.

```
$ mojito-local repo-type-view -n Space
View repo type: Space

Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt -->

$ printf ' ' > tmp/ai-prompt-fixtures/space.txt

$ mojito-local repo-type-update -n Space -apf tmp/ai-prompt-fixtures/space.txt
Update repo type: Space

updated --> repo type id: 2

$ mojito-local repo-type-view -n Space
View repo type: Space

Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt -->

$ mojito-local repo-type-list
List repo types

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> set


Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt --> set


Repo type id --> 3
Name --> Zebra
Description -->
AI prompt -->
```

(The second view line ends with the stored space.)

- [x] `--verbose` and `-vb` print the prompt body for every type; an empty prompt stays empty (not the string `null`).

```
$ mojito-local repo-type-list --verbose
List repo types

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> compact-omit-body-Apple


Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt -->


Repo type id --> 3
Name --> Zebra
Description -->
AI prompt -->

$ mojito-local repo-type-list -vb
List repo types

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> compact-omit-body-Apple


Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt -->


Repo type id --> 3
Name --> Zebra
Description -->
AI prompt -->
```

(Space prints its single stored space after the label.)

- [x] `-v` is the CLI version and is not an alias for `--verbose` on this command: `repo-type-list -v` still prints the compact list (`set`, no bodies). `-n` is not a list filter either — this CLI accepts unknown options, so it is ignored and all types are returned.

```
$ mojito-local -v
0.111-SNAPSHOT (git commit id: 731c8ab324ddb5127db67ac2734b94191c5fe3ee)

$ mojito-local repo-type-list -n Apple
List repo types

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> set


Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt --> set


Repo type id --> 3
Name --> Zebra
Description -->
AI prompt -->
```

- [x] `repo-type-view` is unchanged: it still dumps the prompt body for one name while the compact list keeps showing `set`. Deleting a type removes it from the next list.

```
$ mojito-local repo-type-view -n Apple
View repo type: Apple

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> compact-omit-body-Apple

$ mojito-local repo-type-delete -n Zebra
Delete repo type: Zebra

deleted --> repo type name: Zebra

$ mojito-local repo-type-list
List repo types

Repo type id --> 1
Name --> Apple
Description --> first type
AI prompt --> set


Repo type id --> 2
Name --> Space
Description --> whitespace prompt
AI prompt --> set
```

### Automated

- `RepoTypeListCommandTest` (`CLITestBase`, real HTTP): list-all with per-type blocks and name ordering, whitespace-only prompt → `set` with the body omitted, `-vb` prompt bodies including a null prompt printing empty, and help.
- `RepoTypeListCommandClientTest` (stubbed `RepoTypeClient`, captured console): empty catalog prints `No repo types found` and no type blocks.
